### PR TITLE
chore: check migration sync status with code

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "migration:fake": "yarn migration:run:fake && migration:revert:fake",
     "migration:run:fake": "npx typeorm-ts-node-commonjs  migration:run --fake",
     "migration:revert:fake": "npx typeorm-ts-node-commonjs migration:revert --fake",
-    "migration:check": "npx typeorm-ts-node-commonjs schema:log -d src/plugins/datasource.ts"
+    "migration:check": "npx typeorm-ts-node-commonjs migration:generate src/migrations/migrations --check -d src/plugins/datasource.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.306.0",


### PR DESCRIPTION
Using the existing `--check` flag of TypeORM's `migration:generate` is better than doing `schema:log` because it actually returns an 1 error code when there is syncing error between database state and code entities. This make the CI fails when some migrations are missing.

In this PR workflow we have an example of the CI failing because the current version of the `typeorm` branch is missing one constraint in the migrations: https://github.com/graasp/graasp/actions/runs/5078366591/jobs/9122791219#step:9:66

I made a temporary branch after running `migration:generate` to add missing migration and show that the check step pass in this case:  https://github.com/graasp/graasp/actions/runs/5078483639/jobs/9123045651#step:9:49