### PR TITLE
fix: add creator in recent and liked collections

### DIFF
--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -58,6 +58,7 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
       .from(Item, 'item')
       .innerJoin('item_published', 'pi', 'pi.item_path = item.path')
       .innerJoin('item_membership', 'im', 'im.item_path @> item.path')
+      .innerJoinAndSelect('item.creator', 'member')
       .where('im.member_id = :memberId', { memberId })
       .andWhere('im.permission IN (:...permissions)', {
         permissions: [PermissionLevel.Admin, PermissionLevel.Write],

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -81,6 +81,7 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
   async getRecentItems(limit: number = 10): Promise<Item[]> {
     const publishedInfos = await this.createQueryBuilder('item_published')
       .innerJoinAndSelect('item_published.item', 'item')
+      .innerJoinAndSelect('item.creator', 'member')
       .orderBy('item.createdAt', 'DESC')
       .take(limit)
       .getMany();
@@ -129,9 +130,10 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
   // bug: does not take into account child items
   async getLikedItems(limit: number = 10): Promise<Item[]> {
     const itemPublished = await this.createQueryBuilder('item_published')
-      .leftJoinAndSelect('item_published.item', 'i')
-      .innerJoin('item_like', 'il', 'il.item_id = i.id')
-      .groupBy(['i.id', 'item_published.id'])
+      .innerJoinAndSelect('item_published.item', 'item')
+      .innerJoinAndSelect('item.creator', 'member')
+      .innerJoin('item_like', 'il', 'il.item_id = item.id')
+      .groupBy(['item.id', 'member.id', 'item_published.id'])
       .orderBy('COUNT(il.id)', 'DESC')
       .limit(limit)
       .getMany();


### PR DESCRIPTION
This PR adds the relation "creator" for the recent and liked collections. This way it can be displayed in the library.