### PR TITLE
fix: allow multiple extra and settings fields on update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           yarn
           yarn build
+      
+      - name: yarn check
+        run:
+          yarn check
 
       - name: apply migrations on empty database
         env:

--- a/src/migrations/1689777747530-default-item-settings.ts
+++ b/src/migrations/1689777747530-default-item-settings.ts
@@ -1,14 +1,13 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migrations1689777747530 implements MigrationInterface {
-    name = 'Migrations1689777747530';
+  name = 'Migrations1689777747530';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "item" ALTER COLUMN "settings" DROP DEFAULT`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "item" ALTER COLUMN "settings" DROP DEFAULT`);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "item" ALTER COLUMN "settings" SET DEFAULT '{}'`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "item" ALTER COLUMN "settings" SET DEFAULT '{}'`);
+  }
 }

--- a/src/services/item/plugins/document/document.test.ts
+++ b/src/services/item/plugins/document/document.test.ts
@@ -1,6 +1,6 @@
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 
-import { DocumentItemExtraProperties, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../test/app';
 import { MULTIPLE_ITEMS_LOADING_TIME } from '../../../../../test/constants';
@@ -157,10 +157,13 @@ describe('Document Item tests', () => {
           extra: {
             [ItemType.DOCUMENT]: {
               content: 'new value',
+              // test that flavor can be updated
+              flavor: 'info',
             },
           },
           settings: {
             hasThumbnail: true,
+            isCollapsible: true,
           },
         };
 
@@ -175,7 +178,11 @@ describe('Document Item tests', () => {
           ...item,
           ...payload,
           extra: { ...item.extra, ...payload.extra },
+          settings: { ...item.settings, ...payload.settings },
         });
+
+        expect(response.json().settings).toEqual(payload.settings);
+
         expect(response.statusCode).toBe(StatusCodes.OK);
       });
 

--- a/src/services/item/plugins/document/schemas.ts
+++ b/src/services/item/plugins/document/schemas.ts
@@ -1,6 +1,6 @@
 import S from 'fluent-json-schema';
 
-import { ItemType } from '@graasp/sdk';
+import { DocumentItemExtraFlavor, ItemType } from '@graasp/sdk';
 
 export const updateSchema = S.object()
   // TODO: .additionalProperties(false) in schemas don't seem to work properly and
@@ -11,6 +11,7 @@ export const updateSchema = S.object()
     S.object()
       // .additionalProperties(false)
       .prop('content', S.string())
+      .prop('flavor', S.string().enum(Object.values(DocumentItemExtraFlavor)))
       .required(['content']),
   )
   .required([ItemType.DOCUMENT]);

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -273,20 +273,16 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
 
     // only allow for item type specific changes in extra
     const extraForType = extraChanges?.[item.type];
-    if (data.extra && extraForType) {
-      if (Object.keys(extraForType).length === 1) {
-        data.extra[item.type] = Object.assign({}, item.extra[item.type], extraForType);
-      } else {
-        delete data.extra;
-      }
+    if (extraForType && Object.keys(extraChanges).length === 1) {
+      extraChanges[item.type] = Object.assign({}, item.extra[item.type], extraForType);
+    } else {
+      delete data.extra;
     }
 
     if (settingsChanges) {
-      if (Object.keys(settingsChanges).length === 1) {
-        data.settings = Object.assign({}, item.settings, settingsChanges);
-      } else {
-        delete data.settings;
-      }
+      data.settings = Object.assign({}, item.settings, settingsChanges);
+    } else {
+      delete data.settings;
     }
 
     // TODO: check schema

--- a/test/migrations/migrations1689666251815/migrations.test.ts
+++ b/test/migrations/migrations1689666251815/migrations.test.ts
@@ -11,7 +11,7 @@ import { up } from './fixture';
 // mock datasource
 jest.mock('../../../src/plugins/datasource');
 
-describe('migrations1689666251815', () => { 
+describe('migrations1689666251815', () => {
   let app;
 
   beforeEach(async () => {

--- a/test/migrations/migrations1689777747530/fixture.ts
+++ b/test/migrations/migrations1689777747530/fixture.ts
@@ -28,7 +28,7 @@ const values = {
       creator_id: memberId,
       created_at: '2023-03-31T13:40:04.571Z',
       updated_at: '2023-03-31T13:40:04.571Z',
-    }
+    },
   ],
 };
 

--- a/test/migrations/migrations1689777747530/migrations.test.ts
+++ b/test/migrations/migrations1689777747530/migrations.test.ts
@@ -45,11 +45,8 @@ describe('Migrations1689777747530', () => {
 
     await new Migrations1689777747530().up(app.db.createQueryRunner());
 
-    const [item] = await app.db.query(
-      buildSelectQuery('item', { id: migrationData.item[0].id }),
-    );
+    const [item] = await app.db.query(buildSelectQuery('item', { id: migrationData.item[0].id }));
     console.log(item);
     expect(JSON.parse(item.settings)).toEqual(migrationData.item[0].settings);
-
   });
 });


### PR DESCRIPTION
Closes #500 

- Adds test to check if multiple extra and settings fields can be modified
- Fix logic that checks which extra and settings can be updated
- Adds yarn check (for prettier) in CI