### PR TITLE
fix: return shared sibling items

### DIFF
--- a/src/services/items/db-service.ts
+++ b/src/services/items/db-service.ts
@@ -388,8 +388,12 @@ export class ItemService implements DbService {
       INNER JOIN item
         ON item.path = item_membership.item_path
       WHERE (
-        (item_membership.permission != 'admin'
-        OR item.creator != ${memberId})
+        item_membership.member_id = ${memberId}
+        AND (
+          item_membership.permission != 'admin'
+            OR 
+          item.creator != ${memberId}
+        )
         ${permissionFilter}
       )
       `,


### PR DESCRIPTION
close #304 

I couldn't think of another way of filtering the items through sql. 
The filtering function could be optimized (I'm thinking of sorting by path, then one loop comparing the shortest path and current path, filter out if the current path is a children of the shortest path). 