### PR TITLE
chore(ci): update the workflow version used

### DIFF
--- a/.github/workflows/cdelivery-ecs-backend-caller.yml
+++ b/.github/workflows/cdelivery-ecs-backend-caller.yml
@@ -11,8 +11,8 @@ jobs:
   graasp-deploy-ecs-backend-workflow:
     # repository name
     name: Graasp
-    uses: graasp/graasp-deploy/.github/workflows/cdelivery-ecs-backend.yml@a25d9dd237fd160523078dd9b309243e82b18359
-    # ecs-task-definition with template file. 
+    uses: graasp/graasp-deploy/.github/workflows/cdelivery-ecs-backend.yml@v1
+    # ecs-task-definition with template file.
     with:
       ecs-task-definition: '.aws/graasp-stage.json'
       tag: ${{ github.event.client_payload.tag }}

--- a/.github/workflows/cdeployment-ecs-backend-caller.yml
+++ b/.github/workflows/cdeployment-ecs-backend-caller.yml
@@ -12,7 +12,7 @@ jobs:
     # Replace with repository name
     name: Graasp
     # Replace 'main' with the hash of a commit, so it points to an specific version of the reusable workflow that is used
-    uses: graasp/graasp-deploy/.github/workflows/cdeployment-ecs-backend.yml@a25d9dd237fd160523078dd9b309243e82b18359
+    uses: graasp/graasp-deploy/.github/workflows/cdeployment-ecs-backend.yml@v1
     # Replace input ecs-task-definition with template file. Format: '.aws/<name>-prod.json'
     with:
       ecs-task-definition: '.aws/graasp-prod.json'

--- a/.github/workflows/cintegration-ecs-backend-caller.yml
+++ b/.github/workflows/cintegration-ecs-backend-caller.yml
@@ -17,8 +17,8 @@ jobs:
     # repository name
     name: Graasp
     # Reference reusable workflow file. Using the commit SHA is the safest for stability and security
-    uses: graasp/graasp-deploy/.github/workflows/cintegration-ecs-backend.yml@a25d9dd237fd160523078dd9b309243e82b18359
-    # ecs-task-definition with template file. 
+    uses: graasp/graasp-deploy/.github/workflows/cintegration-ecs-backend.yml@v1
+    # ecs-task-definition with template file.
     with:
       ecs-task-definition: '.aws/graasp-dev.json'
       apps-plugin: true

--- a/.github/workflows/update-staging-version.yml
+++ b/.github/workflows/update-staging-version.yml
@@ -1,5 +1,5 @@
-# This workflow triggers a new workflow inside the graasp-deploy repository. It passes a json 
-# with the repository name and the latest tag pushed from the caller repository. 
+# This workflow triggers a new workflow inside the graasp-deploy repository. It passes a json
+# with the repository name and the latest tag pushed from the caller repository.
 name: Push new tag to graasp-deploy repository
 
 # Controls when the action will run
@@ -14,10 +14,10 @@ on:
         # Default value if no value is explicitly provided
         # Input does not have to be provided for the workflow to run
         type: choice
-        options: 
+        options:
         - first
-        - patch        
-        - minor        
+        - patch
+        - minor
         - major
         default: patch
         required: true
@@ -27,9 +27,9 @@ jobs:
   graasp-deploy-update-staging-version-workflow:
     # Replace with repository name
     name: Graasp
-    # Replace 'main' with the hash of a commit, so it points to an specific version of the reusable workflow that is used
-    # Reference reusable workflow file. Using the commit SHA is the safest for stability and security
-    uses: graasp/graasp-deploy/.github/workflows/update-staging-version.yml@c5c706c5b643b04f6e9012fc4bb5fa736b6a651e
+    # Replace 'main' with the hash of a commit, so it points to a specific version of the reusable workflow that is used
+    # Reference reusable workflow file. Using the commit SHA is the safest for stability and security, but using the major tag ensures less maintance
+    uses: graasp/graasp-deploy/.github/workflows/update-staging-version.yml@v1
     with:
       release-type: ${{ inputs.release-type }}
     secrets:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Graasp
 
+![GitHub package.json version](https://img.shields.io/github/package-json/v/graasp/graasp?color=deepskyblue)
+
 ## Requirements
 
 In order to run the Graasp backend, it requires:


### PR DESCRIPTION
In this PR we change the version of the re-usable workflows used to be `v1`. This is considered less secure than using the commit sha, but it will save on maintainance as we will not have to worry about updating the sha for every new commit in graasp/deploy. 

Alternatively we could use the minor tag `v1.1` for less flexibility.

I also added a badge to the readme to show the current version.

closes #271 