### PR TITLE
fix: copied item should not inherit public tag from original

### DIFF
--- a/src/services/item/plugins/itemLike/itemLike.ts
+++ b/src/services/item/plugins/itemLike/itemLike.ts
@@ -9,14 +9,12 @@ import {
 } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { ItemLike as GraaspItemLike } from '@graasp/sdk';
-
 import { Item } from '../../../item/entities/Item';
 import { Member } from '../../../member/entities/member';
 
 @Entity()
 @Unique('id', ['creator', 'item'])
-export class ItemLike extends BaseEntity implements GraaspItemLike {
+export class ItemLike extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string = v4();
 

--- a/src/services/item/plugins/itemTag/index.ts
+++ b/src/services/item/plugins/itemTag/index.ts
@@ -32,7 +32,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // copy tags alongside item
   // TODO: AUTOMATIZE WITH OWN CLASS
   const hook = async (actor, repositories, { original, copy }: { original: Item; copy: Item }) => {
-    await repositories.itemTagRepository.copyAll(actor, original, copy);
+    await repositories.itemTagRepository.copyAll(actor, original, copy, [ItemTagType.Public]);
   };
   items.service.hooks.setPostHook('copy', hook);
 

--- a/src/services/item/plugins/itemTag/repository.ts
+++ b/src/services/item/plugins/itemTag/repository.ts
@@ -201,12 +201,17 @@ export const ItemTagRepository = AppDataSource.getRepository(ItemTag).extend({
    * @param  {Member} creator
    * @param  {Item} original
    * @param  {Item} copy
+   * @param  {object} excludeTypes
    */
-  async copyAll(creator: Member, original: Item, copy: Item) {
+  async copyAll(creator: Member, original: Item, copy: Item, excludeTypes?: ItemTagType[]) {
     // delete from parent only
     const itemTags = await this.getForItem(original);
     if (itemTags) {
-      await this.insert(itemTags.map(({ type }) => ({ item: copy, type, creator })));
+      await this.insert(
+        itemTags
+          .filter((tag) => !excludeTypes?.includes(tag.type))
+          .map(({ type }) => ({ item: copy, type, creator })),
+      );
     }
   },
 });


### PR DESCRIPTION
In this PR:
- fix: copied item does not inherit public tag from original
- fix: remove dependency on ItemLike in Entity
