### PR TITLE
fix: localstack error during local dev

### DIFF
--- a/src/services/file/repositories/s3.ts
+++ b/src/services/file/repositories/s3.ts
@@ -16,6 +16,7 @@ import { FastifyReply } from 'fastify';
 
 import { S3FileConfiguration, UUID } from '@graasp/sdk';
 
+import { S3_FILE_ITEM_HOST } from '../../../utils/config';
 import { FileRepository } from '../interfaces/fileRepository';
 import { S3_PRESIGNED_EXPIRATION } from '../utils/constants';
 import { DownloadFileUnexpectedError, S3FileNotFound } from '../utils/errors';
@@ -38,6 +39,12 @@ export class S3FileRepository implements FileRepository {
       region,
       useAccelerateEndpoint,
       credentials: { accessKeyId, secretAccessKey },
+      // this is necessary because localstack doesn't support hostnames eg: <bucket>.s3.<region>.amazonaws.com/<key>
+      // so it we must use pathStyle buckets eg: localhost:4566/<bucket>/<key>
+      forcePathStyle: true,
+      // this is necessary to use the localstack instance running on graasp-localstack or localhost
+      // this overrides the default endpoint (amazonaws.com) with S3_FILE_ITEM_HOST
+      endpoint: S3_FILE_ITEM_HOST,
     });
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -155,6 +155,7 @@ export const S3_FILE_ITEM_REGION = process.env.S3_FILE_ITEM_REGION;
 export const S3_FILE_ITEM_BUCKET = process.env.S3_FILE_ITEM_BUCKET;
 export const S3_FILE_ITEM_ACCESS_KEY_ID = process.env.S3_FILE_ITEM_ACCESS_KEY_ID;
 export const S3_FILE_ITEM_SECRET_ACCESS_KEY = process.env.S3_FILE_ITEM_SECRET_ACCESS_KEY;
+export const S3_FILE_ITEM_HOST = process.env.S3_FILE_ITEM_HOST;
 
 export let S3_FILE_ITEM_PLUGIN_OPTIONS: S3FileConfiguration;
 


### PR DESCRIPTION
This config seems seems to have disapeared on the `typeorm` branch. Adding them back allows me to upload files on local dev.

I expect the endpoint to default to the real S3 when it's undefined but maybe i'm missing something?