### PR TITLE
doc: add migrations in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Install the corresponding schema if you are using any fo the following plugins :
 
 - Subscriptions [`db-schema.sql`](https://github.com/graasp/graasp-plugin-subscriptions/blob/main/db-schema.sql)
 
+Also you will need to run all the migrations associated with the plugins you wish to use. For each plugin run **all** migrations in the folder **in increasing order**.
+
+- ChatBox : [`migrations`](https://github.com/graasp/graasp-plugin-chatbox/tree/main/migrations)
+    - [`migration1.sql`](https://github.com/graasp/graasp-plugin-chatbox/blob/main/migrations/migration1.sql)
+
+- Actions : [`migrations`](https://github.com/graasp/graasp-plugin-actions/tree/main/migrations)
+    - [`migration1.sql`](https://github.com/graasp/graasp-plugin-actions/blob/main/migrations/migration1.sql)
+
 ### Configuration
 
 To configure the application, you'll need to change the values in  `.env.development`. The file should have the following structure :


### PR DESCRIPTION
This PR adds documentation for the Migrations so users don't have to look for them in each repo.
They will need to be kept up to date, this is why the link to the migrations folder of the repo is provided first and the individual links for migrations are provided as convinience.

In the future it would be nice to have an automated way of performing the migrations and installation of the database. In the meantime we can try to keep the Readme up-to-date.

closes #234 