### PR TITLE
fix: null creator in ws hooks

### DIFF
--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -180,24 +180,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  // TODO: REMOVE - deleting an item could delete a big tree and take time -> better to use many
-  // delete item
-  // fastify.delete<{ Params: IdParam }>(
-  //   '/:id',
-  //   { schema: deleteOne },
-  //   async ({ member, params: { id }, log }, reply) => {
-  //     db.transaction((manager) => {
-  //       // TODO: implement queue
-  //       return itemService.delete(member, buildRepositories(manager), id);
-  //     }).catch((e) => {
-  //       // TODO: return feedback in queue
-  //       console.error(e);
-  //     });
-  //     reply.status(StatusCodes.ACCEPTED);
-  //     return id;
-  //   },
-  // );
-
   fastify.delete<{ Querystring: IdsParams }>(
     '/',
     {
@@ -224,24 +206,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  // TODO: REMOVE - moving an item could delete a big tree and take time -> better to use many
-  // move item
-  // fastify.post<{ Params: IdParam; Body: ParentIdParam }>(
-  //   '/:id/move',
-  //   { schema: moveOne },
-  //   async ({ member, params: { id }, body: { parentId }, log }, reply) => {
-  //     // TODO: implement queue
-  //     db.transaction(async (manager) => {
-  //       return itemService.move(member, buildRepositories(manager), id, parentId);
-  //     }).catch((e) => {
-  //       // TODO: return feedback in queue
-  //       console.error(e);
-  //     });
-  //     reply.status(StatusCodes.ACCEPTED);
-  //     return id;
-  //   },
-  // );
-
   fastify.post<{ Querystring: IdsParams; Body: ParentIdParam }>(
     '/move',
     { schema: moveMany, preHandler: fastify.verifyAuthentication },
@@ -265,26 +229,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       return ids;
     },
   );
-
-  // TODO: REMOVE - copying an item could copy a big tree and take time -> better to use many
-  // copy item
-  // fastify.post<{ Params: IdParam; Body: { parentId: string } }>(
-  //   '/:id/copy',
-  //   { schema: copyOne },
-  //   async ({ member, params: { id }, body: { parentId }, log }, reply) => {
-  //     // TODO: implement queue
-  //     db.transaction(async (manager) => {
-  //       return itemService.copy(member, buildRepositories(manager), id, {
-  //         parentId,
-  //       });
-  //     }).catch((e) => {
-  //       // TODO: return feedback in queue
-  //       console.error(e);
-  //     });
-  //     reply.status(StatusCodes.ACCEPTED);
-  //     return id;
-  //   },
-  // );
 
   fastify.post<{
     Querystring: IdsParams;

--- a/src/services/item/entities/Item.ts
+++ b/src/services/item/entities/Item.ts
@@ -71,7 +71,7 @@ export class Item extends BaseEntity implements GraaspItem {
     onDelete: 'SET NULL',
   })
   @JoinColumn({ name: 'creator_id' })
-  creator: Member;
+  creator: Member | null;
 
   @CreateDateColumn({ name: 'created_at', nullable: false })
   createdAt: Date;

--- a/src/services/item/plugins/app/appSetting/plugins/file/index.ts
+++ b/src/services/item/plugins/app/appSetting/plugins/file/index.ts
@@ -23,8 +23,6 @@ export interface GraaspPluginFileOptions {
   appSettingService: AppSettingService;
 }
 
-export const DEFAULT_MAX_STORAGE = 1024 * 1024 * 1024 * 1; // 1GB;
-
 const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, options) => {
   const { maxFileSize = DEFAULT_MAX_FILE_SIZE, appSettingService } = options;
 

--- a/src/services/item/plugins/importExport/test/index.test.ts
+++ b/src/services/item/plugins/importExport/test/index.test.ts
@@ -109,7 +109,7 @@ describe('Member routes tests', () => {
           }
           expect(item.type).toEqual(file.type);
           expect(item.description).toContain(file.description);
-          expect(item.creator.id).toEqual(actor.id);
+          expect(item.creator!.id).toEqual(actor.id);
 
           if (item.type === ItemType.S3_FILE) {
             expect((item.extra[ItemType.S3_FILE] as { name: string }).name).toEqual(

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -31,7 +31,7 @@ export class ItemService {
     update: { pre: { item: Item }; post: { item: Item } };
     delete: { pre: { item: Item }; post: { item: Item } };
     copy: { pre: { original: Item }; post: { original: Item; copy: Item } };
-    move: { pre: { source: Item }; post: { source: Item; destination: Item } };
+    move: { pre: { source: Item; destination: Item }; post: { source: Item; destination: Item } };
   }>();
 
   async post(
@@ -321,7 +321,21 @@ export class ItemService {
       await itemRepository.checkHierarchyDepth(parentItem, levelsToFarthestChild);
     }
 
+    // post hook
+    // question: invoque on all items?
+    await this.hooks.runPreHooks('move', actor, repositories, {
+      source: item,
+      destination: parentItem,
+    });
+
     await this._move(actor, repositories, item, parentItem);
+
+    // post hook
+    // question: invoque on all items?
+    await this.hooks.runPostHooks('move', actor, repositories, {
+      source: item,
+      destination: parentItem,
+    });
 
     // TODO: optimize
     return itemRepository.get(itemId);

--- a/src/services/itemMembership/entities/ItemMembership.ts
+++ b/src/services/itemMembership/entities/ItemMembership.ts
@@ -34,7 +34,7 @@ export class ItemMembership extends BaseEntity implements GraaspItemMembership {
     onDelete: 'SET NULL',
   })
   @JoinColumn({ name: 'creator_id' })
-  creator: Member;
+  creator: Member | null;
 
   @Index()
   @ManyToOne(() => Member, (member) => member.id, {

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -104,11 +104,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
     query.where(
       new Brackets((qb) => {
         items.forEach(({ path }, idx) => {
-          // if (idx === 0) {
-          //   qb.where(`item.path @> :path_${path}`, { [`path_${path}`]: path });
-          // } else {
-          qb.orWhere(`item.path @> :path_${path}`, { [`path_${path}`]: path });
-          // }
+          qb.orWhere(`item.path @> :path_${idx}`, { [`path_${idx}`]: path });
         });
       }),
     );

--- a/src/services/itemMembership/test/fixtures/memberships.ts
+++ b/src/services/itemMembership/test/fixtures/memberships.ts
@@ -34,7 +34,7 @@ export const saveItemAndMembership = async (options: {
 export const expectMembership = (
   newMembership:
     | undefined
-    | (Pick<ItemMembership, 'permission' | 'item' | 'member'> & { creator?: Member }),
+    | (Pick<ItemMembership, 'permission' | 'item' | 'member'> & { creator?: Member | null }),
   correctMembership: undefined | Pick<ItemMembership, 'permission' | 'item' | 'member' | 'creator'>,
   creator?: Member,
 ) => {
@@ -46,7 +46,7 @@ export const expectMembership = (
   expect(newMembership.permission).toEqual(correctMembership.permission);
   expect(newMembership.item.id).toContain(correctMembership.item.id);
   if (newMembership.creator && creator) {
-    expect(newMembership.creator.id).toEqual(correctMembership.creator.id);
+    expect(newMembership.creator.id).toEqual(correctMembership!.creator!.id);
   }
 
   expect(newMembership.member.id).toEqual(correctMembership.member.id);

--- a/src/services/itemMembership/ws/hooks.ts
+++ b/src/services/itemMembership/ws/hooks.ts
@@ -25,7 +25,7 @@ export function registerItemMembershipWsHooks(
   // - notify member of new shared item IF creator != member
   // - notify item itself of new membership
   itemMembershipService.hooks.setPostHook('create', async (member, repositories, membership) => {
-    if (membership.member.id !== membership.item.creator.id) {
+    if (membership.member.id !== membership.item?.creator?.id) {
       websockets.publish(
         memberItemsTopic,
         membership.member.id,


### PR DESCRIPTION
This error happens for the following case:

- A > B > C with a membership for each of them for another member Bob
- Removing B, by cascade all the memberships of B and C get deleted
- Since A still have a membership, it triggers the websockets "shared items"
- But since C is get via `getDescendants` which does not return the creator, it fails

In this PR:
- I've added `null` to item's creator and itemMembership's creator
- This highlighted the ws hooks that needed more check on these fields
- added a test
- added postHook for move 

close #526 