### PR TITLE
chore: ignore authorization header error in sentry

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -60,6 +60,7 @@ export function initSentry(instance: FastifyInstance): {
       }
       return breadcrumb;
     },
+    ignoreErrors: ['missing authorization header'],
   });
 
   if (SentryConfig.enablePerformance) {


### PR DESCRIPTION
This error happens like always and is supposed to happen, I think it makes sense to ignore it. Let me know what you think.

![Screenshot 2023-08-11 at 17 12 04](https://github.com/graasp/graasp/assets/11229627/41e31bca-44a0-412a-92db-34edc28dc722)
