### PR TITLE
refactor: handle hasThumbnail

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "graasp-plugin-chatbox": "github:graasp/graasp-plugin-chatbox",
     "graasp-plugin-file": "github:graasp/graasp-plugin-file",
     "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item",
-    "graasp-plugin-hidden-items": "graasp/graasp-plugin-hidden-items",
+    "graasp-plugin-hidden-items": "github:graasp/graasp-plugin-hidden-items",
     "graasp-plugin-import-zip": "github:graasp/graasp-plugin-import-zip",
     "graasp-plugin-item-login": "github:graasp/graasp-plugin-item-login",
     "graasp-plugin-public": "github:graasp/graasp-plugin-public",

--- a/src/services/items/base-item.ts
+++ b/src/services/items/base-item.ts
@@ -1,6 +1,7 @@
 // global
 import { v4 as uuidv4 } from 'uuid';
 import { UnknownExtra } from '../../interfaces/extra';
+import { DEFAULT_ITEM_SETTINGS } from '../../util/config';
 // local
 import { Item, ItemSettings } from './interfaces/item';
 
@@ -26,6 +27,7 @@ export class BaseItem<E extends UnknownExtra> implements Item<E> {
     description: string = null,
     type: string = 'base',
     extra: E,
+    settings: ItemSettings,
     creator: string,
     parent?: Item,
   ) {
@@ -34,6 +36,7 @@ export class BaseItem<E extends UnknownExtra> implements Item<E> {
     this.description = description;
     this.type = type;
     this.extra = extra ? extra : ({} as E);
+    this.settings = settings ?? DEFAULT_ITEM_SETTINGS;
     this.creator = creator;
     this.path = parent ? `${parent.path}.${dashToUnderscore(this.id)}` : dashToUnderscore(this.id);
   }

--- a/src/services/items/db-service.ts
+++ b/src/services/items/db-service.ts
@@ -4,6 +4,7 @@ import { sql, DatabaseTransactionConnection as TrxHandler, ValueExpression } fro
 import { UnknownExtra } from '../../interfaces/extra';
 // other services
 import { PermissionLevel } from '../../services/item-memberships/interfaces/item-membership';
+import { DEFAULT_ITEM_SETTINGS } from '../../util/config';
 // local
 import { Item } from './interfaces/item';
 import { ItemTaskManager } from './interfaces/item-task-manager';
@@ -133,13 +134,24 @@ export class ItemService {
     item: Partial<Item<E>>,
     transactionHandler: TrxHandler,
   ): Promise<Item<E>> {
-    const { id, name, description, type, path, extra, creator } = item;
+    const {
+      id,
+      name,
+      description,
+      type,
+      path,
+      extra,
+      creator,
+      settings = DEFAULT_ITEM_SETTINGS,
+    } = item;
 
     return transactionHandler
       .query<Item<E>>(
         sql`
-        INSERT INTO item (id, name, description, type, path, extra, creator)
-        VALUES (${id}, ${name}, ${description}, ${type}, ${path}, ${sql.json(extra)}, ${creator})
+        INSERT INTO item (id, name, description, type, path, extra, settings, creator)
+        VALUES (${id}, ${name}, ${description}, ${type}, ${path}, ${sql.json(extra)},${sql.json(
+          settings,
+        )}, ${creator})
         RETURNING ${ItemService.allColumns}
       `,
       )

--- a/src/services/items/fluent-schema.ts
+++ b/src/services/items/fluent-schema.ts
@@ -12,7 +12,8 @@ const settings = S.object()
   .additionalProperties(false)
   .prop('isPinned', S.boolean())
   .prop('tags', S.array())
-  .prop('showChatbox', S.boolean());
+  .prop('showChatbox', S.boolean())
+  .prop('hasThumbnail', S.boolean());
 
 const item = S.object()
   .additionalProperties(false)

--- a/src/services/items/interfaces/item.ts
+++ b/src/services/items/interfaces/item.ts
@@ -14,6 +14,8 @@ export interface Item<T extends UnknownExtra = UnknownExtra> {
 }
 
 export interface ItemSettings extends Serializable {
-  isPinned: boolean;
-  showChatBox: boolean;
+  isPinned?: boolean;
+  showChatBox?: boolean;
+  hasThumbnail?: boolean;
+  tags?: string[];
 }

--- a/src/services/items/service-api.ts
+++ b/src/services/items/service-api.ts
@@ -131,6 +131,13 @@ const plugin: FastifyPluginAsync = async (fastify) => {
             tasks[1].input = { validatePermission: PermissionLevel.Write };
             return tasks;
           },
+          uploadPostHookTasks: async (data, { member }) => {
+            const tasks = taskManager.createUpdateTaskSequence(member, data.itemId, {
+              settings: { hasThumbnail: Boolean(data.size) },
+            });
+            return tasks;
+          },
+
           downloadPreHookTasks: async ({ itemId: id, filename }, { member }) => {
             const tasks = membership.createGetOfItemTaskSequence(member, id);
             tasks[1].input = { validatePermission: PermissionLevel.Read };

--- a/src/services/items/tasks/copy-item-task.ts
+++ b/src/services/items/tasks/copy-item-task.ts
@@ -115,13 +115,13 @@ export class CopyItemTask extends BaseItemTask<Item> {
 
     for (let i = 0; i < tree.length; i++) {
       const original = tree[i];
-      const { name, description, type, path, extra } = original;
+      const { name, description, type, path, extra, settings } = original;
       const pathSplit = path.split('.');
       const oldId_ = BaseItem.pathToId(pathSplit.pop());
       let copy: Item;
 
       if (i === 0) {
-        copy = new BaseItem(name, description, type, extra, this.actor.id, parentItem);
+        copy = new BaseItem(name, description, type, extra, settings, this.actor.id, parentItem);
       } else {
         const oldParentId_ = BaseItem.pathToId(pathSplit.pop());
         copy = new BaseItem(
@@ -129,6 +129,7 @@ export class CopyItemTask extends BaseItemTask<Item> {
           description,
           type,
           extra,
+          settings,
           this.actor.id,
           old2New.get(oldParentId_).copy,
         );

--- a/src/services/items/tasks/create-item-task.ts
+++ b/src/services/items/tasks/create-item-task.ts
@@ -47,9 +47,9 @@ export class CreateItemTask<E extends UnknownExtra> extends BaseItemTask<Item<E>
     }
 
     // create item
-    const { name, description, type, extra } = data;
+    const { name, description, type, extra, settings } = data;
     const { id: creator } = this.actor;
-    let item = new BaseItem(name, description, type, extra, creator, parentItem);
+    let item = new BaseItem(name, description, type, extra, settings, creator, parentItem);
 
     await this.preHookHandler?.(item, this.actor, { log, handler });
     item = await this.itemService.create(item, handler);

--- a/src/services/items/tasks/update-item-task.ts
+++ b/src/services/items/tasks/update-item-task.ts
@@ -29,7 +29,7 @@ export class UpdateItemTask<E extends UnknownExtra> extends BaseItemTask<Item<E>
     this.status = TaskStatus.RUNNING;
 
     const { item, data } = this.input;
-    const { extra: extraChanges } = data;
+    const { extra: extraChanges, settings: settingsChanges } = data;
     this.targetId = item.id;
 
     // only allow for item type specific changes in extra
@@ -38,6 +38,14 @@ export class UpdateItemTask<E extends UnknownExtra> extends BaseItemTask<Item<E>
         data.extra = Object.assign({}, item.extra, extraChanges);
       } else {
         delete data.extra;
+      }
+    }
+
+    if (settingsChanges) {
+      if (Object.keys(settingsChanges).length === 1) {
+        data.settings = Object.assign({}, item.settings, settingsChanges);
+      } else {
+        delete data.settings;
       }
     }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { ServiceMethod } from 'graasp-plugin-file';
 import S3 from 'aws-sdk/clients/s3';
+import { ItemSettings } from '..';
 
 enum Environment {
   production = 'production',
@@ -231,3 +232,7 @@ export const ITEMS_ROUTE_PREFIX = '/items';
 export const PUBLIC_ROUTE_PREFIX = '/p';
 export const APP_ITEMS_PREFIX = '/app-items';
 export const THUMBNAILS_ROUTE_PREFIX = '/thumbnails';
+
+export const DEFAULT_ITEM_SETTINGS: Partial<ItemSettings> = {
+  hasThumbnail: false,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,9 +1007,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:^17.0.8":
-  version: 17.0.8
-  resolution: "@types/node@npm:17.0.8"
-  checksum: f4cadeb9e602027520abc88c77142697e33cf6ac98bb02f8b595a398603cbd33df1f94d01c055c9f13cde0c8eaafc5e396ca72645458d42b4318b845bc7f1d0f
+  version: 17.0.9
+  resolution: "@types/node@npm:17.0.9"
+  checksum: 64a1fa91979e3c37c5f42c6e7836b02aad333f2ed41114b8d975b4754e4f4a7fe3343e77ee4daceed6b5706c6662ade13ec1e955326cd1b1e8bf35800de5faf8
   languageName: node
   linkType: hard
 
@@ -1307,14 +1307,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^8.1.0, ajv@npm:^8.6.2":
-  version: 8.8.2
-  resolution: "ajv@npm:8.8.2"
+  version: 8.9.0
+  resolution: "ajv@npm:8.9.0"
   dependencies:
     fast-deep-equal: ^3.1.1
     json-schema-traverse: ^1.0.0
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
-  checksum: 90849ef03c4f4f7051d15f655120137b89e3205537d683beebd39d95f40c0ca00ea8476cd999602d2f433863e7e4bf1b81d1869d1e07f4dcf56d71b6430a605c
+  checksum: 756c048bfa917b43bb84c8a0a53e6a489123203bc4bdec8cbeb8ec2d715674f5e61d49560a1a6ec83268af4f33bed324f5cb6d9c76d96849fd58ed7089b8e7f3
   languageName: node
   linkType: hard
 
@@ -1324,13 +1324,6 @@ __metadata:
   dependencies:
     string-width: ^4.1.0
   checksum: 6abfa08f2141d231c257162b15292467081fa49a208593e055c866aa0455b57f3a86b5a678c190c618faa79b4c59e254493099cb700dd9cf2293c6be2c8f5d8d
-  languageName: node
-  linkType: hard
-
-"ansi-colors@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "ansi-colors@npm:4.1.1"
-  checksum: 138d04a51076cb085da0a7e2d000c5c0bb09f6e772ed5c65c53cb118d37f6c5f1637506d7155fb5f330f0abcf6f12fa2e489ac3f8cdab9da393bf1bb4f9a32b0
   languageName: node
   linkType: hard
 
@@ -1597,8 +1590,8 @@ __metadata:
   linkType: hard
 
 "aws-sdk@npm:^2.1051.0":
-  version: 2.1055.0
-  resolution: "aws-sdk@npm:2.1055.0"
+  version: 2.1058.0
+  resolution: "aws-sdk@npm:2.1058.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -1609,7 +1602,7 @@ __metadata:
     url: 0.10.3
     uuid: 3.3.2
     xml2js: 0.4.19
-  checksum: a54b0435352aad9b704955262e10034948f46396048adcaffd740fa146ad71aedc8b34f6fd0b77c80f7903953e67ba4752ad6c90dfb755fbf85e138158eb818f
+  checksum: 089910be6f5aa7120315916c3441b4d20736aefb530b1d173454ef6c7ecf65047bfc32689f1007f9716113d168ba5a531317ae1328f621bca0741f7e277ea7e8
   languageName: node
   linkType: hard
 
@@ -2025,9 +2018,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001286":
-  version: 1.0.30001299
-  resolution: "caniuse-lite@npm:1.0.30001299"
-  checksum: c770f60ebf3e0cc8043ba4db0ebec12d7a595a6b50cb4437c3c5c55b04de9d2413f711f2828be761e8c37bb46b927a8abe6b199b8f0ffc1a34af0ebdee84be27
+  version: 1.0.30001300
+  resolution: "caniuse-lite@npm:1.0.30001300"
+  checksum: f8c981c0658e2ea67b5e106538a9f3b15d528a6679f2b6e7cb3f508a99e4f9f3f69c73d1b243c77e5ccb3bcef964a801a26a2ba6a13416b42baf314577e3172a
   languageName: node
   linkType: hard
 
@@ -2838,9 +2831,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.17":
-  version: 1.4.43
-  resolution: "electron-to-chromium@npm:1.4.43"
-  checksum: c096a42ec6af0c22736f7151d1386e6597b125ad9a6379a747e67d33d03b3b2923336dbe17edad0037299e7aa1daa0f3feb726d797375e652b6918c1a467b39a
+  version: 1.4.46
+  resolution: "electron-to-chromium@npm:1.4.46"
+  checksum: 16a5e5ed73b7cb6ccf47d82670e1a1d63ea2b39928b0b79c3f349e9192da103120f88fb6486724d4222ee47844cd725f0dc795c4215b290cda67e2623b14a23b
   languageName: node
   linkType: hard
 
@@ -2880,15 +2873,6 @@ __metadata:
   dependencies:
     once: ^1.4.0
   checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
-  languageName: node
-  linkType: hard
-
-"enquirer@npm:^2.3.5":
-  version: 2.3.6
-  resolution: "enquirer@npm:2.3.6"
-  dependencies:
-    ansi-colors: ^4.1.1
-  checksum: 1c0911e14a6f8d26721c91e01db06092a5f7675159f0261d69c403396a385afd13dd76825e7678f66daffa930cfaa8d45f506fb35f818a2788463d022af1b884
   languageName: node
   linkType: hard
 
@@ -3071,16 +3055,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "eslint-visitor-keys@npm:3.1.0"
-  checksum: fd2d613bb315bc549068ca97771d868437fb60c8f13ef8d6d54669773ff53f814b759fa9e57966f15e4c50a5f5e11c6ba47060b8f201f9776311f6c5d5c11b70
+"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.1.0, eslint-visitor-keys@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "eslint-visitor-keys@npm:3.2.0"
+  checksum: fdadbb26f9e6417d3db7ad4f00bb0d573b6031c32fa72e8cdae32d038223faaeddff2ee443c90cb489bf774e75bff765c00912b8f9106d65e4f202ccd78c1b18
   languageName: node
   linkType: hard
 
 "eslint@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "eslint@npm:8.6.0"
+  version: 8.7.0
+  resolution: "eslint@npm:8.7.0"
   dependencies:
     "@eslint/eslintrc": ^1.0.5
     "@humanwhocodes/config-array": ^0.9.2
@@ -3089,11 +3073,10 @@ __metadata:
     cross-spawn: ^7.0.2
     debug: ^4.3.2
     doctrine: ^3.0.0
-    enquirer: ^2.3.5
     escape-string-regexp: ^4.0.0
     eslint-scope: ^7.1.0
     eslint-utils: ^3.0.0
-    eslint-visitor-keys: ^3.1.0
+    eslint-visitor-keys: ^3.2.0
     espree: ^9.3.0
     esquery: ^1.4.0
     esutils: ^2.0.2
@@ -3102,7 +3085,7 @@ __metadata:
     functional-red-black-tree: ^1.0.1
     glob-parent: ^6.0.1
     globals: ^13.6.0
-    ignore: ^4.0.6
+    ignore: ^5.2.0
     import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
     is-glob: ^4.0.0
@@ -3113,16 +3096,14 @@ __metadata:
     minimatch: ^3.0.4
     natural-compare: ^1.4.0
     optionator: ^0.9.1
-    progress: ^2.0.0
     regexpp: ^3.2.0
-    semver: ^7.2.1
     strip-ansi: ^6.0.1
     strip-json-comments: ^3.1.0
     text-table: ^0.2.0
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 19ed82fa872ebb45d0f10c2514975b85ab37e78e9b562a5aa3abdbe7802111d65f7d5a8563e394a975337b403163b40624c2cc8bfa585a061e8c7dc55def39b5
+  checksum: 1c80375a48b0fe3ccae3c6354323e4f0e92e970f23abc5b9705b90b7aef514b69ebd0a63e74962d30789986c91fa41c0e25cd2f98f19e9e2a2d36aafdfc9ccc9
   languageName: node
   linkType: hard
 
@@ -3339,15 +3320,15 @@ __metadata:
   linkType: hard
 
 "fast-glob@npm:^3.2.9":
-  version: 3.2.10
-  resolution: "fast-glob@npm:3.2.10"
+  version: 3.2.11
+  resolution: "fast-glob@npm:3.2.11"
   dependencies:
     "@nodelib/fs.stat": ^2.0.2
     "@nodelib/fs.walk": ^1.2.3
     glob-parent: ^5.1.2
     merge2: ^1.3.0
     micromatch: ^4.0.4
-  checksum: dee958d95638c8d00d200c55af5884dda513cfef96f674caab5a289a4436936ee26d603841a9ab85a6a4d9f7914558bce78dbf1088d3b8ec64b255422eea840b
+  checksum: f473105324a7780a20c06de842e15ddbb41d3cb7e71d1e4fe6e8373204f22245d54f5ab9e2061e6a1c613047345954d29b022e0e76f5c28b1df9858179a0e6d7
   languageName: node
   linkType: hard
 
@@ -4227,12 +4208,12 @@ __metadata:
 
 "graasp-plugin-file-item@github:graasp/graasp-plugin-file-item":
   version: 0.1.0
-  resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=45600fee4e69507e0188b8ac8cb38cd1e0ee6c58"
+  resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=3694c96eea839edc2ca894c77461e916bf341a26"
   dependencies:
     graasp-file-upload-limiter: "github:graasp/graasp-file-upload-limiter"
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
-  checksum: 7fcb09ac5a48293854996e5958717b8d4cce7156aa18fc3436f65457505d859b24962b44ddceff2c100031eff789c92571a9bc6edfff52ae1a7561e6a0ce1bc9
+  checksum: 054ebea4e3de6b0bc7c0a6d740a19fd09386a299677bac3b290179a1dbb1695c1281512f575217fbb117de9afe3e82e38443df0646b0aa6f20ad6bec910f2a44
   languageName: node
   linkType: hard
 
@@ -4248,7 +4229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
+"graasp-plugin-hidden-items@github:graasp/graasp-plugin-hidden-items":
   version: 0.1.0
   resolution: "graasp-plugin-hidden-items@https://github.com/graasp/graasp-plugin-hidden-items.git#commit=22fbcd515901b4e5a2d9e70dc15e8e22bf9c8f66"
   dependencies:
@@ -4315,13 +4296,13 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
 
 "graasp-plugin-thumbnails@github:graasp/graasp-plugin-thumbnails":
   version: 0.1.0
-  resolution: "graasp-plugin-thumbnails@https://github.com/graasp/graasp-plugin-thumbnails.git#commit=dedbb29bc437bbbcf962602341d6ae173c23cd64"
+  resolution: "graasp-plugin-thumbnails@https://github.com/graasp/graasp-plugin-thumbnails.git#commit=ebb30ce62f09a52395ef6bd7cfaba65c108a2b8d"
   dependencies:
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
     graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
     sharp: 0.29.3
-  checksum: 56302076e00abbe754ce32be88dd19d1d1c348dbda7119f1c7971e980b5bb2bb19e481f4013494e08684190976b9308b77e41458cc1ac849e8264d380bc75e6f
+  checksum: 68a069877a05d1d4d12b7eccf16016e4f4fc89d995cb0f5d821a8f763505036beb5cfabab66d85dee112d20e8d75927f0fddb596d35c361014c4990fc4c4102e
   languageName: node
   linkType: hard
 
@@ -4376,7 +4357,7 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
     graasp-plugin-chatbox: "github:graasp/graasp-plugin-chatbox"
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
     graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item"
-    graasp-plugin-hidden-items: graasp/graasp-plugin-hidden-items
+    graasp-plugin-hidden-items: "github:graasp/graasp-plugin-hidden-items"
     graasp-plugin-import-zip: "github:graasp/graasp-plugin-import-zip"
     graasp-plugin-item-login: "github:graasp/graasp-plugin-item-login"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
@@ -6760,11 +6741,16 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
   linkType: hard
 
 "node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5":
-  version: 2.6.6
-  resolution: "node-fetch@npm:2.6.6"
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
   dependencies:
     whatwg-url: ^5.0.0
-  checksum: ee8290626bdb73629c59722b75dcf4b9b6a67c1ed7eb9102e368479c4a13b56a48c2bb3ad71571e378e98c8b2c64c820e11f9cd39e4b8557dd138ad571ef9a42
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
   languageName: node
   linkType: hard
 
@@ -7664,13 +7650,6 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "progress@npm:2.0.3"
-  checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
-  languageName: node
-  linkType: hard
-
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -8248,7 +8227,7 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -9197,8 +9176,8 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
   linkType: hard
 
 "ts-jest@npm:^27.1.2":
-  version: 27.1.2
-  resolution: "ts-jest@npm:27.1.2"
+  version: 27.1.3
+  resolution: "ts-jest@npm:27.1.3"
   dependencies:
     bs-logger: 0.x
     fast-json-stable-stringify: 2.x
@@ -9226,7 +9205,7 @@ graasp-plugin-hidden-items@graasp/graasp-plugin-hidden-items:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 2e7275f8a3545ec1340b37c458ace9244b5903e86861eb108beffff97d433f296c1254f76a41b573b1fe6245110b21bb62150bb88d55159f1dc7a929886535cb
+  checksum: eb54e5b8fc5f06e4cc20ecec7891201ddc78a3537d5eb3775e29ffbc7e83fd2a68f91db801b6a8c820c872060b24dc41fb6decac800b76256d3cdda6520b5c4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
My final solution to optimize thumbnail is to add a `hasThumbnail` in item's settings. It is set by default to false, and set to true once upload is to trigger. Only file items (for given mimetypes) have this setting set to true.

My initial solution was to set this setting on download, but the only fact that there is a delay between the upload and the first download (which often responds false) would break most of the thumbnail upload (the upload would work, but then the download would fail and lock the thumbnail for next download calls).

close #147 