### PR TITLE
fix: remove duplicate public tag in migration

### DIFF
--- a/src/migrations/1689666251815-clean-tags.ts
+++ b/src/migrations/1689666251815-clean-tags.ts
@@ -2,6 +2,15 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migrations1689666251815 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // remove duplicate tag public-item that remains alongside a public tag
+    // induced before this migration
+    await queryRunner.query(`
+        DELETE
+        FROM item_tag AS t1
+        WHERE t1.type = 'public-item' AND
+        EXISTS (SELECT 1 FROM item_tag AS t2 WHERE t2.item_path = t1.item_path AND t2.type = 'public');
+      `);
+
     // rename public tag
     await queryRunner.query(`UPDATE "item_tag" 
         SET type = 'public'

--- a/test/migrations/migrations1689666251815/fixture.ts
+++ b/test/migrations/migrations1689666251815/fixture.ts
@@ -1,6 +1,8 @@
 const memberId = '3e901df0-d246-4672-bb01-34269f4c0fed';
 const itemId = '1e901df0-d246-4672-bb01-34269f4c0fed';
 const itemPath = itemId.replace(/-/g, '_');
+const itemId2 = '2e901df0-d246-4672-bb01-34269f4c0fed';
+const itemPath2 = itemId2.replace(/-/g, '_');
 
 const values = {
   member: [
@@ -21,6 +23,20 @@ const values = {
       description: 'my description',
       type: 'folder',
       path: itemPath,
+      extra: {
+        folder: {},
+      },
+      settings: { hasThumbnail: true },
+      creator_id: memberId,
+      created_at: '2023-03-31T13:40:04.571Z',
+      updated_at: '2023-03-31T13:40:04.571Z',
+    },
+    {
+      id: itemId2,
+      name: 'my item',
+      description: 'my description',
+      type: 'folder',
+      path: itemPath2,
       extra: {
         folder: {},
       },
@@ -56,6 +72,21 @@ const values = {
       id: '4f911df1-d246-d672-bb01-34269f4c0fed',
       type: 'hidden',
       item_path: itemPath,
+      creator_id: memberId,
+      created_at: '2021-03-31T12:40:04.571Z',
+    },
+    // item with duplicated tag
+    {
+      id: '5f911df1-d246-d672-bb01-34269f4c0fed',
+      type: 'public',
+      item_path: itemPath2,
+      creator_id: memberId,
+      created_at: '2021-03-31T12:40:04.571Z',
+    },
+    {
+      id: '6f911df1-d246-d672-bb01-34269f4c0fed',
+      type: 'public-item',
+      item_path: itemPath2,
       creator_id: memberId,
       created_at: '2021-03-31T12:40:04.571Z',
     },

--- a/test/migrations/migrations1689666251815/migrations.test.ts
+++ b/test/migrations/migrations1689666251815/migrations.test.ts
@@ -64,5 +64,15 @@ describe('migrations1689666251815', () => {
       buildSelectQuery('item_tag', { id: migrationData.item_tag[3].id }),
     );
     expect(hiddenTag.type).toEqual(ItemTagType.Hidden);
+
+    const [remainingPublicTag] = await app.db.query(
+      buildSelectQuery('item_tag', { id: migrationData.item_tag[4].id }),
+    );
+    expect(remainingPublicTag.type).toEqual(ItemTagType.Public);
+
+    const duplicateTag = await app.db.query(
+      buildSelectQuery('item_tag', { id: migrationData.item_tag[5].id }),
+    );
+    expect(duplicateTag).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Adds a sql query to remove duplicate tags, it happens only in dev (and stage) since we re-added public to some of the items.