### PR TITLE
chore: delete postcheckout husky hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn 


### PR DESCRIPTION
This PR removes the `postcheckout` husky hook as it caused unwanted installs when rebasing, checking out other branches etc.
It has been evaluated it was more cumbersome thatn helpful, so it is removed.
