### PR TITLE
504 fix app data reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.306.0",
     "@aws-sdk/s3-request-presigner": "3.306.0",
-    "@casl/ability": "6.3.4",
     "@fastify/auth": "4.2.0",
     "@fastify/bearer-auth": "9.0.0",
     "@fastify/cors": "8.2.1",

--- a/src/services/authorization.ts
+++ b/src/services/authorization.ts
@@ -1,5 +1,3 @@
-import { defineAbility } from '@casl/ability';
-
 import { ItemTagType, PermissionLevel, PermissionLevelCompare } from '@graasp/sdk';
 
 import {
@@ -12,13 +10,6 @@ import { Repositories } from '../utils/repositories';
 import { Item } from './item/entities/Item';
 import { ItemMembership } from './itemMembership/entities/ItemMembership';
 import { Actor } from './member/entities/member';
-
-const ownItemAbility = (member) =>
-  defineAbility((can, cannot) => {
-    can(PermissionLevel.Read, 'Item', { member: member.id });
-    can(PermissionLevel.Write, 'Item', { member: member.id });
-    can(PermissionLevel.Admin, 'Item', { member: member.id });
-  });
 
 const permissionMapping = {
   [PermissionLevel.Read]: [PermissionLevel.Read],
@@ -47,10 +38,7 @@ export const validatePermission = async (
     ? await itemMembershipRepository.getInherited(item, member, true)
     : null;
   const highest = inheritedMembership?.permission;
-  const isValid =
-    highest &&
-    (ownItemAbility(member).can(permission, item) ||
-      permissionMapping[highest].includes(permission));
+  const isValid = highest && permissionMapping[highest].includes(permission);
   let tags;
   if (highest === PermissionLevel.Read || permission === PermissionLevel.Read) {
     tags = await itemTagRepository.hasMany(item, [ItemTagType.Public, ItemTagType.Hidden]);

--- a/src/services/item/plugins/app/appAction/repository.ts
+++ b/src/services/item/plugins/app/appAction/repository.ts
@@ -30,12 +30,15 @@ export const AppActionRepository = AppDataSource.getRepository(AppAction).extend
   },
 
   async get(id: string): Promise<AppAction | null> {
-    return this.findOneBy({ id });
+    return this.findOne({ where: { id }, relations: { member: true } });
   },
 
   getForItem(itemId: string, filters: SingleItemGetFilter): Promise<AppAction[]> {
     const { memberId } = filters;
-    return this.findBy({ item: { id: itemId }, member: { id: memberId } });
+    return this.find({
+      where: { item: { id: itemId }, member: { id: memberId } },
+      relations: { member: true },
+    });
   },
 
   async getForManyItems(

--- a/src/services/item/plugins/app/appData/appData.ts
+++ b/src/services/item/plugins/app/appData/appData.ts
@@ -17,7 +17,7 @@ import { Item } from '../../../entities/Item';
 
 export type Filters = {
   visibility?: AppDataVisibility;
-  member?: Partial<Member>;
+  memberId?: Member['id'];
 };
 
 @Entity()

--- a/src/services/item/plugins/app/appData/errors.ts
+++ b/src/services/item/plugins/app/appData/errors.ts
@@ -46,11 +46,24 @@ export class PreventUpdateAppDataFile extends GraaspAppDataError {
   }
 }
 
-export class NotAppDataFile extends GraaspAppDataError {
+export class PreventUpdateOtherAppData extends GraaspAppDataError {
   constructor(data?: unknown) {
     super(
       {
         code: 'GAERR009',
+        statusCode: StatusCodes.FORBIDDEN,
+        message: FAILURE_MESSAGES.CANNOT_MODIFY_OTHER_MEMBERS,
+      },
+      data,
+    );
+  }
+}
+
+export class NotAppDataFile extends GraaspAppDataError {
+  constructor(data?: unknown) {
+    super(
+      {
+        code: 'GAERR010',
         statusCode: StatusCodes.BAD_REQUEST,
         message: 'App data is not a file',
       },

--- a/src/services/item/plugins/app/appData/index.ts
+++ b/src/services/item/plugins/app/appData/index.ts
@@ -3,7 +3,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { IdParam } from '@graasp/sdk';
 
 import { buildRepositories } from '../../../../../utils/repositories';
-import { ManyItemsGetFilter, SingleItemGetFilter } from '../interfaces/request';
+import { ManyItemsGetFilter } from '../interfaces/request';
 import { AppData } from './appData';
 import { InputAppData } from './interfaces/app-data';
 import appDataFilePlugin from './plugins/file';
@@ -73,12 +73,12 @@ const appDataPlugin: FastifyPluginAsync = async (fastify) => {
     );
 
     // get app data
-    fastify.get<{ Params: { itemId: string }; Querystring: SingleItemGetFilter }>(
+    fastify.get<{ Params: { itemId: string } }>(
       '/:itemId/app-data',
       { schema: getForOne },
-      async ({ authTokenSubject: requestDetails, params: { itemId }, query: filters, log }) => {
+      async ({ authTokenSubject: requestDetails, params: { itemId }, log }) => {
         const memberId = requestDetails?.memberId;
-        return appDataService.getForItem(memberId, buildRepositories(), itemId, filters);
+        return appDataService.getForItem(memberId, buildRepositories(), itemId);
       },
     );
 
@@ -86,15 +86,10 @@ const appDataPlugin: FastifyPluginAsync = async (fastify) => {
     fastify.get<{ Querystring: ManyItemsGetFilter }>(
       '/app-data',
       { schema: getForMany },
-      async ({ authTokenSubject: requestDetails, query: filters, log }) => {
+      async ({ authTokenSubject: requestDetails, query, log }) => {
         const memberId = requestDetails?.memberId;
 
-        return appDataService.getForManyItems(
-          memberId,
-          buildRepositories(),
-          filters.itemId,
-          filters,
-        );
+        return appDataService.getForManyItems(memberId, buildRepositories(), query.itemId);
       },
     );
   });

--- a/src/services/item/plugins/app/appData/schemas.ts
+++ b/src/services/item/plugins/app/appData/schemas.ts
@@ -75,14 +75,6 @@ const deleteOne = {
 
 const getForOne = {
   params: { $ref: 'http://graasp.org/apps/#/definitions/itemIdParam' },
-  querystring: {
-    type: 'object',
-    properties: {
-      visibility: { type: 'string', enum: Object.values(AppDataVisibility) },
-      memberId: { $ref: 'http://graasp.org/#/definitions/uuid' },
-    },
-    additionalProperties: false,
-  },
   response: {
     200: {
       type: 'array',
@@ -101,8 +93,6 @@ const getForMany = {
         items: { $ref: 'http://graasp.org/#/definitions/uuid' },
         uniqueItems: true,
       },
-      visibility: { type: 'string', enum: Object.values(AppDataVisibility) },
-      memberId: { $ref: 'http://graasp.org/#/definitions/uuid' },
     },
     additionalProperties: false,
   },

--- a/src/services/item/plugins/app/appData/service.ts
+++ b/src/services/item/plugins/app/appData/service.ts
@@ -6,7 +6,7 @@ import { Repositories } from '../../../../../utils/repositories';
 import { validatePermission } from '../../../../authorization';
 import { ItemMembership } from '../../../../itemMembership/entities/ItemMembership';
 import { Actor } from '../../../../member/entities/member';
-import { AppData, Filters } from './appData';
+import { AppData } from './appData';
 import { AppDataNotAccessible, PreventUpdateOtherAppData } from './errors';
 import { InputAppData } from './interfaces/app-data';
 
@@ -208,12 +208,7 @@ export class AppDataService {
     return appData;
   }
 
-  async getForItem(
-    memberId: string | undefined,
-    repositories: Repositories,
-    itemId: string,
-    filters: Filters,
-  ) {
+  async getForItem(memberId: string | undefined, repositories: Repositories, itemId: string) {
     const { appDataRepository, memberRepository, itemRepository } = repositories;
 
     // get member
@@ -228,8 +223,7 @@ export class AppDataService {
     // posting an app data is allowed to readers
     const membership = await validatePermission(repositories, PermissionLevel.Read, member, item);
 
-    // TODO: get only memberId or with visibility
-    return appDataRepository.getForItem(itemId, { ...filters, memberId }, membership?.permission);
+    return appDataRepository.getForItem(itemId, { memberId }, membership?.permission);
   }
 
   // TODO: check for many items
@@ -237,7 +231,6 @@ export class AppDataService {
     memberId: string | undefined,
     repositories: Repositories,
     itemIds: string[],
-    filters: Filters,
   ) {
     const { appDataRepository, memberRepository, itemRepository } = repositories;
 
@@ -262,7 +255,7 @@ export class AppDataService {
       const membership = await validatePermission(repositories, PermissionLevel.Read, member, item);
       const appData = await appDataRepository.getForItem(
         itemId,
-        { ...filters, memberId },
+        { memberId },
         membership?.permission,
       );
       result.data[itemId] = appData;

--- a/src/services/item/plugins/app/appData/test/index.test.ts
+++ b/src/services/item/plugins/app/appData/test/index.test.ts
@@ -197,11 +197,11 @@ describe('App Data Tests', () => {
     describe('Sign In as reader', () => {
       beforeEach(async () => {
         ({ app, actor } = await build());
-        const creator = await saveMember(BOB);
+        member = await saveMember(BOB);
         ({ item, appData, token } = await setUpForAppData(
           app,
           actor,
-          creator,
+          member,
           PermissionLevel.Read,
         ));
       });
@@ -215,6 +215,22 @@ describe('App Data Tests', () => {
         });
         expect(response.statusCode).toEqual(StatusCodes.OK);
         expectAppData(response.json(), appData);
+      });
+      it("Get others' app data with visibility item", async () => {
+        const otherAppData = await saveAppData({
+          item,
+          creator: member,
+          visibility: AppDataVisibility.Item,
+        });
+        const response = await app.inject({
+          method: HttpMethod.GET,
+          url: `${APP_ITEMS_PREFIX}/${item.id}/app-data`,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        expect(response.statusCode).toEqual(StatusCodes.OK);
+        expect(response.json()).toHaveLength(appData.length + otherAppData.length);
       });
     });
   });

--- a/src/services/item/plugins/app/appData/test/index.test.ts
+++ b/src/services/item/plugins/app/appData/test/index.test.ts
@@ -26,10 +26,12 @@ const saveAppData = async ({
   item,
   creator,
   member,
+  visibility,
 }: {
   item: Item;
   creator: Member;
   member?: Member;
+  visibility?: AppDataVisibility;
 }) => {
   const defaultData = { type: 'some-type', data: { some: 'data' } };
   const s1 = await AppDataRepository.save({
@@ -37,21 +39,21 @@ const saveAppData = async ({
     creator,
     member: member ?? creator,
     ...defaultData,
-    visibility: AppDataVisibility.Item,
+    visibility: visibility ?? AppDataVisibility.Item,
   });
   const s2 = await AppDataRepository.save({
     item,
     creator,
     member: member ?? creator,
     ...defaultData,
-    visibility: AppDataVisibility.Item,
+    visibility: visibility ?? AppDataVisibility.Item,
   });
   const s3 = await AppDataRepository.save({
     item,
     creator,
     member: member ?? creator,
     ...defaultData,
-    visibility: AppDataVisibility.Member,
+    visibility: visibility ?? AppDataVisibility.Member,
   });
   return [s1, s2, s3];
 };
@@ -65,11 +67,15 @@ const setUpForAppData = async (
   setPublic?: boolean,
 ) => {
   const values = await setUp(app, actor, creator, permission, setPublic);
-  const appData = await saveAppData({ item: values.item, creator: creator ?? actor });
+  const appData = await saveAppData({
+    item: values.item,
+    creator: creator ?? actor,
+    member: actor ?? creator,
+  });
   return { ...values, appData };
 };
 
-describe('Apps Data Tests', () => {
+describe('App Data Tests', () => {
   let app;
   let actor;
   let item, token;
@@ -133,8 +139,7 @@ describe('Apps Data Tests', () => {
         expect(response.statusCode).toEqual(StatusCodes.UNAUTHORIZED);
       });
 
-      // TODO: get public data
-      it('Get empty data successfully', async () => {
+      it('Get data with item visibility successfully', async () => {
         ({ app, actor } = await build());
         const member = await saveMember(BOB);
         ({ item, appData, token } = await setUpForAppData(
@@ -144,6 +149,9 @@ describe('Apps Data Tests', () => {
           PermissionLevel.Read,
           true,
         ));
+        const appDataWithItemVisibility = appData.filter(
+          ({ visibility }) => visibility === AppDataVisibility.Item,
+        );
         const response = await app.inject({
           method: HttpMethod.GET,
           url: `${APP_ITEMS_PREFIX}/${item.id}/app-data`,
@@ -152,7 +160,7 @@ describe('Apps Data Tests', () => {
           },
         });
         expect(response.statusCode).toEqual(StatusCodes.OK);
-        expect(response.json()).toHaveLength(0);
+        expect(response.json()).toHaveLength(appDataWithItemVisibility.length);
       });
     });
 
@@ -183,6 +191,30 @@ describe('Apps Data Tests', () => {
           },
         });
         expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+      });
+    });
+
+    describe('Sign In as reader', () => {
+      beforeEach(async () => {
+        ({ app, actor } = await build());
+        const creator = await saveMember(BOB);
+        ({ item, appData, token } = await setUpForAppData(
+          app,
+          actor,
+          creator,
+          PermissionLevel.Read,
+        ));
+      });
+      it('Get app data successfully as reader', async () => {
+        const response = await app.inject({
+          method: HttpMethod.GET,
+          url: `${APP_ITEMS_PREFIX}/${item.id}/app-data`,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        expect(response.statusCode).toEqual(StatusCodes.OK);
+        expectAppData(response.json(), appData);
       });
     });
   });
@@ -365,7 +397,7 @@ describe('Apps Data Tests', () => {
 
       it('Request without member and token throws', async () => {
         const response = await app.inject({
-          method: 'PATCH',
+          method: HttpMethod.PATCH,
           url: `${APP_ITEMS_PREFIX}/${v4()}/app-data/${v4()}`,
           payload: { data: updatedData.data },
         });
@@ -394,43 +426,9 @@ describe('Apps Data Tests', () => {
         expect(response.json()).toMatchObject(updatedData);
       });
 
-      // it('Throw if app data is a file', async () => {
-      //   const fileAppSetting = buildAppSetting({
-      //     data: buildFileItemData({
-      //       name: 'name',
-      //       type: fileItemType,
-      //       filename: 'filename',
-      //       filepath: 'filepath',
-      //       size: 120,
-      //       mimetype: 'mimetype',
-      //     }),
-      //   });
-      //   appSettingService.getById = jest.fn().mockResolvedValue(fileAppSetting);
-      //   appSettingService.update = jest.fn().mockResolvedValue(fileAppSetting);
-
-      //   const updateTask = new UpdateAppSettingTask(
-      //     GRAASP_ACTOR,
-      //     fileAppSetting.id,
-      //     data,
-      //     itemId,
-      //     requestDetails,
-      //     appSettingService,
-      //     itemService,
-      //     itemMembershipService,
-      //     fileItemType,
-      //   );
-
-      //   try {
-      //     await updateTask.run(handler);
-      //   } catch (e) {
-      //     expect(e).toBeInstanceOf(PreventUpdateAppSettingFile);
-      //     expect(appSettingService.update).not.toHaveBeenCalled();
-      //   }
-      // });
-
       it('Invalid item id throws bad request', async () => {
         const response = await app.inject({
-          method: 'PATCH',
+          method: HttpMethod.PATCH,
           url: `${APP_ITEMS_PREFIX}/invalid-id/app-data/${chosenAppData.id}`,
           payload: { data: updatedData.data },
         });
@@ -438,11 +436,81 @@ describe('Apps Data Tests', () => {
       });
       it('Invalid app data id throws bad request', async () => {
         const response = await app.inject({
-          method: 'PATCH',
+          method: HttpMethod.PATCH,
           url: `${APP_ITEMS_PREFIX}/${item.id}/app-data/invalid-id`,
           payload: { data: updatedData.data },
         });
         expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+      });
+
+      // it('Throw if app data is a file', async () => {
+      //   const fileAppData = ({
+      //     type: 'type',
+      //     member:actor,
+      //     data: ({
+      //       name: 'name',
+      //       type: ItemType.S3_FILE,
+      //       filename: 'filename',
+      //       filepath: 'filepath',
+      //       size: 120,
+      //       mimetype: 'mimetype',
+      //     }),
+      //     visibility: AppDataVisibility.Item,
+      //     item: appData[0].item
+      //   });
+      //   await AppDataRepository.save(fileAppData);
+
+      //   const response = await app.inject({
+      //     method: HttpMethod.PATCH,
+      //     url: `${APP_ITEMS_PREFIX}/invalid-id/app-data/${chosenAppData.id}`,
+      //     payload: { data: updatedData.data },
+      //   });
+      //   expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+
+      // });
+    });
+
+    describe('Sign In as reader', () => {
+      beforeEach(async () => {
+        ({ app, actor } = await build());
+        member = await saveMember(BOB);
+        let appData;
+        ({ item, token, appData } = await setUpForAppData(
+          app,
+          actor,
+          member,
+          PermissionLevel.Read,
+        ));
+        chosenAppData = appData[0];
+      });
+
+      it('Can patch own app data', async () => {
+        const [a] = await saveAppData({
+          item,
+          creator: actor,
+        });
+        const response = await app.inject({
+          method: HttpMethod.PATCH,
+          url: `${APP_ITEMS_PREFIX}/${item.id}/app-data/${a.id}`,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          payload: { data: updatedData.data },
+        });
+        expect(response.statusCode).toEqual(StatusCodes.OK);
+        expect(response.json()).toMatchObject(updatedData);
+      });
+
+      it("Cannot patch someone else's app data", async () => {
+        const response = await app.inject({
+          method: HttpMethod.PATCH,
+          url: `${APP_ITEMS_PREFIX}/${item.id}/app-data/${chosenAppData.id}`,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          payload: { data: updatedData.data },
+        });
+        expect(response.statusCode).toEqual(StatusCodes.FORBIDDEN);
       });
     });
   });

--- a/src/services/item/plugins/published/test/index.test.ts
+++ b/src/services/item/plugins/published/test/index.test.ts
@@ -222,9 +222,7 @@ describe('Item Published', () => {
         });
         expect(res.statusCode).toBe(StatusCodes.OK);
         const result = (await res.json().data) as { [key: string]: ItemPublished };
-        console.log(result);
         const items = Object.values(result).map((i) => i.item);
-        console.log(items);
         expectManyItems(items as Item[], [otherParentItem, parentItem]);
       });
       it('Throw if category id is invalid', async () => {

--- a/test/migrations/migrations1689777747530/migrations.test.ts
+++ b/test/migrations/migrations1689777747530/migrations.test.ts
@@ -46,7 +46,6 @@ describe('Migrations1689777747530', () => {
     await new Migrations1689777747530().up(app.db.createQueryRunner());
 
     const [item] = await app.db.query(buildSelectQuery('item', { id: migrationData.item[0].id }));
-    console.log(item);
     expect(JSON.parse(item.settings)).toEqual(migrationData.item[0].settings);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,15 +2236,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@casl/ability@npm:6.3.4":
-  version: 6.3.4
-  resolution: "@casl/ability@npm:6.3.4"
-  dependencies:
-    "@ucast/mongo2js": ^1.3.0
-  checksum: 8d3e1977efb790153fb8e58a91b4d61902cb6383bba18ca79367713dafc1599c0f2af8cd74f1cc44373a61c8b878d9dcf476af4e6878496cb56dbcda7b8c9c85
-  languageName: node
-  linkType: hard
-
 "@commitlint/cli@npm:17.6.6, @commitlint/cli@npm:^17.6.3":
   version: 17.6.6
   resolution: "@commitlint/cli@npm:17.6.6"
@@ -4305,42 +4296,6 @@ __metadata:
     "@typescript-eslint/types": 5.60.1
     eslint-visitor-keys: ^3.3.0
   checksum: 137f6a6f8efb398969087147b59f99f7d0deed044d89d7efce3631bb90bc32e3a13a5cee6a65e1c9830862c5c4402ac1a9b2c9e31fe46d1716602af2813bffae
-  languageName: node
-  linkType: hard
-
-"@ucast/core@npm:^1.0.0, @ucast/core@npm:^1.4.1, @ucast/core@npm:^1.6.1":
-  version: 1.10.2
-  resolution: "@ucast/core@npm:1.10.2"
-  checksum: 5081194db186bdc4ce774c42d097452b6dcf7329996bea3c8b06a47ff1c45f1d2a997c1cd02c967187b46de5172f0e052a8a2163a4116237ace30d50c61faff8
-  languageName: node
-  linkType: hard
-
-"@ucast/js@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "@ucast/js@npm:3.0.3"
-  dependencies:
-    "@ucast/core": ^1.0.0
-  checksum: 579d2e3bdb6643afe11403bd74b432327dc85cd19d4b5017db608696868605e6b299aa7e510463affcedb9a42779d2867936f92bd6ec252e9a0132c6385127bd
-  languageName: node
-  linkType: hard
-
-"@ucast/mongo2js@npm:^1.3.0":
-  version: 1.3.4
-  resolution: "@ucast/mongo2js@npm:1.3.4"
-  dependencies:
-    "@ucast/core": ^1.6.1
-    "@ucast/js": ^3.0.0
-    "@ucast/mongo": ^2.4.0
-  checksum: db2b97b85e8ed6f1103566a69e01ab547365406473550a03f2f0f47d58b9dbb1962d8af094327a9a990a9a3854ac86afa1d0cd0408a5adacb3b66e5131d5d285
-  languageName: node
-  linkType: hard
-
-"@ucast/mongo@npm:^2.4.0":
-  version: 2.4.3
-  resolution: "@ucast/mongo@npm:2.4.3"
-  dependencies:
-    "@ucast/core": ^1.4.1
-  checksum: 1817d7dc525eda48c911960a89cf9c820afbf12b3ab0610d856fc66fb27e02d2dd4a773a33ca0a328d6fcc0c9ccb2f1fe093e59546ebb57af093b8f8d2a70a4d
   languageName: node
   linkType: hard
 
@@ -7068,7 +7023,6 @@ __metadata:
   dependencies:
     "@aws-sdk/client-s3": 3.306.0
     "@aws-sdk/s3-request-presigner": 3.306.0
-    "@casl/ability": 6.3.4
     "@commitlint/cli": 17.6.6
     "@commitlint/config-conventional": 17.6.6
     "@fastify/auth": 4.2.0


### PR DESCRIPTION
The every app data couldn't be fetch by the reader: we missed the `member` visibility app data.

- I've moved the permission logic to the repository. I've noticed `casl` abilities don't work so I've removed it from `appData` and `authorization` 
- For simplicity, and because we don't use it, I've removed the possibility to add filters for `GET /appData`
- `PATCH /appData` was also missing a throw check.  
- added member to `GET /appAction`

close #504 