### PR TITLE
fix: return creator for published items

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     image: localstack/localstack
     volumes:
       - ${TMPDIR}/localstack:/tmp/graasp-localstack
-      - ./localstack:/docker-entrypoint-initaws.d
+      - './localstack/init.sh:/etc/localstack/init/ready.d/init-aws.sh'
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - SERVICES=s3

--- a/.devcontainer/localstack/init.sh
+++ b/.devcontainer/localstack/init.sh
@@ -24,7 +24,7 @@ corsConfig='{
             ],
             "AllowedMethods": [
                 "HEAD",
-                "GET",
+                "GET"
             ],
             "AllowedOrigins": [
                 "*"

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -37,7 +37,8 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
 
   // return public item entry? contains when it was published
   async getAllItems() {
-    const publishedRows = await this.find({ relations: { item: true } });
+    // we get the nested relation of item.creator because we only return the item and without this the creator is not returned
+    const publishedRows = await this.find({ relations: ['item', 'item.creator'] });
     return publishedRows.map(({ item }) => item);
   },
 


### PR DESCRIPTION
This PR adds the creator field to the returned published items.

~~Maybe we should filter the properties of the member that are returned ? But this would mean we have to create a new `PublicMember` type that only contains information that is ok to share. I do not know how we would handle that with relation to the type that is defined on the relation ... Maybe there is a way to filter the data directly using typeorm ? Like only exporting certain allowed columns ?~~
Update: The creator properties are handled by the schema, only "id", "name" and "email" are allowed, so we are fine. 😄 

This change is needed for the user avatars to work in the library. 