### PR TITLE
fix: throw for undefined member id in token

### DIFF
--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,55 +1,34 @@
-import jwt, { Secret, SignOptions, VerifyOptions } from 'jsonwebtoken';
-import { promisify } from 'util';
-
 import fastifyAuth from '@fastify/auth';
 import fastifyBearerAuth from '@fastify/bearer-auth';
 import fastifyCors from '@fastify/cors';
 import fastifySecureSession from '@fastify/secure-session';
-import { FastifyPluginAsync, FastifyRequest } from 'fastify';
-
-import { MAIL } from '@graasp/translations';
+import { FastifyPluginAsync } from 'fastify';
 
 import {
-  AUTH_TOKEN_EXPIRATION_IN_MINUTES,
-  AUTH_TOKEN_JWT_SECRET,
-  JWT_SECRET,
-  LOGIN_TOKEN_EXPIRATION_IN_MINUTES,
   PROD,
-  PUBLIC_URL,
   RECAPTCHA_SECRET_ACCESS_KEY,
-  REFRESH_TOKEN_EXPIRATION_IN_MINUTES,
-  REFRESH_TOKEN_JWT_SECRET,
-  REGISTER_TOKEN_EXPIRATION_IN_MINUTES,
   SECURE_SESSION_SECRET_KEY,
   STAGING,
   TOKEN_BASED_AUTH,
 } from '../../utils/config';
-import { InvalidSession, OrphanSession } from '../../utils/errors';
-import { Member } from '../member/entities/member';
-import MemberRepository from '../member/repository';
 import { AuthPluginOptions } from './interfaces/auth';
 import captchaPlugin from './plugins/captcha';
 import magicLinkController from './plugins/magicLink';
 import mobileController from './plugins/mobile';
 import passwordController from './plugins/password';
-import { getRedirectionUrl } from './utils';
-
-const promisifiedJwtVerify = promisify<
-  string,
-  Secret,
-  VerifyOptions,
-  { sub: string; challenge?: string }
->(jwt.verify);
-const promisifiedJwtSign = promisify<
-  { sub: string; challenge?: string },
-  Secret,
-  SignOptions,
-  string
->(jwt.sign);
+import { AuthService } from './service';
+import {
+  fetchMemberInSession,
+  generateAuthTokensPair,
+  verifyMemberInAuthToken,
+  verifyMemberInSession,
+} from './utils';
 
 const plugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, options) => {
   const { sessionCookieDomain: domain } = options;
   const { log, mailer } = fastify;
+
+  const authService = new AuthService(mailer, log);
 
   // cookie based auth
   await fastify.register(fastifySecureSession, {
@@ -60,67 +39,9 @@ const plugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, options) =
   // captcha
   await fastify.register(captchaPlugin, { secretAccessKey: RECAPTCHA_SECRET_ACCESS_KEY });
 
-  async function verifyMemberInSession(request: FastifyRequest) {
-    const { session } = request;
-    const memberId = session.get('member');
-
-    if (!memberId) {
-      throw new InvalidSession();
-    }
-
-    // TODO: do we really need to get the user from the DB? (or actor: { id } is enough?)
-    // maybe when the groups are implemented it will be necessary.
-    const member = await MemberRepository.findOneBy({ id: memberId });
-
-    if (!member) {
-      session.delete();
-      throw new OrphanSession();
-    }
-
-    request.member = member;
-  }
-
-  // set member in request from session if exist
-  // used to get authenticated member without throwing
-  async function fetchMemberInSession(request: FastifyRequest) {
-    const { session } = request;
-    const memberId = session.get('member');
-
-    if (!memberId) return;
-
-    // TODO: do we really need to get the user from the DB? (or actor: { id } is enough?)
-    // maybe when the groups are implemented it will be necessary.
-    request.member = (await MemberRepository.findOneBy({ id: memberId })) ?? undefined;
-  }
-
   fastify.decorate('fetchMemberInSession', fetchMemberInSession);
 
   fastify.decorate('validateSession', verifyMemberInSession);
-
-  // for token based auth
-  async function verifyMemberInAuthToken(jwtToken: string, request: FastifyRequest) {
-    try {
-      const { routerPath } = request;
-      const refreshing = '/m/auth/refresh' === routerPath;
-      const secret = refreshing ? REFRESH_TOKEN_JWT_SECRET : AUTH_TOKEN_JWT_SECRET;
-
-      const { sub: memberId } = await promisifiedJwtVerify(jwtToken, secret, {});
-
-      if (refreshing) {
-        request.memberId = memberId;
-      } else {
-        const member = await MemberRepository.findOneBy({ id: memberId });
-        if (!member) return false;
-        request.member = member;
-      }
-
-      return true;
-    } catch (error) {
-      const { log } = request;
-      log.warn('Invalid auth token');
-      return false;
-    }
-  }
 
   await fastify.register(fastifyAuth);
   await fastify.register(fastifyBearerAuth, {
@@ -130,7 +51,7 @@ const plugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, options) =
   });
 
   if (!fastify.verifyBearerAuth) {
-    throw new Error();
+    throw new Error('verifyBearerAuth is not defined');
   }
 
   fastify.decorate(
@@ -153,88 +74,12 @@ const plugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, options) =
 
   fastify.decorate('verifyAuthentication', verifyAuthentication);
 
-  const getLangFromMember = (member, defaultLang?): string => member.extra?.lang ?? defaultLang;
-
-  async function generateAuthTokensPair(
-    memberId: string,
-  ): Promise<{ authToken: string; refreshToken: string }> {
-    const [authToken, refreshToken] = await Promise.all([
-      promisifiedJwtSign({ sub: memberId }, AUTH_TOKEN_JWT_SECRET, {
-        expiresIn: `${AUTH_TOKEN_EXPIRATION_IN_MINUTES}m`,
-      }),
-      promisifiedJwtSign({ sub: memberId }, REFRESH_TOKEN_JWT_SECRET, {
-        expiresIn: `${REFRESH_TOKEN_EXPIRATION_IN_MINUTES}m`,
-      }),
-    ]);
-    return { authToken, refreshToken };
-  }
   fastify.decorate('generateAuthTokensPair', generateAuthTokensPair);
 
-  async function generateRegisterLinkAndEmailIt(
-    member,
-    options: { challenge?; url?: string } = {},
-  ) {
-    const { challenge, url } = options;
+  // TODO: decorate auth service and use it instead of decorating function
+  fastify.decorate('generateRegisterLinkAndEmailIt', authService.generateRegisterLinkAndEmailIt);
 
-    // generate token with member info and expiration
-    const token = await promisifiedJwtSign({ sub: member.id, challenge }, JWT_SECRET, {
-      expiresIn: `${REGISTER_TOKEN_EXPIRATION_IN_MINUTES}m`,
-    });
-
-    const redirectionUrl = getRedirectionUrl(url);
-
-    const linkPath = challenge ? '/m/deep-link' : '/auth';
-    const link = new URL(`${linkPath}?t=${token}&url=${redirectionUrl}`, PUBLIC_URL).toString();
-
-    const lang = getLangFromMember(member);
-
-    const translated = mailer.translate(lang);
-    const subject = translated(MAIL.SIGN_UP_TITLE);
-    const html = `
-    ${mailer.buildText(translated(MAIL.GREETINGS))}
-    ${mailer.buildText(translated(MAIL.SIGN_UP_TEXT))}
-    ${mailer.buildButton(link, translated(MAIL.SIGN_UP_BUTTON_TEXT))}
-    ${mailer.buildText(translated(MAIL.SIGN_UP_NOT_REQUESTED))}`;
-
-    // don't wait for mailer's response; log error and link if it fails.
-    mailer
-      .sendEmail(subject, member.email, link, html)
-      .catch((err) => log.warn(err, `mailer failed. link: ${link}`));
-  }
-
-  fastify.decorate('generateRegisterLinkAndEmailIt', generateRegisterLinkAndEmailIt);
-
-  async function generateLoginLinkAndEmailIt(
-    member: Member,
-    options: { challenge?: string; lang?: string; url?: string } = {},
-  ) {
-    const { challenge, lang, url } = options;
-
-    // generate token with member info and expiration
-    const token = await promisifiedJwtSign({ sub: member.id, challenge }, JWT_SECRET, {
-      expiresIn: `${LOGIN_TOKEN_EXPIRATION_IN_MINUTES}m`,
-    });
-
-    const redirectionUrl = getRedirectionUrl(url);
-    const linkPath = challenge ? '/m/deep-link' : '/auth';
-    const link = new URL(`${linkPath}?t=${token}&url=${redirectionUrl}`, PUBLIC_URL).toString();
-
-    const memberLang = getLangFromMember(member) ?? lang;
-
-    const translated = mailer.translate(memberLang);
-    const subject = translated(MAIL.SIGN_IN_TITLE);
-    const html = `
-    ${mailer.buildText(translated(MAIL.SIGN_IN_TEXT))}
-    ${mailer.buildButton(link, translated(MAIL.SIGN_IN_BUTTON_TEXT))}
-    ${mailer.buildText(translated(MAIL.SIGN_IN_NOT_REQUESTED))}`;
-
-    // don't wait for mailer's response; log error and link if it fails.
-    fastify.mailer
-      .sendEmail(subject, member.email, link, html)
-      .catch((err) => log.warn(err, `mailer failed. link: ${link}`));
-  }
-
-  fastify.decorate('generateLoginLinkAndEmailIt', generateLoginLinkAndEmailIt);
+  fastify.decorate('generateLoginLinkAndEmailIt', authService.generateLoginLinkAndEmailIt);
 
   fastify.register(async function (fastify) {
     // add CORS support

--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -209,7 +209,9 @@ describe('Auth routes tests', () => {
         url: `/auth?t=${t}`,
       });
       expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
+      expect(response.headers.location).not.toContain('error');
     });
+
     it('Fail if token contains undefined memberId', async () => {
       const t = jwt.sign({ id: undefined }, JWT_SECRET);
       const response = await app.inject({
@@ -217,7 +219,11 @@ describe('Auth routes tests', () => {
         url: `/auth?t=${t}`,
       });
       expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
+      const url = new URL('/', AUTH_CLIENT_HOST);
+      url.searchParams.set('error', 'true');
+      expect(response.headers.location).toEqual(url.toString());
     });
+
     it('Fail if token contains unknown member id', async () => {
       const t = jwt.sign({ id: v4() }, JWT_SECRET);
       const response = await app.inject({
@@ -225,6 +231,9 @@ describe('Auth routes tests', () => {
         url: `/auth?t=${t}`,
       });
       expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
+      const url = new URL('/', AUTH_CLIENT_HOST);
+      url.searchParams.set('error', 'true');
+      expect(response.headers.location).toEqual(url.toString());
     });
 
     it('Fail to authenticate if token is invalid', async () => {

--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -1,6 +1,7 @@
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import jwt from 'jsonwebtoken';
 import fetch from 'node-fetch';
+import { v4 } from 'uuid';
 
 import { HttpMethod, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
 
@@ -203,6 +204,22 @@ describe('Auth routes tests', () => {
     it('Authenticate successfully', async () => {
       const member = await saveMember(BOB);
       const t = jwt.sign({ id: member.id }, JWT_SECRET);
+      const response = await app.inject({
+        method: HttpMethod.GET,
+        url: `/auth?t=${t}`,
+      });
+      expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
+    });
+    it('Fail if token contains undefined memberId', async () => {
+      const t = jwt.sign({ id: undefined }, JWT_SECRET);
+      const response = await app.inject({
+        method: HttpMethod.GET,
+        url: `/auth?t=${t}`,
+      });
+      expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
+    });
+    it('Fail if token contains unknown member id', async () => {
+      const t = jwt.sign({ id: v4() }, JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.GET,
         url: `/auth?t=${t}`,

--- a/src/services/auth/plugins/magicLink/service.ts
+++ b/src/services/auth/plugins/magicLink/service.ts
@@ -9,7 +9,6 @@ import { DEFAULT_LANG } from '@graasp/sdk';
 import { JWT_SECRET } from '../../../../utils/config';
 import {
   InvalidToken,
-  MemberNotFound,
   MemberNotSignedUp,
   TokenExpired,
   UnexpectedError,
@@ -53,13 +52,9 @@ export class MagicLinkService {
   async auth(actor: Actor, repositories: Repositories, token: string) {
     try {
       // verify and extract member info
-      const result = await promisifiedJwtVerify(token, JWT_SECRET, {});
-
+      const result = (await promisifiedJwtVerify(token, JWT_SECRET, {})) as jwt.JwtPayload;
       // pre test the user existence to avoid providing a key
-      const member = await repositories.memberRepository.get(result.sub);
-      if (!member) {
-        throw new MemberNotFound(result.sub);
-      }
+      await repositories.memberRepository.get(result.id);
 
       return result;
     } catch (error) {

--- a/src/services/auth/plugins/magicLink/service.ts
+++ b/src/services/auth/plugins/magicLink/service.ts
@@ -52,8 +52,10 @@ export class MagicLinkService {
   async auth(actor: Actor, repositories: Repositories, token: string) {
     try {
       // verify and extract member info
+      // cast because return value is unknown
       const result = (await promisifiedJwtVerify(token, JWT_SECRET, {})) as jwt.JwtPayload;
       // pre test the user existence to avoid providing a key
+      // throw if no member is found
       await repositories.memberRepository.get(result.id);
 
       return result;

--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -108,10 +108,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.get(
-    '/auth/refresh', // there's a hardcoded reference to this path above: "verifyMemberInAuthToken()"
-    { preHandler: fastify.verifyBearerAuth },
-    async ({ memberId }) => generateAuthTokensPair(memberId),
+  fastify.get('/auth/refresh', { preHandler: fastify.verifyBearerAuth }, async ({ memberId }) =>
+    generateAuthTokensPair(memberId),
   );
 
   fastify.get<{ Querystring: { t: string } }>(

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -289,10 +289,6 @@ describe('Mobile Endpoints', () => {
       const verifier = 'verifier';
       // compute challenge from verifier
       const challenge = crypto.createHash('sha256').update(verifier).digest('hex');
-      // mock verification
-      jest.spyOn(jwt, 'verify').mockImplementation(() => {
-        return { sub: member.id, challenge };
-      });
 
       const t = jwt.sign({ sub: member.id, challenge }, JWT_SECRET);
 
@@ -311,7 +307,7 @@ describe('Mobile Endpoints', () => {
 
     it('Fail to authenticate if verifier and challenge do not match', async () => {
       const member = await saveMember(BOB);
-      const t = jwt.sign({ id: member.id }, JWT_SECRET);
+      const t = jwt.sign({ sub: member.id }, JWT_SECRET);
       const verifier = 'verifier';
       const response = await app.inject({
         method: HttpMethod.POST,
@@ -345,7 +341,6 @@ describe('Mobile Endpoints', () => {
       const challenge = crypto.createHash('sha256').update(verifier).digest('hex');
       // mock verification
       jest.spyOn(jwt, 'verify').mockImplementation(() => {
-        console.log('w9oifje');
         return { sub: undefined, challenge };
       });
 
@@ -368,7 +363,7 @@ describe('Mobile Endpoints', () => {
   describe('GET /m/auth/refresh', () => {
     it('Refresh tokens successfully', async () => {
       const member = await saveMember(BOB);
-      const t = jwt.sign({ memberId: member.id }, REFRESH_TOKEN_JWT_SECRET);
+      const t = jwt.sign({ sub: member.id }, REFRESH_TOKEN_JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.GET,
         url: '/m/auth/refresh',
@@ -381,7 +376,7 @@ describe('Mobile Endpoints', () => {
       expect(response.json()).toHaveProperty('authToken');
     });
     it('Throw if token contains undefined member id', async () => {
-      const t = jwt.sign({ id: undefined }, REFRESH_TOKEN_JWT_SECRET);
+      const t = jwt.sign({ sub: undefined }, REFRESH_TOKEN_JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.GET,
         url: '/m/auth/refresh',
@@ -393,7 +388,7 @@ describe('Mobile Endpoints', () => {
     });
     it('Fail if token is invalid', async () => {
       const member = await saveMember(BOB);
-      const t = jwt.sign({ id: member.id }, 'REFRESH_TOKEN_JWT_SECRET');
+      const t = jwt.sign({ sub: member.id }, 'REFRESH_TOKEN_JWT_SECRET');
       const response = await app.inject({
         method: HttpMethod.GET,
         url: '/m/auth/refresh',
@@ -408,7 +403,7 @@ describe('Mobile Endpoints', () => {
   describe('GET /m/deep-link', () => {
     it('Refresh tokens successfully', async () => {
       const member = await saveMember(BOB);
-      const t = jwt.sign({ id: member.id }, JWT_SECRET);
+      const t = jwt.sign({ sub: member.id }, JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.GET,
         url: `/m/deep-link?t=${t}`,

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -339,10 +339,6 @@ describe('Mobile Endpoints', () => {
       const verifier = 'verifier';
       // compute challenge from verifier
       const challenge = crypto.createHash('sha256').update(verifier).digest('hex');
-      // mock verification
-      jest.spyOn(jwt, 'verify').mockImplementation(() => {
-        return { sub: undefined, challenge };
-      });
 
       const t = jwt.sign({ sub: undefined, challenge }, JWT_SECRET);
 

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -7,6 +7,7 @@ import { HttpMethod, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../test/app';
 import { AUTH_CLIENT_HOST, JWT_SECRET, REFRESH_TOKEN_JWT_SECRET } from '../../../../utils/config';
+import { MemberNotFound } from '../../../../utils/errors';
 import MemberRepository from '../../../member/repository';
 import { ANNA, BOB, LOUISA, expectMember, saveMember } from '../../../member/test/fixtures/members';
 import { MOCK_CAPTCHA } from '../captcha/test/utils';
@@ -337,12 +338,37 @@ describe('Mobile Endpoints', () => {
       });
       expect(response.statusCode).toEqual(StatusCodes.UNAUTHORIZED);
     });
+
+    it('Fail to authenticate if token contains undefined member id', async () => {
+      const verifier = 'verifier';
+      // compute challenge from verifier
+      const challenge = crypto.createHash('sha256').update(verifier).digest('hex');
+      // mock verification
+      jest.spyOn(jwt, 'verify').mockImplementation(() => {
+        console.log('w9oifje');
+        return { sub: undefined, challenge };
+      });
+
+      const t = jwt.sign({ sub: undefined, challenge }, JWT_SECRET);
+
+      const response = await app.inject({
+        method: HttpMethod.POST,
+        url: '/m/auth',
+        payload: {
+          t,
+          verifier,
+        },
+      });
+
+      expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
+      expect(response.json().message).toEqual(new MemberNotFound().message);
+    });
   });
 
   describe('GET /m/auth/refresh', () => {
     it('Refresh tokens successfully', async () => {
       const member = await saveMember(BOB);
-      const t = jwt.sign({ id: member.id }, REFRESH_TOKEN_JWT_SECRET);
+      const t = jwt.sign({ memberId: member.id }, REFRESH_TOKEN_JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.GET,
         url: '/m/auth/refresh',
@@ -353,6 +379,17 @@ describe('Mobile Endpoints', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK);
       expect(response.json()).toHaveProperty('refreshToken');
       expect(response.json()).toHaveProperty('authToken');
+    });
+    it('Throw if token contains undefined member id', async () => {
+      const t = jwt.sign({ id: undefined }, REFRESH_TOKEN_JWT_SECRET);
+      const response = await app.inject({
+        method: HttpMethod.GET,
+        url: '/m/auth/refresh',
+        headers: {
+          authorization: `Bearer ${t}`,
+        },
+      });
+      expect(response.statusCode).toEqual(StatusCodes.UNAUTHORIZED);
     });
     it('Fail if token is invalid', async () => {
       const member = await saveMember(BOB);

--- a/src/services/auth/plugins/mobile/service.ts
+++ b/src/services/auth/plugins/mobile/service.ts
@@ -91,10 +91,7 @@ export class MobileService {
       }
 
       // pre test the user existence to avoid providing a key
-      const member = await repositories.memberRepository.get(memberId);
-      if (!member) {
-        throw new MemberNotFound(memberId);
-      }
+      await repositories.memberRepository.get(memberId);
 
       // TODO: should we fetch/test the member from the DB?
       return this.fastify.generateAuthTokensPair(memberId);

--- a/src/services/auth/plugins/mobile/service.ts
+++ b/src/services/auth/plugins/mobile/service.ts
@@ -91,6 +91,7 @@ export class MobileService {
       }
 
       // pre test the user existence to avoid providing a key
+      // throws if member does not exist
       await repositories.memberRepository.get(memberId);
 
       // TODO: should we fetch/test the member from the DB?

--- a/src/services/auth/plugins/password/repository.ts
+++ b/src/services/auth/plugins/password/repository.ts
@@ -1,13 +1,24 @@
 import { UUID, isPasswordStrong } from '@graasp/sdk';
 
 import { AppDataSource } from '../../../../plugins/datasource';
-import { EmptyCurrentPassword, IncorrectPassword, InvalidPassword } from '../../../../utils/errors';
+import {
+  EmptyCurrentPassword,
+  IncorrectPassword,
+  InvalidPassword,
+  MemberNotFound,
+} from '../../../../utils/errors';
 import { MemberPassword } from './entities/password';
 import { PasswordNotStrong } from './errors';
 import { encryptPassword, verifyCredentials, verifyCurrentPassword } from './utils';
 
 export const MemberPasswordRepository = AppDataSource.getRepository(MemberPassword).extend({
   async getForMemberId(memberId: string, args: { shouldExist: boolean } = { shouldExist: true }) {
+    // additional check that id is not null
+    // o/w empty parameter to findOneBy return the first entry
+    if (!memberId) {
+      throw new MemberNotFound(memberId);
+    }
+
     const memberPassword = this.findOneBy({ member: { id: memberId } });
 
     if (!memberPassword && args.shouldExist) {

--- a/src/services/auth/service.ts
+++ b/src/services/auth/service.ts
@@ -1,0 +1,99 @@
+import jwt, { Secret, SignOptions } from 'jsonwebtoken';
+import { promisify } from 'util';
+
+import { FastifyBaseLogger } from 'fastify';
+
+import { MAIL } from '@graasp/translations';
+
+import {
+  JWT_SECRET,
+  LOGIN_TOKEN_EXPIRATION_IN_MINUTES,
+  PUBLIC_URL,
+  REGISTER_TOKEN_EXPIRATION_IN_MINUTES,
+} from '../../utils/config';
+import { Member } from '../member/entities/member';
+import { getRedirectionUrl } from './utils';
+
+const promisifiedJwtSign = promisify<
+  { sub: string; challenge?: string },
+  Secret,
+  SignOptions,
+  string
+>(jwt.sign);
+
+export class AuthService {
+  log: FastifyBaseLogger;
+  mailer: any; // TODO
+
+  constructor(mailer, log) {
+    this.mailer = mailer;
+    this.log = log;
+  }
+
+  generateToken(data, expiration) {
+    return promisifiedJwtSign(data, JWT_SECRET, {
+      expiresIn: expiration,
+    });
+  }
+
+  generateRegisterLinkAndEmailIt = async (
+    member: Member,
+    options: { challenge?; url?: string } = {},
+  ) => {
+    const { challenge, url } = options;
+
+    // generate token with member info and expiration
+    const token = await promisifiedJwtSign({ sub: member.id, challenge }, JWT_SECRET, {
+      expiresIn: `${REGISTER_TOKEN_EXPIRATION_IN_MINUTES}m`,
+    });
+
+    const redirectionUrl = getRedirectionUrl(url);
+    const linkPath = challenge ? '/m/deep-link' : '/auth';
+    const link = new URL(`${linkPath}?t=${token}&url=${redirectionUrl}`, PUBLIC_URL).toString();
+
+    const lang = member.lang;
+
+    const translated = this.mailer.translate(lang);
+    const subject = translated(MAIL.SIGN_UP_TITLE);
+    const html = `
+    ${this.mailer.buildText(translated(MAIL.GREETINGS))}
+    ${this.mailer.buildText(translated(MAIL.SIGN_UP_TEXT))}
+    ${this.mailer.buildButton(link, translated(MAIL.SIGN_UP_BUTTON_TEXT))}
+    ${this.mailer.buildText(translated(MAIL.SIGN_UP_NOT_REQUESTED))}`;
+
+    // don't wait for mailer's response; log error and link if it fails.
+    this.mailer
+      .sendEmail(subject, member.email, link, html)
+      .catch((err) => this.log.warn(err, `mailer failed. link: ${link}`));
+  };
+
+  generateLoginLinkAndEmailIt = async (
+    member: Member,
+    options: { challenge?: string; lang?: string; url?: string } = {},
+  ) => {
+    const { challenge, lang, url } = options;
+
+    // generate token with member info and expiration
+    const token = await promisifiedJwtSign({ sub: member.id, challenge }, JWT_SECRET, {
+      expiresIn: `${LOGIN_TOKEN_EXPIRATION_IN_MINUTES}m`,
+    });
+
+    const redirectionUrl = getRedirectionUrl(url);
+    const linkPath = challenge ? '/m/deep-link' : '/auth';
+    const link = new URL(`${linkPath}?t=${token}&url=${redirectionUrl}`, PUBLIC_URL).toString();
+
+    const memberLang = member.lang ?? lang;
+
+    const translated = this.mailer.translate(memberLang);
+    const subject = translated(MAIL.SIGN_IN_TITLE);
+    const html = `
+    ${this.mailer.buildText(translated(MAIL.SIGN_IN_TEXT))}
+    ${this.mailer.buildButton(link, translated(MAIL.SIGN_IN_BUTTON_TEXT))}
+    ${this.mailer.buildText(translated(MAIL.SIGN_IN_NOT_REQUESTED))}`;
+
+    // don't wait for mailer's response; log error and link if it fails.
+    this.mailer
+      .sendEmail(subject, member.email, link, html)
+      .catch((err) => this.log.warn(err, `mailer failed. link: ${link}`));
+  };
+}

--- a/src/services/auth/service.ts
+++ b/src/services/auth/service.ts
@@ -5,6 +5,7 @@ import { FastifyBaseLogger } from 'fastify';
 
 import { MAIL } from '@graasp/translations';
 
+import { MailerDecoration } from '../../plugins/mailer';
 import {
   JWT_SECRET,
   LOGIN_TOKEN_EXPIRATION_IN_MINUTES,
@@ -23,7 +24,7 @@ const promisifiedJwtSign = promisify<
 
 export class AuthService {
   log: FastifyBaseLogger;
-  mailer: any; // TODO
+  mailer: MailerDecoration;
 
   constructor(mailer, log) {
     this.mailer = mailer;

--- a/src/services/auth/utils.test.ts
+++ b/src/services/auth/utils.test.ts
@@ -12,7 +12,7 @@ import { BOB, saveMember } from '../member/test/fixtures/members';
 import { fetchMemberInSession, verifyMemberInAuthToken, verifyMemberInSession } from './utils';
 
 // mock datasource
-jest.mock('../../../../../plugins/datasource');
+jest.mock('../../plugins/datasource');
 
 const buildRequest = (memberId?: string) =>
   ({

--- a/src/services/auth/utils.test.ts
+++ b/src/services/auth/utils.test.ts
@@ -1,0 +1,106 @@
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import { v4 } from 'uuid';
+
+import { FastifyRequest } from 'fastify';
+
+import build, { clearDatabase } from '../../../test/app';
+import { AUTH_TOKEN_JWT_SECRET } from '../../utils/config';
+import { InvalidSession, MemberNotFound, OrphanSession } from '../../utils/errors';
+import { Member } from '../member/entities/member';
+import { BOB, saveMember } from '../member/test/fixtures/members';
+import { fetchMemberInSession, verifyMemberInAuthToken, verifyMemberInSession } from './utils';
+
+const buildRequest = (memberId?: string) =>
+  ({
+    session: {
+      get: () => memberId,
+      delete: jest.fn(),
+    },
+    log: { warn: jest.fn() },
+  } as unknown as FastifyRequest & { member?: Member });
+
+describe('Auth utils', () => {
+  let app, member;
+  beforeAll(async () => {
+    ({ app } = await build());
+
+    member = await saveMember(BOB);
+  });
+
+  afterAll(async () => {
+    await clearDatabase(app.db);
+  });
+  describe('verifyMemberInSession', () => {
+    it('Correctly set member in request', async () => {
+      const request = buildRequest(member.id);
+      await verifyMemberInSession(request);
+
+      expect(request.member).toEqual(member);
+    });
+    it('Throw for undefined memberId', async () => {
+      const request = buildRequest();
+      expect(verifyMemberInSession(request)).rejects.toBeInstanceOf(InvalidSession);
+
+      expect(request.member).toBeUndefined();
+    });
+    it('Throw if member does not exist', async () => {
+      const request = buildRequest(v4());
+      expect(verifyMemberInSession(request)).rejects.toBeInstanceOf(OrphanSession);
+
+      expect(request.member).toBeUndefined();
+    });
+  });
+
+  describe('fetchMemberInSession', () => {
+    it('Correctly set member in request', async () => {
+      const request = buildRequest(member.id);
+      await fetchMemberInSession(request);
+
+      expect(request.member).toEqual(member);
+    });
+    it('No memberId does not throw', async () => {
+      const request = buildRequest();
+      await fetchMemberInSession(request);
+
+      expect(request.member).toBeUndefined();
+    });
+    it('Throw if member does not exist', async () => {
+      const request = buildRequest(v4());
+      expect(fetchMemberInSession(request)).rejects.toBeInstanceOf(MemberNotFound);
+
+      expect(request.member).toBeUndefined();
+    });
+  });
+
+  describe('verifyMemberInAuthToken', () => {
+    const verifier = 'verifier';
+    const challenge = crypto.createHash('sha256').update(verifier).digest('hex');
+
+    it('Correctly set member in request', async () => {
+      const request = buildRequest();
+
+      const t = jwt.sign({ sub: member.id, challenge }, AUTH_TOKEN_JWT_SECRET);
+      expect(await verifyMemberInAuthToken(t, request)).toBeTruthy();
+
+      expect(request.member).toEqual(member);
+    });
+    it('No memberId return false', async () => {
+      const request = buildRequest();
+
+      const t = jwt.sign({ sub: undefined, challenge }, AUTH_TOKEN_JWT_SECRET);
+      expect(await verifyMemberInAuthToken(t, request)).toBeFalsy();
+
+      expect(request.member).toBeUndefined();
+    });
+    it('If member does not exist return false', async () => {
+      const request = buildRequest();
+
+      const t = jwt.sign({ sub: v4(), challenge }, AUTH_TOKEN_JWT_SECRET);
+
+      expect(await verifyMemberInAuthToken(t, request)).toBeFalsy();
+
+      expect(request.member).toBeUndefined();
+    });
+  });
+});

--- a/src/services/auth/utils.test.ts
+++ b/src/services/auth/utils.test.ts
@@ -11,6 +11,9 @@ import { Member } from '../member/entities/member';
 import { BOB, saveMember } from '../member/test/fixtures/members';
 import { fetchMemberInSession, verifyMemberInAuthToken, verifyMemberInSession } from './utils';
 
+// mock datasource
+jest.mock('../../../../../plugins/datasource');
+
 const buildRequest = (memberId?: string) =>
   ({
     session: {

--- a/src/services/auth/utils.ts
+++ b/src/services/auth/utils.ts
@@ -1,6 +1,26 @@
+import jwt, { Secret, SignOptions } from 'jsonwebtoken';
+import { promisify } from 'util';
+
+import { FastifyRequest } from 'fastify';
+
 import { Context } from '@graasp/sdk';
 
-import { CLIENT_HOSTS } from '../../utils/config';
+import {
+  AUTH_TOKEN_EXPIRATION_IN_MINUTES,
+  AUTH_TOKEN_JWT_SECRET,
+  CLIENT_HOSTS,
+  REFRESH_TOKEN_EXPIRATION_IN_MINUTES,
+  REFRESH_TOKEN_JWT_SECRET,
+} from '../../utils/config';
+import { InvalidSession, OrphanSession } from '../../utils/errors';
+import MemberRepository from '../member/repository';
+
+const promisifiedJwtSign = promisify<
+  { sub: string; challenge?: string },
+  Secret,
+  SignOptions,
+  string
+>(jwt.sign);
 
 const defaultClientHost = CLIENT_HOSTS.find((c) => c.name === Context.Builder);
 if (!defaultClientHost) {
@@ -21,3 +41,69 @@ export const getRedirectionUrl = (target?: string) => {
 
   return target;
 };
+
+export async function verifyMemberInSession(request: FastifyRequest) {
+  const { session } = request;
+  const memberId = session.get('member');
+
+  if (!memberId) {
+    throw new InvalidSession(memberId);
+  }
+
+  try {
+    const member = await MemberRepository.get(memberId);
+    request.member = member;
+  } catch (e) {
+    session.delete();
+    throw new OrphanSession(memberId);
+  }
+}
+
+// set member in request from session if exist
+// used to get authenticated member without throwing
+export async function fetchMemberInSession(request: FastifyRequest) {
+  const { session } = request;
+  const memberId = session.get('member');
+
+  if (!memberId) return;
+
+  // this throws if someone tries to use a fake member id
+  request.member = await MemberRepository.get(memberId);
+}
+
+// for token based auth
+export async function verifyMemberInAuthToken(jwtToken: string, request: FastifyRequest) {
+  try {
+    const { routerPath } = request;
+    const refreshing = '/m/auth/refresh' === routerPath;
+    const secret = refreshing ? REFRESH_TOKEN_JWT_SECRET : AUTH_TOKEN_JWT_SECRET;
+    const { memberId } = jwt.verify(jwtToken, secret, {}) as jwt.JwtPayload;
+    const member = await MemberRepository.get(memberId);
+
+    if (refreshing) {
+      request.memberId = memberId;
+    } else {
+      request.member = member;
+    }
+
+    return true;
+  } catch (error) {
+    const { log } = request;
+    log.warn('Invalid auth token');
+    return false;
+  }
+}
+
+export async function generateAuthTokensPair(
+  memberId: string,
+): Promise<{ authToken: string; refreshToken: string }> {
+  const [authToken, refreshToken] = await Promise.all([
+    promisifiedJwtSign({ sub: memberId }, AUTH_TOKEN_JWT_SECRET, {
+      expiresIn: `${AUTH_TOKEN_EXPIRATION_IN_MINUTES}m`,
+    }),
+    promisifiedJwtSign({ sub: memberId }, REFRESH_TOKEN_JWT_SECRET, {
+      expiresIn: `${REFRESH_TOKEN_EXPIRATION_IN_MINUTES}m`,
+    }),
+  ]);
+  return { authToken, refreshToken };
+}

--- a/src/services/item/plugins/app/appSetting/repository.ts
+++ b/src/services/item/plugins/app/appSetting/repository.ts
@@ -47,6 +47,11 @@ export const AppSettingRepository = AppDataSource.getRepository(AppSetting).exte
   },
 
   async get(id: string) {
+    // additional check that id is not null
+    // o/w empty parameter to findOneBy return the first entry
+    if (!id) {
+      throw new AppSettingNotFound(id);
+    }
     return this.findOneBy({ id });
   },
 

--- a/src/services/item/plugins/itemCategory/errors.ts
+++ b/src/services/item/plugins/itemCategory/errors.ts
@@ -16,3 +16,16 @@ export class DuplicateItemCategoryError extends GraaspCategoriesError {
     );
   }
 }
+
+export class CategoryNotFound extends GraaspCategoriesError {
+  constructor(data?: unknown) {
+    super(
+      {
+        code: 'GPCATERR002',
+        statusCode: StatusCodes.NOT_FOUND,
+        message: 'Category not found',
+      },
+      data,
+    );
+  }
+}

--- a/src/services/item/plugins/itemCategory/repositories/category.ts
+++ b/src/services/item/plugins/itemCategory/repositories/category.ts
@@ -1,5 +1,6 @@
 import { AppDataSource } from '../../../../../plugins/datasource';
 import { Category } from '../entities/Category';
+import { CategoryNotFound } from '../errors';
 
 export const CategoryRepository = AppDataSource.getRepository(Category).extend({
   async getAll(): Promise<Category[]> {
@@ -11,6 +12,11 @@ export const CategoryRepository = AppDataSource.getRepository(Category).extend({
    * @param id Category's id
    */
   async get(id: string): Promise<Category | null> {
+    // additional check that id is not null
+    // o/w empty parameter to findOneBy return the first entry
+    if (!id) {
+      throw new CategoryNotFound(id);
+    }
     return this.findOneBy({ id });
   },
 });

--- a/src/services/item/plugins/itemLike/repository.ts
+++ b/src/services/item/plugins/itemLike/repository.ts
@@ -6,6 +6,11 @@ import { ItemLike } from './itemLike';
 
 export const ItemLikeRepository = AppDataSource.getRepository(ItemLike).extend({
   get(entryId: string) {
+    // additional check that id is not null
+    // o/w empty parameter to findOneBy return the first entry
+    if (!entryId) {
+      throw new ItemLikeNotFound(entryId);
+    }
     return this.findOneBy({ id: entryId });
   },
 

--- a/src/services/item/plugins/validation/errors.ts
+++ b/src/services/item/plugins/validation/errors.ts
@@ -83,3 +83,16 @@ export class ItemValidationGroupNotFound extends GraaspValidationError {
     );
   }
 }
+
+export class ItemValidationNotFound extends GraaspValidationError {
+  constructor(data?: unknown) {
+    super(
+      {
+        code: 'GPVERR007',
+        statusCode: StatusCodes.NOT_FOUND,
+        message: 'Item validation not found',
+      },
+      data,
+    );
+  }
+}

--- a/src/services/item/plugins/validation/repositories/itemValidation.ts
+++ b/src/services/item/plugins/validation/repositories/itemValidation.ts
@@ -2,9 +2,15 @@ import { ItemValidationProcess, ItemValidationStatus } from '@graasp/sdk';
 
 import { AppDataSource } from '../../../../../plugins/datasource';
 import { ItemValidation } from '../entities/ItemValidation';
+import { ItemValidationNotFound } from '../errors';
 
 export const ItemValidationRepository = AppDataSource.getRepository(ItemValidation).extend({
   async get(id: string): Promise<ItemValidation | null> {
+    // additional check that id is not null
+    // o/w empty parameter to findOneBy return the first entry
+    if (!id) {
+      throw new ItemValidationNotFound(id);
+    }
     return this.findOneBy({ id });
   },
 

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -1,10 +1,9 @@
 import { In } from 'typeorm';
 
-import { FileItemType, UUID } from '@graasp/sdk';
+import { UUID } from '@graasp/sdk';
 
 import { AppDataSource } from '../../plugins/datasource';
 import { MemberNotFound } from '../../utils/errors';
-import { Item } from '../item/entities/Item';
 import { mapById } from '../utils';
 import { Member } from './entities/member';
 
@@ -18,9 +17,8 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
   async get(id: string): Promise<Member> {
     // additional check that id is not null
     // o/w empty parameter to findOneBy return the first entry
-    // TODO: improve
     if (!id) {
-      throw new Error('id should not be falsy');
+      throw new MemberNotFound(id);
     }
     const m = await this.findOneBy({ id });
     if (!m) {

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -24,7 +24,7 @@ describe('Member routes tests', () => {
   });
 
   describe('GET /members/current', () => {
-    it('Returns successfully if signed in', async () => {
+    it.only('Returns successfully if signed in', async () => {
       ({ app, actor } = await build());
 
       const response = await app.inject({

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -24,7 +24,7 @@ describe('Member routes tests', () => {
   });
 
   describe('GET /members/current', () => {
-    it.only('Returns successfully if signed in', async () => {
+    it('Returns successfully if signed in', async () => {
       ({ app, actor } = await build());
 
       const response = await app.inject({


### PR DESCRIPTION
This PR fix the undefined member id in token by:
- using the member repository `get` instead of raw `findOneById`
- refactor auth utils in a dedicated file + `AuthService` (probably we don't need the decoration anymore). It's still confused because we have many functions doing "similar" logic , but I've left major refactor for later
- regression tests + unit tests of auth utils

Additionally:
- All other functions using  `findOneById` have an additional check over id

close #543 