### PR TITLE
refactor: add deploy refactor workflow

### DIFF
--- a/.aws/refactor.json
+++ b/.aws/refactor.json
@@ -1,0 +1,188 @@
+{
+  "ipcMode": null,
+  "executionRoleArn": "arn:aws:iam::299720865162:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/refactor",
+          "awslogs-region": "eu-central-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 3111,
+          "protocol": "tcp",
+          "containerPort": 3111
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 0,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": null,
+      "memory": null,
+      "memoryReservation": null,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": null,
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "refactor"
+    },
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/graasp-iframely-development",
+          "awslogs-region": "eu-central-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 8061,
+          "protocol": "tcp",
+          "containerPort": 8061
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 0,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": null,
+      "memory": null,
+      "memoryReservation": null,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": null,
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "graasp-iframely-development"
+    },
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/graasp-nudenet-development",
+          "awslogs-region": "eu-central-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "containerPort": 8080
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 0,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": null,
+      "memory": null,
+      "memoryReservation": null,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": null,
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "graasp-nudenet"
+    }
+  ],
+  "placementConstraints": [],
+  "memory": "3072",
+  "taskRoleArn": null,
+  "compatibilities": [],
+  "taskDefinitionArn": null,
+  "family": "refactor",
+  "requiresAttributes": [],
+  "pidMode": null,
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "runtimePlatform": {
+    "operatingSystemFamily": "LINUX",
+    "cpuArchitecture": null
+  },
+  "cpu": "1024",
+  "revision": null,
+  "status": null,
+  "inferenceAccelerators": null,
+  "proxyConfiguration": null,
+  "volumes": []
+}

--- a/.github/workflows/deploy-refactor.yml
+++ b/.github/workflows/deploy-refactor.yml
@@ -1,0 +1,105 @@
+name: Deploy to refactor environment
+
+# Controls when the action will run.
+on:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# This workflow is made up of one job that calls the reusable workflow in graasp-deploy
+jobs:
+  refactor-deploy-ecs-backend-workflow:
+    # repository name
+    name: Graasp
+    # Reference reusable workflow file. Using the commit SHA is the safest for stability and security
+    uses: graasp/graasp-deploy/.github/workflows/cintegration-ecs-backend.yml@v1
+
+    # abort previous deployment if a newer one is in progress
+    concurrency:
+      group: deploy-refactor
+      cancel-in-progress: true
+
+    # ecs-task-definition with template file.
+    with:
+      ecs-task-definition: '.aws/refactor.json'
+      apps-plugin: true
+      chatbox-plugin: true
+      database-logs: false
+      embedded-link-item-plugin: true
+      etherpad-cookie-domain: ${{ vars.ETHERPAD_COOKIE_DOMAIN_DEV }}
+      etherpad-url: ${{ vars.ETHERPAD_URL_DEV }}
+      hidden-items-plugin: true
+      node-env: production
+      node-env-iframely: production
+      public-plugin: true
+      roarr-log: false
+      s3-file-item-plugin: true
+      save-actions: true
+      subscriptions-plugin: true
+      token-based-auth: true
+      websockets-plugin: true
+
+    # required secrets
+    secrets:
+      aws-access-key-id: ${{ secrets.TMP_AWS_ACCESS_KEY_ID_DEV }}
+      aws-secret-access-key: ${{ secrets.TMP_AWS_SECRET_ACCESS_KEY_DEV }}
+      aws-region: ${{ secrets.AWS_REGION_DEV }}
+      ecs-cluster: ${{ secrets.TMP_ECS_CLUSTER_REFACTOR }}
+      ecs-service: ${{ secrets.TMP_ECS_SERVICE_REFACTOR }}
+      ecr-repository: ${{ secrets.TMP_ECR_REPOSITORY_GRAASP_DEV }}
+      container-name-graasp: ${{ secrets.TMP_CONTAINER_NAME_REFACTOR }}
+      container-name-iframely: ${{ secrets.CONTAINER_NAME_IFRAMELY_DEV }}
+      container-name-classifier: ${{ secrets.CONTAINER_NAME_CLASSIFIER }}
+      container-image-iframely: ${{ secrets.TMP_CONTAINER_IMAGE_IFRAMELY }}
+      container-image-classifier: ${{ secrets.TMP_CONTAINER_IMAGE_CLASSIFIER }}
+      analyzer-client-host: ''
+      apps-jwt-secret: ${{ secrets.TMP_APPS_JWT_SECRET_DEV }}
+      apps-publisher-id: ''
+      auth-client-host: ''
+      auth-token-expiration-in-minutes: ${{ secrets.TMP_AUTH_TOKEN_EXPIRATION_IN_MINUTES }}
+      auth-token-jwt-secret: ${{ secrets.TMP_AUTH_TOKEN_JWT_SECRET_DEV }}
+      avatars-path-prefix: ''
+      builder-client-host: ''
+      client-host: ${{ secrets.TMP_CLIENT_HOST_DEV }}
+      cookie-domain: ${{ secrets.TMP_COOKIE_DOMAIN_DEV }}
+      cors-origin-regex: ${{ secrets.TMP_CORS_ORIGIN_REGEX_DEV }}
+      email-links-host: ''
+      embedded-link-item-iframely-href-origin: ${{ secrets.EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN }}
+      etherpad-api-key: ${{ secrets.TMP_ETHERPAD_API_KEY_DEV }}
+      explorer-client-host: ''
+      file-storage-root-path: ${{ secrets.TMP_FILE_STORAGE_ROOT_PATH }}
+      files-path-prefix: ${{ secrets.TMP_FILES_PATH_PREFIX }}
+      h5p-content-access-key-id: ${{ secrets.TMP_H5P_CONTENT_ACCESS_KEY_ID_DEV }}
+      h5p-content-bucket-name: ${{ secrets.TMP_H5P_CONTENT_BUCKET_DEV }}
+      h5p-content-region: ${{ secrets.TMP_H5P_CONTENT_REGION_DEV }}
+      h5p-content-secret-access-key: ${{ secrets.TMP_H5P_CONTENT_SECRET_ACCESS_KEY_DEV }}
+      h5p-path-prefix: ${{ secrets.TMP_H5P_PATH_PREFIX_DEV }}
+      hidden-tag-id: 'dont use anymore'
+      hostname: ${{ secrets.TMP_HOSTNAME_DEV}}
+      image-classifier-api: ${{ secrets.IMAGE_CLASSIFIER_API }}
+      jwt-secret: ${{ secrets.TMP_JWT_SECRET_DEV }}
+      login-item-tag-id: 'dont use anymore'
+      mailer-config-from-email: ${{ secrets.MAILER_CONFIG_FROM_EMAIL_DEV }}
+      mailer-config-password: ${{ secrets.MAILER_CONFIG_PASSWORD_DEV }}
+      mailer-config-smtp-host: ${{ secrets.MAILER_CONFIG_SMTP_HOST }}
+      mailer-config-username: ${{ secrets.MAILER_CONFIG_USERNAME_DEV }}
+      pg-connection-uri: ${{ secrets.TMP_PG_CONNECTION_URI_DEV }}
+      pg-read-replicas-connection-uris: 'dont use yet'
+      player-client-host: ''
+      port: ${{ secrets.PORT }}
+      public-tag-id: 'dont use anymore'
+      published-tag-id: 'dont use anymore'
+      redis-host: ${{ secrets.TMP_REDIS_HOST_DEV }}
+      redis-port: ${{ secrets.TMP_REDIS_PORT }}
+      redis-username: ${{ secrets.TMP_REDIS_USERNAME }}
+      refresh-token-expiration-in-minutes: ${{ secrets.TMP_REFRESH_TOKEN_EXPIRATION_IN_MINUTES }}
+      refresh-token-jwt-secret: ${{ secrets.TMP_REFRESH_TOKEN_JWT_SECRET_DEV }}
+      s3-file-item-access-key-id: ${{ secrets.TMP_S3_FILE_ITEM_ACCESS_KEY_ID_DEV }}
+      s3-file-item-bucket: ${{ secrets.TMP_S3_FILE_ITEM_BUCKET_DEV }}
+      s3-file-item-region: ${{ secrets.TMP_S3_FILE_ITEM_REGION }}
+      s3-file-item-secret-access-key: ${{ secrets.TMP_S3_FILE_ITEM_SECRET_ACCESS_KEY_DEV }}
+      secure-session-secret-key: ${{ secrets.TMP_SECURE_SESSION_SECRET_KEY_DEV }}
+      sentry-dsn: ${{ secrets.TMP_SENTRY_DSN }}
+      stripe-secret-key: 'dont use yet'
+      stripe-default-plan-price-id: 'dont use yet'
+      thumbnails-path-prefix: ''


### PR DESCRIPTION
This PR adds a first version of the deployment workflow for the refactor.

The idea is to duplicate the environment (new h5p container, new s3 file buckets, etc).
Only the mail service will be the same.

close #338 