### PR TITLE
Broadcast apps data change events with websockets

### DIFF
--- a/src/services/item/plugins/app/appAction/index.ts
+++ b/src/services/item/plugins/app/appAction/index.ts
@@ -21,7 +21,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.register(async function (fastify) {
     fastify.addHook('preHandler', fastify.verifyBearerAuth as preHandlerHookHandler);
 
-    if (WEBSOCKETS_PLUGIN) fastify.register(appActionsWsHooks, { appActionService });
+    if (WEBSOCKETS_PLUGIN) {
+      fastify.register(appActionsWsHooks, { appActionService });
+    }
 
     // create app action
     fastify.post<{ Params: { itemId: string }; Body: Partial<InputAppAction> }>(

--- a/src/services/item/plugins/app/appAction/index.ts
+++ b/src/services/item/plugins/app/appAction/index.ts
@@ -1,8 +1,10 @@
 import { preHandlerHookHandler } from 'fastify';
 import { FastifyPluginAsync } from 'fastify';
 
+import { WEBSOCKETS_PLUGIN } from '../../../../../utils/config';
 import { buildRepositories } from '../../../../../utils/repositories';
 import { ManyItemsGetFilter, SingleItemGetFilter } from '../interfaces/request';
+import { appActionsWsHooks } from '../ws/hooks';
 import { InputAppAction } from './interfaces/app-action';
 import common, { create, getForMany, getForOne } from './schemas';
 import { AppActionService } from './service';
@@ -18,6 +20,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // endpoints accessible to third parties with Bearer token
   fastify.register(async function (fastify) {
     fastify.addHook('preHandler', fastify.verifyBearerAuth as preHandlerHookHandler);
+
+    if (WEBSOCKETS_PLUGIN) fastify.register(appActionsWsHooks, { appActionService });
 
     // create app action
     fastify.post<{ Params: { itemId: string }; Body: Partial<InputAppAction> }>(

--- a/src/services/item/plugins/app/appAction/index.ts
+++ b/src/services/item/plugins/app/appAction/index.ts
@@ -1,7 +1,6 @@
 import { preHandlerHookHandler } from 'fastify';
 import { FastifyPluginAsync } from 'fastify';
 
-import { WEBSOCKETS_PLUGIN } from '../../../../../utils/config';
 import { buildRepositories } from '../../../../../utils/repositories';
 import { ManyItemsGetFilter, SingleItemGetFilter } from '../interfaces/request';
 import { appActionsWsHooks } from '../ws/hooks';
@@ -21,9 +20,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.register(async function (fastify) {
     fastify.addHook('preHandler', fastify.verifyBearerAuth as preHandlerHookHandler);
 
-    if (WEBSOCKETS_PLUGIN) {
-      fastify.register(appActionsWsHooks, { appActionService });
-    }
+    fastify.register(appActionsWsHooks, { appActionService });
 
     // create app action
     fastify.post<{ Params: { itemId: string }; Body: Partial<InputAppAction> }>(

--- a/src/services/item/plugins/app/appAction/service.ts
+++ b/src/services/item/plugins/app/appAction/service.ts
@@ -27,13 +27,12 @@ export class AppActionService {
 
     await this.hooks.runPreHooks('post', member, repositories, { appAction: body, itemId });
 
-    return appActionRepository.post(itemId, actorId, body).then(async (newAppAction) => {
-      await this.hooks.runPostHooks('post', member, repositories, {
-        appAction: newAppAction,
-        itemId,
-      });
-      return newAppAction;
+    const appAction = await appActionRepository.post(itemId, actorId, body);
+    await this.hooks.runPostHooks('post', member, repositories, {
+      appAction,
+      itemId,
     });
+    return appAction;
   }
 
   async getForItem(

--- a/src/services/item/plugins/app/appAction/service.ts
+++ b/src/services/item/plugins/app/appAction/service.ts
@@ -22,7 +22,7 @@ export class AppActionService {
     // check item exists? let post fail?
     const item = await itemRepository.get(itemId);
 
-    // posting an app data is allowed to readers
+    // posting an app action is allowed to readers
     await validatePermission(repositories, PermissionLevel.Read, member, item);
 
     await this.hooks.runPreHooks('post', member, repositories, { appAction: body, itemId });
@@ -81,7 +81,7 @@ export class AppActionService {
     // check item exists
     const item = await itemRepository.get(itemIds[0]);
 
-    // posting an app data is allowed to readers
+    // posting an app action is allowed to readers
     const membership = await validatePermission(repositories, PermissionLevel.Read, member, item);
     const permission = membership?.permission;
     let { memberId: fMemberId } = filters;

--- a/src/services/item/plugins/app/appData/index.ts
+++ b/src/services/item/plugins/app/appData/index.ts
@@ -3,7 +3,6 @@ import { FastifyPluginAsync } from 'fastify';
 
 import { IdParam } from '@graasp/sdk';
 
-import { WEBSOCKETS_PLUGIN } from '../../../../../utils/config';
 import { buildRepositories } from '../../../../../utils/repositories';
 import { ManyItemsGetFilter } from '../interfaces/request';
 import { appDataWsHooks } from '../ws/hooks';
@@ -27,9 +26,7 @@ const appDataPlugin: FastifyPluginAsync = async (fastify) => {
     // origins from the publishers table an build a rule with that.
 
     fastify.register(appDataFilePlugin, { appDataService });
-    if (WEBSOCKETS_PLUGIN) {
-      fastify.register(appDataWsHooks, { appDataService });
-    }
+    fastify.register(appDataWsHooks, { appDataService });
 
     // create app data
     fastify.post<{ Params: { itemId: string }; Body: Partial<InputAppData> }>(

--- a/src/services/item/plugins/app/appData/index.ts
+++ b/src/services/item/plugins/app/appData/index.ts
@@ -1,9 +1,12 @@
+import fastifyView from '@fastify/view';
 import { FastifyPluginAsync } from 'fastify';
 
 import { IdParam } from '@graasp/sdk';
 
+import { WEBSOCKETS_PLUGIN } from '../../../../../utils/config';
 import { buildRepositories } from '../../../../../utils/repositories';
 import { ManyItemsGetFilter } from '../interfaces/request';
+import { appDataWsHooks } from '../ws/hooks';
 import { AppData } from './appData';
 import { InputAppData } from './interfaces/app-data';
 import appDataFilePlugin from './plugins/file';
@@ -24,6 +27,7 @@ const appDataPlugin: FastifyPluginAsync = async (fastify) => {
     // origins from the publishers table an build a rule with that.
 
     fastify.register(appDataFilePlugin, { appDataService });
+    if (WEBSOCKETS_PLUGIN) fastify.register(appDataWsHooks, { appDataService });
 
     // create app data
     fastify.post<{ Params: { itemId: string }; Body: Partial<InputAppData> }>(

--- a/src/services/item/plugins/app/appData/index.ts
+++ b/src/services/item/plugins/app/appData/index.ts
@@ -27,7 +27,9 @@ const appDataPlugin: FastifyPluginAsync = async (fastify) => {
     // origins from the publishers table an build a rule with that.
 
     fastify.register(appDataFilePlugin, { appDataService });
-    if (WEBSOCKETS_PLUGIN) fastify.register(appDataWsHooks, { appDataService });
+    if (WEBSOCKETS_PLUGIN) {
+      fastify.register(appDataWsHooks, { appDataService });
+    }
 
     // create app data
     fastify.post<{ Params: { itemId: string }; Body: Partial<InputAppData> }>(

--- a/src/services/item/plugins/app/appData/plugins/file/index.ts
+++ b/src/services/item/plugins/app/appData/plugins/file/index.ts
@@ -54,14 +54,23 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
   });
 
   // register post delete handler to remove the file object after item delete
-  const deleteHook = async (actor: Member, repositories: Repositories, appData: AppData) => {
-    await appDataFileService.deleteOne(actor, repositories, appData);
+  const deleteHook = async (
+    actor: Member,
+    repositories: Repositories,
+    args: { appData: AppData },
+  ) => {
+    await appDataFileService.deleteOne(actor, repositories, args.appData);
   };
   appDataService.hooks.setPostHook('delete', deleteHook);
 
   // prevent patch on app data file
-  const patchPreHook = async (actor: Actor, repositories: Repositories, appData: AppData) => {
-    if (appData.data[fileService.type]) {
+  const patchPreHook = async (
+    actor: Actor,
+    repositories: Repositories,
+    args: { appData: Partial<AppData> },
+  ) => {
+    const { appData } = args;
+    if (appData?.data && appData.data[fileService.type]) {
       throw new PreventUpdateAppDataFile(appData);
     }
   };

--- a/src/services/item/plugins/app/appData/service.ts
+++ b/src/services/item/plugins/app/appData/service.ts
@@ -76,8 +76,6 @@ export class AppDataService {
     }
     const member = await memberRepository.get(actorId);
 
-    await this.hooks.runPreHooks('post', member, repositories, { appData: body, itemId });
-
     // check item exists? let post fail?
     const item = await itemRepository.get(itemId);
 
@@ -100,6 +98,8 @@ export class AppDataService {
         itemId,
       },
     );
+
+    await this.hooks.runPreHooks('post', member, repositories, { appData: body, itemId });
 
     const appData = await appDataRepository.post(itemId, actorId, completeData);
     await this.hooks.runPostHooks('post', member, repositories, { appData, itemId });
@@ -171,8 +171,6 @@ export class AppDataService {
     }
     const member = await memberRepository.get(memberId);
 
-    await this.hooks.runPreHooks('delete', member, repositories, { appDataId, itemId });
-
     // check item exists? let post fail?
     const item = await itemRepository.get(itemId);
 
@@ -194,6 +192,8 @@ export class AppDataService {
       PermissionLevel.Admin,
       inheritedMembership,
     );
+
+    await this.hooks.runPreHooks('delete', member, repositories, { appDataId, itemId });
 
     const result = await appDataRepository.deleteOne(itemId, appDataId);
 

--- a/src/services/item/plugins/app/appSetting/index.ts
+++ b/src/services/item/plugins/app/appSetting/index.ts
@@ -2,9 +2,11 @@ import { FastifyPluginAsync, preHandlerHookHandler } from 'fastify';
 
 import { IdParam, ItemType } from '@graasp/sdk';
 
+import { WEBSOCKETS_PLUGIN } from '../../../../../utils/config';
 import { Repositories, buildRepositories } from '../../../../../utils/repositories';
 import { Actor } from '../../../../member/entities/member';
 import { Item } from '../../../entities/Item';
+import { appSettingsWsHooks } from '../ws/hooks';
 import { AppSetting } from './appSettings';
 import { InputAppSetting } from './interfaces/app-setting';
 import appSettingFilePlugin from './plugins/file';
@@ -21,6 +23,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.addSchema(common);
 
   const appSettingService = new AppSettingService(itemService);
+
+  if (WEBSOCKETS_PLUGIN) fastify.register(appSettingsWsHooks, { appSettingService });
 
   // copy app settings and related files on item copy
   const hook = async (

--- a/src/services/item/plugins/app/appSetting/index.ts
+++ b/src/services/item/plugins/app/appSetting/index.ts
@@ -24,7 +24,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
   const appSettingService = new AppSettingService(itemService);
 
-  if (WEBSOCKETS_PLUGIN) fastify.register(appSettingsWsHooks, { appSettingService });
+  if (WEBSOCKETS_PLUGIN) {
+    fastify.register(appSettingsWsHooks, { appSettingService });
+  }
 
   // copy app settings and related files on item copy
   const hook = async (

--- a/src/services/item/plugins/app/appSetting/index.ts
+++ b/src/services/item/plugins/app/appSetting/index.ts
@@ -2,7 +2,6 @@ import { FastifyPluginAsync, preHandlerHookHandler } from 'fastify';
 
 import { IdParam, ItemType } from '@graasp/sdk';
 
-import { WEBSOCKETS_PLUGIN } from '../../../../../utils/config';
 import { Repositories, buildRepositories } from '../../../../../utils/repositories';
 import { Actor } from '../../../../member/entities/member';
 import { Item } from '../../../entities/Item';
@@ -24,9 +23,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
   const appSettingService = new AppSettingService(itemService);
 
-  if (WEBSOCKETS_PLUGIN) {
-    fastify.register(appSettingsWsHooks, { appSettingService });
-  }
+  fastify.register(appSettingsWsHooks, { appSettingService });
 
   // copy app settings and related files on item copy
   const hook = async (

--- a/src/services/item/plugins/app/appSetting/plugins/file/index.ts
+++ b/src/services/item/plugins/app/appSetting/plugins/file/index.ts
@@ -82,9 +82,15 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
   appSettingService.hooks.setPostHook('copyMany', hook);
 
   // prevent patch on app setting file
-  const patchPreHook = async (actor: Actor, repositories: Repositories, { appSetting }) => {
-    if (appSetting.data[fileService.type]) {
-      throw new PreventUpdateAppSettingFile(appSetting);
+  const patchPreHook = async (
+    actor: Actor,
+    repositories: Repositories,
+    { appSetting }: { appSetting: Partial<AppSetting> },
+  ) => {
+    if (appSetting?.data) {
+      if (appSetting.data[fileService.type]) {
+        throw new PreventUpdateAppSettingFile(appSetting);
+      }
     }
   };
   appSettingService.hooks.setPreHook('patch', patchPreHook);

--- a/src/services/item/plugins/app/appSetting/plugins/file/index.ts
+++ b/src/services/item/plugins/app/appSetting/plugins/file/index.ts
@@ -53,7 +53,11 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
   });
 
   // register post delete handler to remove the file object after item delete
-  const deleteHook = async (actor: Actor, repositories: Repositories, { appSetting, itemId }) => {
+  const deleteHook = async (
+    actor: Actor,
+    repositories: Repositories,
+    { appSetting, itemId }: { appSetting: AppSetting; itemId: string },
+  ) => {
     await appSettingFileService.deleteOne(actor, repositories, appSetting);
   };
   appSettingService.hooks.setPostHook('delete', deleteHook);
@@ -62,7 +66,11 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
   const hook = async (
     actor: Member,
     repositories: Repositories,
-    { appSettings, originalItemId, copyItemId },
+    {
+      appSettings,
+      originalItemId,
+      copyItemId,
+    }: { appSettings: AppSetting[]; originalItemId: string; copyItemId: string },
   ) => {
     // copy file only if content is a file
     const isFileSetting = (a: AppSetting) => a.data[fileService.type];

--- a/src/services/item/plugins/app/appSetting/service.ts
+++ b/src/services/item/plugins/app/appSetting/service.ts
@@ -47,10 +47,10 @@ export class AppSettingService {
     }
     const member = await memberRepository.get(memberId);
 
-    await this.hooks.runPreHooks('post', member, repositories, { appSetting: body, itemId });
-
     // posting an app setting is allowed to admin only
     await this.itemService.get(member, repositories, itemId, PermissionLevel.Admin);
+
+    await this.hooks.runPreHooks('post', member, repositories, { appSetting: body, itemId });
 
     const appSetting = await appSettingRepository.post(itemId, memberId, body);
     await this.hooks.runPostHooks('post', member, repositories, {
@@ -103,10 +103,10 @@ export class AppSettingService {
     }
     const member = await memberRepository.get(memberId);
 
-    await this.hooks.runPreHooks('delete', member, repositories, { appSettingId, itemId });
-
     // delete an app data is allowed to admins
     await this.itemService.get(member, repositories, itemId, PermissionLevel.Admin);
+
+    await this.hooks.runPreHooks('delete', member, repositories, { appSettingId, itemId });
 
     const appSetting = await appSettingRepository.get(appSettingId);
 

--- a/src/services/item/plugins/app/appSetting/service.ts
+++ b/src/services/item/plugins/app/appSetting/service.ts
@@ -106,9 +106,9 @@ export class AppSettingService {
     // delete an app data is allowed to admins
     await this.itemService.get(member, repositories, itemId, PermissionLevel.Admin);
 
-    await this.hooks.runPreHooks('delete', member, repositories, { appSettingId, itemId });
-
     const appSetting = await appSettingRepository.get(appSettingId);
+
+    await this.hooks.runPreHooks('delete', member, repositories, { appSettingId, itemId });
 
     const result = await appSettingRepository.deleteOne(itemId, appSettingId);
 

--- a/src/services/item/plugins/app/ws/events.ts
+++ b/src/services/item/plugins/app/ws/events.ts
@@ -6,6 +6,7 @@ import { AppAction, AppSetting } from '@graasp/sdk';
 import { AppData } from '../appData/appData';
 
 // changes on app entities
+// TODO: Move these topics to graasp/sdk
 export const appDataTopic = 'app-data';
 export const appActionsTopic = 'app-actions';
 export const appSettingsTopic = 'app-settings';

--- a/src/services/item/plugins/app/ws/events.ts
+++ b/src/services/item/plugins/app/ws/events.ts
@@ -1,0 +1,86 @@
+/**
+ * App websocket events are registered under these topics
+ */
+import { AppAction, AppSetting } from '@graasp/sdk';
+
+import { AppData } from '../appData/appData';
+
+// changes on app entities
+export const appDataTopic = 'app-data';
+export const appActionsTopic = 'app-actions';
+export const appSettingsTopic = 'app-settings';
+// changes on items of given user
+// export const memberItemsTopic = 'item/member';
+
+type AppOperations = 'post' | 'patch' | 'delete';
+
+/**
+ * All websocket events for app will have this shape
+ */
+interface AppEvent {
+  kind: string;
+  op: AppOperations;
+}
+
+/**
+ * Events that affect an app data
+ */
+interface AppDataEvent extends AppEvent {
+  kind: 'app-data';
+  appData: AppData;
+}
+
+/**
+ * Factory of AppDataEvent
+ * @param op operation of the event
+ * @param appData value of the appData for this event
+ * @returns instance of app data event
+ */
+export const AppDataEvent = (op: AppDataEvent['op'], appData: AppData): AppDataEvent => ({
+  kind: 'app-data',
+  op,
+  appData,
+});
+
+/**
+ * Events that affect an app action
+ */
+interface AppActionEvent extends AppEvent {
+  kind: 'app-actions';
+  appAction: AppAction;
+}
+
+/**
+ * Factory of AppActionEvent
+ * @param op operation of the event
+ * @param appAction value of the app action for this event
+ * @returns instance of app action event
+ */
+export const AppActionEvent = (op: AppActionEvent['op'], appAction: AppAction): AppActionEvent => ({
+  kind: 'app-actions',
+  op,
+  appAction,
+});
+
+/**
+ * Events that affect an app setting
+ */
+interface AppSettingEvent extends AppEvent {
+  kind: 'app-settings';
+  appSetting: AppSetting;
+}
+
+/**
+ * Factory of AppSettingEvent
+ * @param op operation of the event
+ * @param appAction value of the app setting for this event
+ * @returns instance of app setting event
+ */
+export const AppSettingEvent = (
+  op: AppSettingEvent['op'],
+  appSetting: AppSetting,
+): AppSettingEvent => ({
+  kind: 'app-settings',
+  op,
+  appSetting,
+});

--- a/src/services/item/plugins/app/ws/events.ts
+++ b/src/services/item/plugins/app/ws/events.ts
@@ -9,8 +9,6 @@ import { AppData } from '../appData/appData';
 export const appDataTopic = 'app-data';
 export const appActionsTopic = 'app-actions';
 export const appSettingsTopic = 'app-settings';
-// changes on items of given user
-// export const memberItemsTopic = 'item/member';
 
 type AppOperations = 'post' | 'patch' | 'delete';
 

--- a/src/services/item/plugins/app/ws/events.ts
+++ b/src/services/item/plugins/app/ws/events.ts
@@ -16,7 +16,7 @@ type AppOperations = 'post' | 'patch' | 'delete';
  * All websocket events for app will have this shape
  */
 interface AppEvent {
-  kind: string;
+  kind: typeof appDataTopic | typeof appActionsTopic | typeof appSettingsTopic;
   op: AppOperations;
 }
 
@@ -24,7 +24,7 @@ interface AppEvent {
  * Events that affect an app data
  */
 interface AppDataEvent extends AppEvent {
-  kind: 'app-data';
+  kind: typeof appDataTopic;
   appData: AppData;
 }
 
@@ -35,7 +35,7 @@ interface AppDataEvent extends AppEvent {
  * @returns instance of app data event
  */
 export const AppDataEvent = (op: AppDataEvent['op'], appData: AppData): AppDataEvent => ({
-  kind: 'app-data',
+  kind: appDataTopic,
   op,
   appData,
 });
@@ -44,7 +44,7 @@ export const AppDataEvent = (op: AppDataEvent['op'], appData: AppData): AppDataE
  * Events that affect an app action
  */
 interface AppActionEvent extends AppEvent {
-  kind: 'app-actions';
+  kind: typeof appActionsTopic;
   appAction: AppAction;
 }
 
@@ -55,7 +55,7 @@ interface AppActionEvent extends AppEvent {
  * @returns instance of app action event
  */
 export const AppActionEvent = (op: AppActionEvent['op'], appAction: AppAction): AppActionEvent => ({
-  kind: 'app-actions',
+  kind: appActionsTopic,
   op,
   appAction,
 });
@@ -64,7 +64,7 @@ export const AppActionEvent = (op: AppActionEvent['op'], appAction: AppAction): 
  * Events that affect an app setting
  */
 interface AppSettingEvent extends AppEvent {
-  kind: 'app-settings';
+  kind: typeof appSettingsTopic;
   appSetting: AppSetting;
 }
 
@@ -78,7 +78,7 @@ export const AppSettingEvent = (
   op: AppSettingEvent['op'],
   appSetting: AppSetting,
 ): AppSettingEvent => ({
-  kind: 'app-settings',
+  kind: appSettingsTopic,
   op,
   appSetting,
 });

--- a/src/services/item/plugins/app/ws/hooks.ts
+++ b/src/services/item/plugins/app/ws/hooks.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 
-import { AppDataVisibility, ItemType, PermissionLevel, Websocket } from '@graasp/sdk';
+import { AppDataVisibility, PermissionLevel } from '@graasp/sdk';
 
 import { buildRepositories } from '../../../../../utils/repositories';
 import { validatePermission } from '../../../../authorization';
@@ -17,6 +17,7 @@ import {
   appDataTopic,
   appSettingsTopic,
 } from './events';
+import { checkItemIsApp } from './utils';
 
 /**
  * helper to register app data topic
@@ -31,9 +32,7 @@ function registerAppDataTopic(
     const repositories = buildRepositories();
     const item = await itemService.get(member, repositories, id);
     await validatePermission(repositories, PermissionLevel.Read, member, item);
-    if (item.type !== ItemType.APP) {
-      throw new Websocket.AccessDeniedError('item is not app');
-    }
+    checkItemIsApp(item);
   });
 
   // on post app data, notify apps of new app data
@@ -69,9 +68,7 @@ function registerAppActionTopic(
     const repositories = buildRepositories();
     const item = await itemService.get(member, repositories, id);
     await validatePermission(repositories, PermissionLevel.Admin, member, item);
-    if (item.type !== ItemType.APP) {
-      throw new Websocket.AccessDeniedError('item is not app');
-    }
+    checkItemIsApp(item);
   });
 
   // on post app action, notify apps of new app action
@@ -98,9 +95,7 @@ function registerAppSettingsTopic(
     const repositories = buildRepositories();
     const item = await itemService.get(member, repositories, id);
     await validatePermission(repositories, PermissionLevel.Read, member, item);
-    if (item.type !== ItemType.APP) {
-      throw new Websocket.AccessDeniedError('item is not app');
-    }
+    checkItemIsApp(item);
   });
 
   // on post app data, notify apps of new app data

--- a/src/services/item/plugins/app/ws/hooks.ts
+++ b/src/services/item/plugins/app/ws/hooks.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 
-import { ItemType, Websocket } from '@graasp/sdk';
+import { AppDataVisibility, ItemType, Websocket } from '@graasp/sdk';
 
 import { buildRepositories } from '../../../../../utils/repositories';
 import { WebsocketService } from '../../../../websockets/ws-service';
@@ -35,19 +35,19 @@ function registerAppDataTopic(
 
   // on post app data, notify apps of new app data
   appDataService.hooks.setPostHook('post', async (member, repositories, { appData, itemId }) => {
-    if (itemId !== undefined) {
+    if (itemId !== undefined && appData.visibility === AppDataVisibility.Item) {
       websockets.publish(appDataTopic, itemId, AppDataEvent('post', appData));
     }
   });
 
   appDataService.hooks.setPostHook('patch', async (member, repositories, { appData, itemId }) => {
-    if (itemId !== undefined) {
+    if (itemId !== undefined && appData.visibility === AppDataVisibility.Item) {
       websockets.publish(appDataTopic, itemId, AppDataEvent('patch', appData));
     }
   });
 
   appDataService.hooks.setPostHook('delete', async (member, repositories, { appData, itemId }) => {
-    if (itemId !== undefined) {
+    if (itemId !== undefined && appData.visibility === AppDataVisibility.Item) {
       websockets.publish(appDataTopic, itemId, AppDataEvent('delete', appData));
     }
   });

--- a/src/services/item/plugins/app/ws/hooks.ts
+++ b/src/services/item/plugins/app/ws/hooks.ts
@@ -1,8 +1,9 @@
 import { FastifyPluginAsync } from 'fastify';
 
-import { AppDataVisibility, ItemType, Websocket } from '@graasp/sdk';
+import { AppDataVisibility, ItemType, PermissionLevel, Websocket } from '@graasp/sdk';
 
 import { buildRepositories } from '../../../../../utils/repositories';
+import { validatePermission } from '../../../../authorization';
 import { WebsocketService } from '../../../../websockets/ws-service';
 import { ItemService } from '../../../service';
 import { AppActionService } from '../appAction/service';
@@ -27,7 +28,9 @@ function registerAppDataTopic(
 ) {
   websockets.register(appDataTopic, async (req) => {
     const { channel: id, member } = req;
-    const item = await itemService.get(member, buildRepositories(), id);
+    const repositories = buildRepositories();
+    const item = await itemService.get(member, repositories, id);
+    await validatePermission(repositories, PermissionLevel.Read, member, item);
     if (item.type !== ItemType.APP) {
       throw new Websocket.AccessDeniedError('item is not app');
     }
@@ -63,7 +66,9 @@ function registerAppActionTopic(
 ) {
   websockets.register(appActionsTopic, async (req) => {
     const { channel: id, member } = req;
-    const item = await itemService.get(member, buildRepositories(), id);
+    const repositories = buildRepositories();
+    const item = await itemService.get(member, repositories, id);
+    await validatePermission(repositories, PermissionLevel.Admin, member, item);
     if (item.type !== ItemType.APP) {
       throw new Websocket.AccessDeniedError('item is not app');
     }
@@ -90,7 +95,9 @@ function registerAppSettingsTopic(
 ) {
   websockets.register(appSettingsTopic, async (req) => {
     const { channel: id, member } = req;
-    const item = await itemService.get(member, buildRepositories(), id);
+    const repositories = buildRepositories();
+    const item = await itemService.get(member, repositories, id);
+    await validatePermission(repositories, PermissionLevel.Read, member, item);
     if (item.type !== ItemType.APP) {
       throw new Websocket.AccessDeniedError('item is not app');
     }

--- a/src/services/item/plugins/app/ws/hooks.ts
+++ b/src/services/item/plugins/app/ws/hooks.ts
@@ -1,0 +1,174 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { ItemType, Websocket } from '@graasp/sdk';
+
+import { buildRepositories } from '../../../../../utils/repositories';
+import { WebsocketService } from '../../../../websockets/ws-service';
+import { ItemService } from '../../../service';
+import { AppActionService } from '../appAction/service';
+import { AppDataService } from '../appData/service';
+import { AppSettingService } from '../appSetting/service';
+import {
+  AppActionEvent,
+  AppDataEvent,
+  AppSettingEvent,
+  appActionsTopic,
+  appDataTopic,
+  appSettingsTopic,
+} from './events';
+
+/**
+ * helper to register app data topic
+ */
+function registerAppDataTopic(
+  websockets: WebsocketService,
+  appDataService: AppDataService,
+  itemService: ItemService,
+) {
+  websockets.register(appDataTopic, async (req) => {
+    const { channel: id, member } = req;
+    const item = await itemService.get(member, buildRepositories(), id);
+    if (item.type !== ItemType.APP) {
+      throw new Websocket.AccessDeniedError('item is not app');
+    }
+  });
+
+  // on post app data, notify apps of new app data
+  appDataService.hooks.setPostHook('post', async (member, repositories, { appData, itemId }) => {
+    if (itemId !== undefined) {
+      websockets.publish(appDataTopic, itemId, AppDataEvent('post', appData));
+    }
+  });
+
+  appDataService.hooks.setPostHook('patch', async (member, repositories, { appData, itemId }) => {
+    if (itemId !== undefined) {
+      websockets.publish(appDataTopic, itemId, AppDataEvent('patch', appData));
+    }
+  });
+
+  appDataService.hooks.setPostHook('delete', async (member, repositories, { appData, itemId }) => {
+    if (itemId !== undefined) {
+      websockets.publish(appDataTopic, itemId, AppDataEvent('delete', appData));
+    }
+  });
+}
+
+/**
+ * helper to register app action topic
+ */
+function registerAppActionTopic(
+  websockets: WebsocketService,
+  appActionService: AppActionService,
+  itemService: ItemService,
+) {
+  websockets.register(appActionsTopic, async (req) => {
+    const { channel: id, member } = req;
+    const item = await itemService.get(member, buildRepositories(), id);
+    if (item.type !== ItemType.APP) {
+      throw new Websocket.AccessDeniedError('item is not app');
+    }
+  });
+
+  // on post app action, notify apps of new app action
+  appActionService.hooks.setPostHook(
+    'post',
+    async (member, repositories, { appAction, itemId }) => {
+      if (itemId !== undefined) {
+        websockets.publish(appActionsTopic, itemId, AppActionEvent('post', appAction));
+      }
+    },
+  );
+}
+
+/**
+ * helper to register app setting topic
+ */
+function registerAppSettingsTopic(
+  websockets: WebsocketService,
+  appSettingService: AppSettingService,
+  itemService: ItemService,
+) {
+  websockets.register(appSettingsTopic, async (req) => {
+    const { channel: id, member } = req;
+    const item = await itemService.get(member, buildRepositories(), id);
+    if (item.type !== ItemType.APP) {
+      throw new Websocket.AccessDeniedError('item is not app');
+    }
+  });
+
+  // on post app data, notify apps of new app data
+  appSettingService.hooks.setPostHook(
+    'post',
+    async (member, repositories, { appSetting, itemId }) => {
+      if (itemId !== undefined) {
+        websockets.publish(appSettingsTopic, itemId, AppSettingEvent('post', appSetting));
+      }
+    },
+  );
+
+  appSettingService.hooks.setPostHook(
+    'patch',
+    async (member, repositories, { appSetting, itemId }) => {
+      if (itemId !== undefined) {
+        websockets.publish(appSettingsTopic, itemId, AppSettingEvent('patch', appSetting));
+      }
+    },
+  );
+
+  appSettingService.hooks.setPostHook(
+    'delete',
+    async (member, repositories, { appSetting, itemId }) => {
+      if (itemId !== undefined) {
+        websockets.publish(appSettingsTopic, itemId, AppSettingEvent('delete', appSetting));
+      }
+    },
+  );
+}
+
+interface GraaspPluginAppDataWsHooksOptions {
+  appDataService: AppDataService;
+}
+
+/**
+ * Registers real-time websocket events for the app data service
+ */
+export const appDataWsHooks: FastifyPluginAsync<GraaspPluginAppDataWsHooksOptions> = async (
+  fastify,
+  options,
+) => {
+  const { websockets, items } = fastify;
+  const { appDataService } = options;
+  registerAppDataTopic(websockets, appDataService, items.service);
+};
+
+interface GraaspPluginAppActionsWsHooksOptions {
+  appActionService: AppActionService;
+}
+
+/**
+ * Registers real-time websocket events for the app action service
+ */
+export const appActionsWsHooks: FastifyPluginAsync<GraaspPluginAppActionsWsHooksOptions> = async (
+  fastify,
+  options,
+) => {
+  const { websockets, items } = fastify;
+  const { appActionService } = options;
+  registerAppActionTopic(websockets, appActionService, items.service);
+};
+
+interface GraaspPluginAppSettingsWsHooksOptions {
+  appSettingService: AppSettingService;
+}
+
+/**
+ * Registers real-time websocket events for the app setting service
+ */
+export const appSettingsWsHooks: FastifyPluginAsync<GraaspPluginAppSettingsWsHooksOptions> = async (
+  fastify,
+  options,
+) => {
+  const { websockets, items } = fastify;
+  const { appSettingService } = options;
+  registerAppSettingsTopic(websockets, appSettingService, items.service);
+};

--- a/src/services/item/plugins/app/ws/utils.ts
+++ b/src/services/item/plugins/app/ws/utils.ts
@@ -1,0 +1,9 @@
+import { ItemType, Websocket } from '@graasp/sdk';
+
+import { Item } from '../../../entities/Item';
+
+export const checkItemIsApp = (item: Item): void => {
+  if (item.type !== ItemType.APP) {
+    throw new Websocket.AccessDeniedError('item is not app');
+  }
+};


### PR DESCRIPTION
Use websockets to send events (post, patch, delete) on app data, actions and settings.

Refer to https://github.com/graasp/graasp-apps-query-client/pull/142 for details.

## Backend features

- [x] Implement plugin providing hooks for signaling updates with websockets.
- [x] Use WS plugin for signaling changes in app data
    - [x] 🧪 -> 📋 Test `post`
    - [x] 🧪 -> 📋 Test `patch`
    - [x] 🧪 -> 📋 Test `delete`
- [x] Use WS plugin for signaling changes in app settings
    - [x] 🧪 -> 📋 Test `post`
    - [x] 🧪 -> 📋 Test `patch`
    - [x] 🧪 -> 📋 Test `delete`
- [x] Use WS plugin for signaling changes in app actions
    - [x] 🧪 -> 📋 Test `post`
