### PR TITLE
fix: allow posthook in descendants in copy task

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "graasp-plugin-item-publish": "github:graasp/graasp-plugin-item-publish",
     "graasp-plugin-item-zip": "github:graasp/graasp-plugin-item-zip",
     "graasp-plugin-public": "github:graasp/graasp-plugin-public",
-    "graasp-plugin-recycle-bin": "github:graasp/graasp-plugin-recycle-bin",
+    "graasp-plugin-recycle-bin": "github:graasp/graasp-plugin-recycle-bin#34-get-descendants",
     "graasp-plugin-search": "github:graasp/graasp-plugin-search",
     "graasp-plugin-subscriptions": "github:graasp/graasp-plugin-subscriptions",
     "graasp-plugin-thumbnails": "github:graasp/graasp-plugin-thumbnails",

--- a/src/services/items/task-manager.ts
+++ b/src/services/items/task-manager.ts
@@ -10,6 +10,7 @@ import {
   UnknownExtra,
 } from '@graasp/sdk';
 
+import { MAX_DESCENDANTS_FOR_COPY } from '../../util/config';
 import { BaseItemMembership } from '../item-memberships/base-item-membership';
 import { CreateItemMembershipSubTask } from '../item-memberships/tasks/create-item-membership-task';
 import { GetMemberItemMembershipOverItemTask } from '../item-memberships/tasks/get-member-item-membership-over-item-task';
@@ -239,8 +240,22 @@ export class TaskManager implements ItemTaskManager<Member> {
       tasks.push(t4);
     }
 
+    // get descendants and check whether parentItem depth is valid, and max number of descendants
+    const getDescendantsTask = new GetItemDescendantsTask(member, this.itemService);
+    getDescendantsTask.getInput = () => ({
+      item: itemTask.result,
+      parentItem: t3?.result,
+      maxDescendantsNb: MAX_DESCENDANTS_FOR_COPY,
+    });
+    tasks.push(getDescendantsTask);
+
     const t5 = new CopyItemTask(member, this.itemService);
-    t5.getInput = () => ({ item: itemTask.result, parentItem: t3?.result, shouldCopyTags });
+    t5.getInput = () => ({
+      item: itemTask.result,
+      parentItem: t3?.result,
+      descendants: getDescendantsTask.result,
+      shouldCopyTags,
+    });
     tasks.push(t5);
 
     const t6 = new CreateItemMembershipSubTask(member, this.itemMembershipService);

--- a/src/services/items/tasks/get-item-descendants-task.ts
+++ b/src/services/items/tasks/get-item-descendants-task.ts
@@ -2,9 +2,16 @@ import { FastifyLoggerInstance } from 'fastify';
 
 import { DatabaseTransactionHandler, Item, ItemService, Member, TaskStatus } from '@graasp/sdk';
 
+import { MAX_TREE_LEVELS } from '../../../util/config';
+import { HierarchyTooDeep, TooManyDescendants } from '../../../util/graasp-error';
+import { BaseItem } from '../base-item';
 import { BaseItemTask } from './base-item-task';
 
-export type GetItemDescendantsTaskInputType = { item?: Item };
+export type GetItemDescendantsTaskInputType = {
+  item?: Item;
+  parentItem?: Item;
+  maxDescendantsNb?: number;
+};
 
 export class GetItemDescendantsTask extends BaseItemTask<Item[]> {
   get name(): string {
@@ -22,8 +29,32 @@ export class GetItemDescendantsTask extends BaseItemTask<Item[]> {
   async run(handler: DatabaseTransactionHandler, log: FastifyLoggerInstance): Promise<void> {
     this.status = TaskStatus.RUNNING;
 
-    const { item } = this.input;
+    const { item, parentItem, maxDescendantsNb } = this.input;
     this.targetId = item.id;
+
+    // temporary solution for a prehook for copy in get desendants
+    // we moved the following checks from copy-item-task
+    // because we needed a posthook on descendants (recycle-bin)
+    // check how "big the tree is" below the item
+    if (maxDescendantsNb) {
+      const numberOfDescendants = await this.itemService.getNumberOfDescendants(item, handler);
+      if (numberOfDescendants > maxDescendantsNb) {
+        throw new TooManyDescendants(item.id);
+      }
+    }
+
+    if (parentItem) {
+      // attaching copy to some item
+      // check how deep (number of levels) the resulting tree will be
+      const levelsToFarthestChild = await this.itemService.getNumberOfLevelsToFarthestChild(
+        item,
+        handler,
+      );
+
+      if (BaseItem.itemDepth(parentItem) + 1 + levelsToFarthestChild > MAX_TREE_LEVELS) {
+        throw new HierarchyTooDeep();
+      }
+    }
 
     // get descendants to max level
     const descendants = await this.itemService.getDescendants(item, handler);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,12 +5292,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graasp-plugin-recycle-bin@github:graasp/graasp-plugin-recycle-bin":
+"graasp-plugin-recycle-bin@github:graasp/graasp-plugin-recycle-bin#34-get-descendants":
   version: 0.1.0
-  resolution: "graasp-plugin-recycle-bin@https://github.com/graasp/graasp-plugin-recycle-bin.git#commit=b7d9c66eb7fad251688da1c9014b88a8cc5fd24f"
+  resolution: "graasp-plugin-recycle-bin@https://github.com/graasp/graasp-plugin-recycle-bin.git#commit=a452b3f434e15cc9b3ddde0e8ca36388564748b3"
   dependencies:
     http-status-codes: ^2.2.0
-  checksum: 13ae37ff1d36206e480a5535106e6db00a7454dec8082f7a15457e893a5bff68b5e7a144cade23941160cf0f1c10c7840e6a24ead243bd12dcc8e66755d32dc7
+  checksum: 193e1b6b45f82f49cc3610203ea11263fd0b89cf86fc105b056fbacce32adf7fedaf4a65f8c4ec1432148c96e3ab36c48e3fea29192986a113160337c0b44a70
   languageName: node
   linkType: hard
 
@@ -5423,7 +5423,7 @@ __metadata:
     graasp-plugin-item-publish: "github:graasp/graasp-plugin-item-publish"
     graasp-plugin-item-zip: "github:graasp/graasp-plugin-item-zip"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
-    graasp-plugin-recycle-bin: "github:graasp/graasp-plugin-recycle-bin"
+    graasp-plugin-recycle-bin: "github:graasp/graasp-plugin-recycle-bin#34-get-descendants"
     graasp-plugin-search: "github:graasp/graasp-plugin-search"
     graasp-plugin-subscriptions: "github:graasp/graasp-plugin-subscriptions"
     graasp-plugin-thumbnails: "github:graasp/graasp-plugin-thumbnails"


### PR DESCRIPTION
This PR transforms the copy task so it uses `GetDescendantsTask`. It is clearly not the best solution, but since you cannot run a task in a task, the logic got passed to getDescendants... 

A cleaner solution would be to allow posthook at the slonik level, which does not exist. 

An ORM could probably dynamically add subqueries to the original query.

close #185 