### PR TITLE
feat: update graasp-plugin-websockets 

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "graasp-plugin-subscriptions": "github:graasp/graasp-plugin-subscriptions",
     "graasp-plugin-thumbnails": "github:graasp/graasp-plugin-thumbnails",
     "graasp-plugin-validation": "github:graasp/graasp-plugin-validation",
-    "graasp-websockets": "github:graasp/graasp-websockets",
+    "graasp-plugin-websockets": "github:graasp/graasp-plugin-websockets",
     "http-status-codes": "2.2.0",
     "jsonwebtoken": "9.0.0",
     "qs": "6.10.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import fp from 'fastify-plugin';
 
 import mailerPlugin from 'graasp-mailer';
 import graaspPluginActions from 'graasp-plugin-actions';
-import graaspWebSockets from 'graasp-websockets';
+import graaspWebSockets from 'graasp-plugin-websockets';
 
 import authPlugin from './plugins/auth/auth';
 import databasePlugin from './plugins/database';

--- a/src/services/item-memberships/ws/hooks.ts
+++ b/src/services/item-memberships/ws/hooks.ts
@@ -8,7 +8,7 @@ import {
   TaskRunner,
   getChildFromPath,
 } from '@graasp/sdk';
-import { AccessDenied, NotFound, WebSocketService } from 'graasp-websockets';
+import { AccessDenied, NotFound, WebSocketService } from 'graasp-plugin-websockets';
 
 import { SharedItemsEvent, memberItemsTopic } from '../../items/ws/events';
 import { ItemMembershipEvent, itemMembershipsTopic } from './events';

--- a/src/services/items/ws/hooks.ts
+++ b/src/services/items/ws/hooks.ts
@@ -8,7 +8,7 @@ import {
   TaskRunner,
   getParentFromPath,
 } from '@graasp/sdk';
-import { AccessDenied, NotFound, WebSocketService } from 'graasp-websockets';
+import { AccessDenied, NotFound, WebSocketService } from 'graasp-plugin-websockets';
 
 import {
   ChildItemEvent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5732,6 +5732,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graasp-plugin-websockets@github:graasp/graasp-plugin-websockets":
+  version: 1.0.0
+  resolution: "graasp-plugin-websockets@https://github.com/graasp/graasp-plugin-websockets.git#commit=3977527ed1dd6d4c8b90681c586897243d4f49cf"
+  dependencies:
+    ajv: ^8.11.0
+    dotenv: ^9.0.2
+    fastify: ^3.29.1
+    fastify-plugin: ^3.0.1
+    fastify-websocket: ^3.2.2
+    ioredis: ^4.28.5
+  checksum: 696c25bd4cee69e16a6245190a86db84e5870caf14ff80679edcead921737cc12a5141c2fa43d48fa063414c15279dc952b498345af957b42105c5b0f5b0a365
+  languageName: node
+  linkType: hard
+
 "graasp-websockets@github:graasp/graasp-websockets":
   version: 1.0.0
   resolution: "graasp-websockets@https://github.com/graasp/graasp-websockets.git#commit=3977527ed1dd6d4c8b90681c586897243d4f49cf"
@@ -5809,7 +5823,7 @@ __metadata:
     graasp-plugin-subscriptions: "github:graasp/graasp-plugin-subscriptions"
     graasp-plugin-thumbnails: "github:graasp/graasp-plugin-thumbnails"
     graasp-plugin-validation: "github:graasp/graasp-plugin-validation"
-    graasp-websockets: "github:graasp/graasp-websockets"
+    graasp-plugin-websockets: "github:graasp/graasp-plugin-websockets"
     http-status-codes: 2.2.0
     husky: 7.0.4
     jest: 29.4.1


### PR DESCRIPTION
TODO: some other plugins are depending on websockets - check that they do not point to old repo name anymore (lookup "graasp-websockets" in yarn.lock)