### PR TITLE
fix: pin graasp-plugin-thumbnails and graasp-plugin-file-item

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "graasp-plugin-chatbox": "github:graasp/graasp-plugin-chatbox",
     "graasp-plugin-etherpad": "github:graasp/graasp-plugin-etherpad",
     "graasp-plugin-file": "github:graasp/graasp-plugin-file",
-    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item",
+    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item#f311ad8ad3b8e2ad85e1e402fad669d0d5bd06a6",
     "graasp-plugin-h5p": "github:graasp/graasp-plugin-h5p",
     "graasp-plugin-hidden-items": "github:graasp/graasp-plugin-hidden-items",
     "graasp-plugin-invitations": "github:graasp/graasp-plugin-invitations",
@@ -82,7 +82,7 @@
     "graasp-plugin-recycle-bin": "github:graasp/graasp-plugin-recycle-bin",
     "graasp-plugin-search": "github:graasp/graasp-plugin-search",
     "graasp-plugin-subscriptions": "github:graasp/graasp-plugin-subscriptions",
-    "graasp-plugin-thumbnails": "github:graasp/graasp-plugin-thumbnails",
+    "graasp-plugin-thumbnails": "github:graasp/graasp-plugin-thumbnails#0a01cc2b0f3c3c43fd8613024f00b338e8036c07",
     "graasp-plugin-validation": "github:graasp/graasp-plugin-validation",
     "graasp-websockets": "github:graasp/graasp-websockets",
     "http-status-codes": "2.2.0",
@@ -120,6 +120,8 @@
   },
   "packageManager": "yarn@3.2.4",
   "resolutions": {
+    "graasp-plugin-thumbnails": "github:graasp/graasp-plugin-thumbnails#0a01cc2b0f3c3c43fd8613024f00b338e8036c07",
+    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item#f311ad8ad3b8e2ad85e1e402fad669d0d5bd06a6",
     "bcrypt": "5.0.1",
     "fastify": "3.29.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5400,7 +5400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graasp-plugin-file-item@github:graasp/graasp-plugin-file-item":
+"graasp-plugin-file-item@github:graasp/graasp-plugin-file-item#f311ad8ad3b8e2ad85e1e402fad669d0d5bd06a6":
   version: 0.1.0
   resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=f311ad8ad3b8e2ad85e1e402fad669d0d5bd06a6"
   dependencies:
@@ -5569,7 +5569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graasp-plugin-thumbnails@github:graasp/graasp-plugin-thumbnails":
+"graasp-plugin-thumbnails@github:graasp/graasp-plugin-thumbnails#0a01cc2b0f3c3c43fd8613024f00b338e8036c07":
   version: 0.1.0
   resolution: "graasp-plugin-thumbnails@https://github.com/graasp/graasp-plugin-thumbnails.git#commit=0a01cc2b0f3c3c43fd8613024f00b338e8036c07"
   dependencies:
@@ -5662,7 +5662,7 @@ __metadata:
     graasp-plugin-chatbox: "github:graasp/graasp-plugin-chatbox"
     graasp-plugin-etherpad: "github:graasp/graasp-plugin-etherpad"
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
-    graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item"
+    graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item#f311ad8ad3b8e2ad85e1e402fad669d0d5bd06a6"
     graasp-plugin-h5p: "github:graasp/graasp-plugin-h5p"
     graasp-plugin-hidden-items: "github:graasp/graasp-plugin-hidden-items"
     graasp-plugin-invitations: "github:graasp/graasp-plugin-invitations"
@@ -5674,7 +5674,7 @@ __metadata:
     graasp-plugin-recycle-bin: "github:graasp/graasp-plugin-recycle-bin"
     graasp-plugin-search: "github:graasp/graasp-plugin-search"
     graasp-plugin-subscriptions: "github:graasp/graasp-plugin-subscriptions"
-    graasp-plugin-thumbnails: "github:graasp/graasp-plugin-thumbnails"
+    graasp-plugin-thumbnails: "github:graasp/graasp-plugin-thumbnails#0a01cc2b0f3c3c43fd8613024f00b338e8036c07"
     graasp-plugin-validation: "github:graasp/graasp-plugin-validation"
     graasp-websockets: "github:graasp/graasp-websockets"
     http-status-codes: 2.2.0


### PR DESCRIPTION
Ensure that graasp-plugin-thumbnails and graasp-plugin-file-item do not resolve to the latest versions implemented by #287. Instead, use their respective latest commit before the fix.

:warning: the hash is fixed in the resolutions, so make sure to remove the hardcoded values in the future when thumbnails is working properly