### PR TITLE
fix: return root published item when querying for a child item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ types
 
 # Secrets
 secret-key
+
+# caches
+.jest-cache

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,3 @@ types
 
 # Secrets
 secret-key
-
-# caches
-.jest-cache

--- a/src/services/item/plugins/itemTag/repository.ts
+++ b/src/services/item/plugins/itemTag/repository.ts
@@ -1,4 +1,4 @@
-import { Brackets, In } from 'typeorm';
+import { Brackets } from 'typeorm';
 
 import { ItemTagType, ResultOf } from '@graasp/sdk';
 
@@ -8,12 +8,7 @@ import { mapById } from '../../../utils';
 import { Item } from '../../entities/Item';
 import { pathToId } from '../../utils';
 import { ItemTag } from './ItemTag';
-import {
-  CannotModifyParentTag,
-  ConflictingTagsInTheHierarchy,
-  ItemHasTag,
-  ItemTagNotFound,
-} from './errors';
+import { CannotModifyParentTag, ConflictingTagsInTheHierarchy, ItemTagNotFound } from './errors';
 
 /**
  * Database's first layer of abstraction for Item Tags and (exceptionally) for Tags (at the bottom)
@@ -43,7 +38,7 @@ export const ItemTagRepository = AppDataSource.getRepository(ItemTag).extend({
   async hasMany(item: Item, tagTypes: ItemTagType[]) {
     const hasTags = await this.createQueryBuilder('itemTag')
       .leftJoinAndSelect('itemTag.item', 'item')
-      .where('item.path @> :path', { path: item.path })
+      .where('itemTag.item @> :path', { path: item.path })
       .andWhere('itemTag.type IN (:...types)', { types: tagTypes })
       .getMany();
 

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -11,7 +11,7 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
   async getForItem(item: Item) {
     // this returns the root published item when querying a child item
     const entry = await this.createQueryBuilder('pi')
-      .innerJoinAndSelect('pi.item', 'item', 'pi.item_path @> :itemPath', { itemPath: item.path })
+      .innerJoinAndSelect('pi.item', 'item', 'pi.item @> :itemPath', { itemPath: item.path })
       .innerJoinAndSelect('pi.creator', 'member')
       .getOne();
     if (!entry) {
@@ -24,7 +24,7 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
     const paths = items.map((i) => i.path);
     const ids = items.map((i) => i.id);
     const entries = await this.createQueryBuilder('pi')
-      .innerJoinAndSelect('pi.item', 'item', 'pi.item_path @> ARRAY[:...paths]::ltree[]', {
+      .innerJoinAndSelect('pi.item', 'item', 'pi.item @> ARRAY[:...paths]::ltree[]', {
         paths,
       })
       .innerJoinAndSelect('pi.creator', 'member')

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -11,10 +11,11 @@ import { ItemPublishedNotFound } from '../errors';
 
 export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished).extend({
   async getForItem(item: Item) {
-    const entry = await this.findOne({
-      where: { item: { id: item.id } },
-      relations: { item: true, creator: true },
-    });
+    // this returns the root published item when querying a child item
+    const entry = await this.createQueryBuilder('pi')
+      .innerJoinAndSelect('pi.item', 'item', 'pi.item_path @> :itemPath', { itemPath: item.path })
+      .innerJoinAndSelect('pi.creator', 'member')
+      .getOne();
     if (!entry) {
       throw new ItemPublishedNotFound(item.id);
     }


### PR DESCRIPTION
This PR updates the publish information call to return the root item when querying for a child item that is published.
- single call
  - [x] repository 
  - [x] tests
- multiple call
  - [x] repository
  - [x] tests