### PR TITLE
fix: add member back in itemLike response

### DIFF
--- a/src/services/item/plugins/itemLike/repository.ts
+++ b/src/services/item/plugins/itemLike/repository.ts
@@ -16,7 +16,9 @@ export const ItemLikeRepository = AppDataSource.getRepository(ItemLike).extend({
   async getItemsForMember(memberId: string): Promise<ItemLike[]> {
     const itemLikes = await this.createQueryBuilder('itemLike')
       .innerJoinAndSelect('itemLike.item', 'item')
-      .where('itemLike.creator = :memberId', { memberId })
+      .innerJoinAndSelect('itemLike.creator', 'member', 'itemLike.creator = :memberId', {
+        memberId,
+      })
       .getMany();
     return itemLikes;
   },

--- a/src/services/item/plugins/itemLike/schemas.ts
+++ b/src/services/item/plugins/itemLike/schemas.ts
@@ -11,7 +11,7 @@ export default {
           $ref: 'http://graasp.org/items/#/definitions/item',
         },
         creator: {
-          $ref: 'http://graasp.org/member/#/definitions/member',
+          $ref: 'http://graasp.org/members/#/definitions/member',
         },
         createdAt: {},
       },

--- a/src/services/item/plugins/itemLike/schemas.ts
+++ b/src/services/item/plugins/itemLike/schemas.ts
@@ -10,10 +10,9 @@ export default {
         item: {
           $ref: 'http://graasp.org/items/#/definitions/item',
         },
-        // warning: do not include for privacy for now
-        // member: {
-        //   $ref: 'http://graasp.org/#/definitions/uuid',
-        // },
+        creator: {
+          $ref: 'http://graasp.org/member/#/definitions/member',
+        },
         createdAt: {},
       },
       additionalProperties: false,


### PR DESCRIPTION
Should we add the member back in the response of item like ?

Do we consider members as "public" ? 

I think there could be some privacy implications by returning the email. Maybe we could just return `id` and `name` ? 

Currently only users with read access to the item can use the `getItemLikeForItem`.
We should maybe add a publicly accessible call to query just the number of likes of an item. It should also check that that item is published.