### PR TITLE
refactor: include redis port forwarding

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     # with the value of the variable set.
     command: redis-server --requirepass $REDIS_PASSWORD
     restart: unless-stopped
+    ports:
+      - 6379:6379
 
   # Localstack is used to test aws services locally
   localstack:


### PR DESCRIPTION
Whenever you want to run the core locally outside of the container, it is necessary to have this for the app to recognize the redis port. It is a frequent issue with the m1 chip.
It is not harmful to have this forwarding as all of the rest of the services have them.