### PR TITLE
fix: fix migrations for recycled items

### DIFF
--- a/src/migrations/1679669193721-migrations.ts
+++ b/src/migrations/1679669193721-migrations.ts
@@ -92,8 +92,10 @@ export class Migrations1679669193721 implements MigrationInterface {
     await queryRunner.query(
       'INSERT INTO "item" (id, name, type, description, path, creator_id, extra, settings, created_at, updated_at) SELECT id, name, type, description, path, creator, extra, settings, created_at, updated_at from item_old',
     );
+
+    // we use item_id instead of item_path since it is constrained
     await queryRunner.query(`UPDATE "item" as a1 SET deleted_at = (
-                        SELECT created_at FROM recycled_item_old WHERE a1.path = recycled_item_old.item_path)`);
+                        SELECT created_at FROM recycled_item_old WHERE a1.id = recycled_item_old.item_id)`);
 
     await queryRunner.query(`CREATE TABLE "item_membership" (
             "id" uuid NOT NULL DEFAULT uuid_generate_v4(), 
@@ -1195,7 +1197,7 @@ export class Migrations1679669193721 implements MigrationInterface {
             "created_at" timestamp NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc')
             )`);
     await queryRunner.query(
-      `INSERT INTO "recycled_item_old" (id,creator, item_path, item_id, created_at) SELECT rid.id, rid.creator_id, item_path, i.id, rid.created_at FROM recycled_item_data as rid
+      `INSERT INTO "recycled_item_old" (id, creator, item_path, item_id, created_at) SELECT rid.id, rid.creator_id, item_path, i.id, rid.created_at FROM recycled_item_data as rid
       INNER JOIN item as i on path=item_path
       `,
     );

--- a/src/migrations/1679669193721-migrations.ts
+++ b/src/migrations/1679669193721-migrations.ts
@@ -129,8 +129,10 @@ export class Migrations1679669193721 implements MigrationInterface {
     await queryRunner.query(
       'CREATE TABLE "recycled_item_data" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "creator_id" uuid, "item_path" ltree NOT NULL REFERENCES item("path") ON DELETE CASCADE ON UPDATE CASCADE, CONSTRAINT "recycled-item-data" UNIQUE ("item_path"), CONSTRAINT "PK_d6f781e5054e98174c35c87c225" PRIMARY KEY ("id"))',
     );
+
+    // we use item_id because item_path was not constrained in the previous schema
     await queryRunner.query(
-      'INSERT INTO "recycled_item_data" (id, creator_id, item_path, created_at) SELECT id, creator, item_path, created_at FROM recycled_item_old',
+      'INSERT INTO "recycled_item_data" (id, creator_id, item_path, created_at) SELECT recycled_item_old.id, creator, item.path, recycled_item_old.created_at FROM recycled_item_old LEFT JOIN item ON item.id = item_id',
     );
 
     // item like

--- a/test/migrations/migrations1679669193721/migrations1679669193721.fixtures.ts
+++ b/test/migrations/migrations1679669193721/migrations1679669193721.fixtures.ts
@@ -136,7 +136,7 @@ const values = {
     {
       id: '3f901df1-d246-d672-bb01-34269f4c0fed',
       item_path: recycledItemPath,
-      item_id: itemId,
+      item_id: recycledItemId,
       creator: memberId,
       created_at: '2021-05-31T12:40:04.571Z',
     },


### PR DESCRIPTION
The fix takes into account:
- item that might not exist anymore
- uses `item_id`  that is more accurate than `item_path` (since `item_path` was not constrained https://github.com/graasp/graasp-plugin-recycle-bin/commit/5e461b796070d49782b47fc60d74b2ae3d75ad7c )

I didn't write regression tests because this case only exists because the staging env very probably uses an outdated db schema. The base schema we use for the tests (`migrations1679669193720`) contains the constraint so the error cannot happen.

close #404 