### PR TITLE
fix: login-password to use a redirect with the token in query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ In order to run the Graasp backend, it requires:
 
 - [VS Code](https://code.visualstudio.com) : IDE to manage the database and make changes to the source code.
 
-    - [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) : A extension for VS Code. It allows to easily setup the dev environnement.
+  - [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) : A extension for VS Code. It allows to easily setup the dev environnement.
 
-    - [SQLTools](https://marketplace.visualstudio.com/items?itemName=mtxr.sqltools) : A extension for VS Code. It allows easy access to the database.
+  - [SQLTools](https://marketplace.visualstudio.com/items?itemName=mtxr.sqltools) : A extension for VS Code. It allows easy access to the database.
 
 ## Installation
 
@@ -39,6 +39,7 @@ We recommend to set up the development environment using Docker, as it allows to
 First open the folder in the dev-container by using the command palette <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>P</kbd> (or <kbd>ctrl</kbd> instead of <kbd>cmd</kbd>), and typing `Open Folder in Container`.
 
 This will create 3 containers :
+
 - `app` : Node.js backend of Graasp
 - `db` : PostgreSQL database used by the backend
 - `redis` : Redis instance to enable websockets
@@ -66,28 +67,32 @@ Then open the folder locally and run the following command to install the requir
 
 ### Database and Migrations
 
-The application will run migrations on start. 
+The application will run migrations on start.
 
 #### Create a migration
+
 Migrations are saved in `src/migrations/*.ts`. They are then transformed into js files so typeorm can run them.
 
 Run the generate and run command to create and apply the migration.
+
 ```` bash
 yarn migration:generate
 yarn migration:run
 ````
 
 If you need to revert
+
 ```` bash
 yarn migration:revert
 ````
 
 To test your migrations, you can run
+
 ```` bash
 yarn migration:fake
 ````
 
-Each migration should have its own test to verify the `up` and `down` procedures in `test/migrations`. 
+Each migration should have its own test to verify the `up` and `down` procedures in `test/migrations`.
 
 Up tests start from the previous migration state, insert mock data and apply the up procedure. Then each table should still contain the inserted data with necessary changes. The down tests have a similar approach.
 
@@ -199,6 +204,7 @@ BUILDER_CLIENT_HOST=<value>
 PLAYER_CLIENT_HOST=<value>
 EXPLORER_CLIENT_HOST=<value>
 AUTH_CLIENT_HOST=<value>
+GRAASP_MOBILE_BUILDER=<value>
 
 # validation containers
 IMAGE_CLASSIFIER_API=<url>

--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -95,7 +95,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
       const redirectionUrl = new URL(`${GRAASP_MOBILE_BUILDER_PROTOCOL}://auth`);
       redirectionUrl.searchParams.set('t', token);
-      reply.redirect(redirectionUrl.toString());
+      reply.status(StatusCodes.SEE_OTHER);
+      return { resource: redirectionUrl.toString() };
     },
   );
 

--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -4,6 +4,7 @@ import { FastifyPluginAsync } from 'fastify';
 
 import { DEFAULT_LANG, RecaptchaAction } from '@graasp/sdk';
 
+import { AUTH_CLIENT_HOST, GRAASP_MOBILE_BUILDER_PROTOCOL } from '../../../../utils/config';
 import { buildRepositories } from '../../../../utils/repositories';
 import { MemberPasswordService } from '../password/service';
 import { mPasswordLogin, mauth, mdeepLink, mlogin, mregister } from './schemas';
@@ -92,7 +93,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         body.challenge,
       );
 
-      reply.status(StatusCodes.OK).send({ t: token });
+      const redirectionUrl = new URL(`${GRAASP_MOBILE_BUILDER_PROTOCOL}://auth`);
+      redirectionUrl.searchParams.set('t', token);
+      reply.redirect(redirectionUrl.toString());
     },
   );
 

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -221,8 +221,10 @@ describe('Mobile Endpoints', () => {
           captcha: MOCK_CAPTCHA,
         },
       });
-      expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
-      expect(response.headers.location).toContain(`${GRAASP_MOBILE_BUILDER_PROTOCOL}://auth?t=`);
+      expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
+      const result = await response.json();
+      expect(result).toHaveProperty('resource');
+      expect(result.resource).toContain(`${GRAASP_MOBILE_BUILDER_PROTOCOL}://auth?t=`);
     });
 
     it('Sign In does send unauthorized error for wrong password', async () => {

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -217,8 +217,8 @@ describe('Mobile Endpoints', () => {
           captcha: MOCK_CAPTCHA,
         },
       });
-      expect(response.statusCode).toEqual(StatusCodes.OK);
-      expect(response.json()).toHaveProperty('t');
+      expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+      expect(response.headers.location).toContain('graasp-mobile-builder://auth?t=');
     });
 
     it('Sign In does send unauthorized error for wrong password', async () => {

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -6,7 +6,11 @@ import fetch from 'node-fetch';
 import { HttpMethod, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../test/app';
-import { JWT_SECRET, REFRESH_TOKEN_JWT_SECRET } from '../../../../utils/config';
+import {
+  GRAASP_MOBILE_BUILDER_PROTOCOL,
+  JWT_SECRET,
+  REFRESH_TOKEN_JWT_SECRET,
+} from '../../../../utils/config';
 import MemberRepository from '../../../member/repository';
 import { ANNA, BOB, LOUISA, expectMember, saveMember } from '../../../member/test/fixtures/members';
 import { MOCK_CAPTCHA } from '../captcha/test/utils';
@@ -218,7 +222,7 @@ describe('Mobile Endpoints', () => {
         },
       });
       expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
-      expect(response.headers.location).toContain('graasp-mobile-builder://auth?t=');
+      expect(response.headers.location).toContain(`${GRAASP_MOBILE_BUILDER_PROTOCOL}://auth?t=`);
     });
 
     it('Sign In does send unauthorized error for wrong password', async () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -75,6 +75,8 @@ export const CORS_ORIGIN_REGEX = process.env.CORS_ORIGIN_REGEX;
 export const CLIENT_HOST = process.env.CLIENT_HOST;
 export const AUTH_CLIENT_HOST = process.env.AUTH_CLIENT_HOST;
 export const EMAIL_LINKS_HOST = process.env.EMAIL_LINKS_HOST || HOST;
+export const GRAASP_MOBILE_BUILDER_PROTOCOL =
+  process.env.GRAASP_MOBILE_BUILDER || 'graasp-mobile-builder';
 
 // export const PG_CONNECTION_URI = process.env.PG_CONNECTION_URI;
 // export const PG_READ_REPLICAS_CONNECTION_URIS =


### PR DESCRIPTION
This PR updates the `/m/login-password` endpoint to use a redirect and send the token as a query-param. 
This is to support the workflow of the mobile login from the webauth.

The deep-link uses the protocol set in the `GRAASP_MOBILE_BUILDER` env variable which defaults to `graasp-mobile-builder`.

We could mirror what is happenning with the web endpoints for the redirect url which can be set as a query param in the request, and the backend uses it if it is in the allowed whitelist. 