### PR TITLE
fix: add creator in getPublishedItemsByCategories

### DIFF
--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -106,7 +106,8 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
       .from(Item, 'item')
       .innerJoin('item_published', 'ip', 'ip.item_path = item.path')
       .innerJoin('item_category', 'ic', 'ic.item_path @> item.path')
-      .groupBy('item.id');
+      .innerJoinAndSelect('item.creator', 'member')
+      .groupBy(['item.id', 'member.id']);
 
     categoryIds.forEach((idString, idx) => {
       // split categories


### PR DESCRIPTION
This PR fixes a missing call related to the issue fixed in #502 
The creator was not joined and thus was missing from the response.