### PR TITLE
feat: add get most liked collections endpoint

### DIFF
--- a/src/services/item/plugins/itemLike/service.ts
+++ b/src/services/item/plugins/itemLike/service.ts
@@ -2,7 +2,6 @@ import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import ItemService from '../../../item/service';
 import { Actor } from '../../../member/entities/member';
-import { CannotGetOthersLikes } from './errors';
 
 export class ItemLikeService {
   private itemService: ItemService;

--- a/src/services/item/plugins/itemLike/test/index.test.ts
+++ b/src/services/item/plugins/itemLike/test/index.test.ts
@@ -1,22 +1,21 @@
 import { StatusCodes } from 'http-status-codes';
-import { v4 } from 'uuid';
 
 import { HttpMethod } from '@graasp/sdk';
 
-import build, { clearDatabase } from '../../../../../test/app';
-import { MemberCannotAccess } from '../../../../utils/errors';
-import { saveItemAndMembership } from '../../../itemMembership/test/fixtures/memberships';
-import { Member } from '../../../member/entities/member';
-import { BOB, saveMember } from '../../../member/test/fixtures/members';
-import { Item } from '../../entities/Item';
-import { expectManyItems, saveItem } from '../../test/fixtures/items';
-import { setItemPublic } from '../itemTag/test/fixtures';
-import { ItemLikeNotFound } from './errors';
-import { ItemLike } from './itemLike';
-import { ItemLikeRepository } from './repository';
+import build, { clearDatabase } from '../../../../../../test/app';
+import { MemberCannotAccess } from '../../../../../utils/errors';
+import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
+import { Member } from '../../../../member/entities/member';
+import { BOB, saveMember } from '../../../../member/test/fixtures/members';
+import { expectManyItems } from '../../../test/fixtures/items';
+import { setItemPublic } from '../../itemTag/test/fixtures';
+import { ItemLikeNotFound } from '../errors';
+import { ItemLike } from '../itemLike';
+import { ItemLikeRepository } from '../repository';
+import { saveItemLikes } from './utils';
 
 // mock datasource
-jest.mock('../../../../plugins/datasource');
+jest.mock('../../../../../plugins/datasource');
 
 export const expectItemLike = (newLike: ItemLike, correctLike: ItemLike, creator?: Member) => {
   expect(newLike.item.id).toEqual(correctLike.item.id);
@@ -39,15 +38,6 @@ export const expectManyItemLikes = (
     }
     expectItemLike(l, like, creator);
   });
-};
-
-const saveItemLikes = async (items: Item[], member: Member) => {
-  const likes: ItemLike[] = [];
-  for (const item of items) {
-    const like = await ItemLikeRepository.save({ item, creator: member });
-    likes.push(like);
-  }
-  return likes;
 };
 
 const getFullItemLike = (id) => {

--- a/src/services/item/plugins/itemLike/test/utils.ts
+++ b/src/services/item/plugins/itemLike/test/utils.ts
@@ -1,0 +1,13 @@
+import { Member } from '../../../../member/entities/member';
+import { Item } from '../../../entities/Item';
+import { ItemLike } from '../itemLike';
+import { ItemLikeRepository } from '../repository';
+
+export const saveItemLikes = async (items: Item[], member: Member) => {
+  const likes: ItemLike[] = [];
+  for (const item of items) {
+    const like = await ItemLikeRepository.save({ item, creator: member });
+    likes.push(like);
+  }
+  return likes;
+};

--- a/src/services/item/plugins/published/index.ts
+++ b/src/services/item/plugins/published/index.ts
@@ -9,6 +9,7 @@ import {
   getCollectionsForMember,
   getInformations,
   getManyInformations,
+  getMostLikedItems,
   getRecentCollections,
   publishItem,
   unpublishItem,
@@ -62,6 +63,17 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
     async ({ member, query: { itemId } }) => {
       return pIS.getMany(member, buildRepositories(), itemId);
+    },
+  );
+
+  fastify.get<{ Querystring: { limit?: number } }>(
+    '/collections/liked',
+    {
+      preHandler: fastify.fetchMemberInSession,
+      schema: getMostLikedItems,
+    },
+    async ({ member, query: { limit } }) => {
+      return pIS.getLikedItems(member, buildRepositories(), limit);
     },
   );
 

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -115,4 +115,18 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
     });
     return query.getMany();
   },
+
+  // return public items sorted by most liked
+  // bug: does not take into account child items
+  async getLikedItems(limit: number = 10): Promise<Item[]> {
+    const itemPublished = await this.createQueryBuilder('item_published')
+      .leftJoinAndSelect('item_published.item', 'i')
+      .innerJoin('item_like', 'il', 'il.item_id = i.id')
+      .groupBy(['i.id', 'item_published.id'])
+      .orderBy('COUNT(il.id)', 'DESC')
+      .limit(limit)
+      .getMany();
+
+    return itemPublished.map(({ item }) => item);
+  },
 });

--- a/src/services/item/plugins/published/schemas.ts
+++ b/src/services/item/plugins/published/schemas.ts
@@ -1,6 +1,10 @@
 import { MAX_TARGETS_FOR_READ_REQUEST } from '@graasp/sdk';
 
 import { UUID_REGEX } from '../../../../schemas/global';
+import {
+  GET_MOST_LIKED_ITEMS_MAXIMUM,
+  GET_MOST_RECENT_ITEMS_MAXIMUM,
+} from '../../../../utils/config';
 
 const publishEntry = {
   type: 'object',
@@ -56,8 +60,30 @@ export const getRecentCollections = {
     properties: {
       limit: {
         type: 'number',
-        maximum: 50,
-        minimum: 0,
+        maximum: GET_MOST_RECENT_ITEMS_MAXIMUM,
+        minimum: 1,
+      },
+    },
+  },
+
+  response: {
+    200: {
+      type: 'array',
+      items: {
+        $ref: 'http://graasp.org/items/#/definitions/item',
+      },
+    },
+  },
+};
+
+export const getMostLikedItems = {
+  querystring: {
+    type: 'object',
+    properties: {
+      limit: {
+        type: 'number',
+        maximum: GET_MOST_LIKED_ITEMS_MAXIMUM,
+        minimum: 1,
       },
     },
   },

--- a/src/services/item/plugins/published/service.ts
+++ b/src/services/item/plugins/published/service.ts
@@ -120,6 +120,12 @@ export class ItemPublishedService {
     return itemPublishedRepository.getItemsForMember(memberId);
   }
 
+  async getLikedItems(actor: Actor, repositories: Repositories, limit?: number) {
+    const { itemPublishedRepository } = repositories;
+    const items = await itemPublishedRepository.getLikedItems(limit);
+    return filterOutHiddenItems(repositories, items);
+  }
+
   // filter out by categories, not defined will return all items
   async getItemsByCategories(actor: Actor, repositories: Repositories, categoryIds?: string[]) {
     const { itemPublishedRepository } = repositories;

--- a/src/services/item/plugins/published/test/index.test.ts
+++ b/src/services/item/plugins/published/test/index.test.ts
@@ -266,6 +266,12 @@ describe('Item Published', () => {
 
       it('Get 2 most liked collections without hidden', async () => {
         // hide first collection
+        const hiddenCollection = collections[0];
+        await ItemTagRepository.save({
+          item: hiddenCollection,
+          creator: actor,
+          type: ItemTagType.Hidden,
+        });
 
         const res = await app.inject({
           method: HttpMethod.GET,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -293,3 +293,7 @@ if (!process.env.RECAPTCHA_SECRET_ACCESS_KEY) {
 export const RECAPTCHA_SECRET_ACCESS_KEY = process.env.RECAPTCHA_SECRET_ACCESS_KEY;
 export const RECAPTCHA_VERIFY_LINK = 'https://www.google.com/recaptcha/api/siteverify';
 export const RECAPTCHA_SCORE_THRESHOLD = 0.5;
+
+// todo: use env var?
+export const GET_MOST_LIKED_ITEMS_MAXIMUM = 50;
+export const GET_MOST_RECENT_ITEMS_MAXIMUM = 50;


### PR DESCRIPTION
I've implemented an endpoint to get the most liked items for the library.
I couldn't make it work to consider child of published items, but I guess it's not really important currently.

close #395 