### PR TITLE
fix: allow bearer token by using attemptVerifyAuthentication instead of fetchMemberInSession

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -73,6 +73,7 @@ declare module 'fastify' {
       captcha: string,
       actionType: RecaptchaActionType,
     ) => Promise<void>;
+    attemptVerifyAuthentication: (request: FastifyRequest) => Promise<void>;
     fetchMemberInSession: (request: FastifyRequest) => Promise<void>;
     generateAuthTokensPair: (memberId: string) => Promise<{
       authToken: string;

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -58,7 +58,7 @@ const plugin: FastifyPluginAsync<GraaspChatPluginOptions> = async (fastify, opti
 
     fastify.get<{ Params: { itemId: string } }>(
       '/:itemId/chat',
-      { schema: getChat, preHandler: fastify.fetchMemberInSession },
+      { schema: getChat, preHandler: fastify.attemptVerifyAuthentication },
       async ({ member, params: { itemId }, log }) => {
         return chatService.getForItem(member, buildRepositories(), itemId);
       },

--- a/src/services/chat/plugins/mentions/index.ts
+++ b/src/services/chat/plugins/mentions/index.ts
@@ -62,7 +62,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // mentions
   fastify.get(
     '/mentions',
-    { schema: getMentions, preHandler: fastify.fetchMemberInSession },
+    { schema: getMentions, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, log }) => {
       if (!member) {
         throw new UnauthorizedMember(member);

--- a/src/services/invitation/index.ts
+++ b/src/services/invitation/index.ts
@@ -34,7 +34,7 @@ const plugin: FastifyPluginAsync = async (fastify, options) => {
   // do not require authentication
   fastify.get<{ Params: IdParam }>(
     '/invitations/:id',
-    { schema: getById, preHandler: fastify.fetchMemberInSession },
+    { schema: getById, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, params }) => {
       const { id } = params;
       const aa = await iS.get(member, buildRepositories(), id);

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -59,7 +59,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/:id',
     {
       schema: getOne,
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ member, params: { id }, log }) => {
       return itemService.get(member, buildRepositories(), id);
@@ -68,7 +68,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
   fastify.get<{ Querystring: IdsParams }>(
     '/',
-    { schema: getMany, preHandler: fastify.fetchMemberInSession },
+    { schema: getMany, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, query: { id: ids }, log }) => {
       return itemService.getMany(member, buildRepositories(), ids);
     },
@@ -98,7 +98,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // get item's children
   fastify.get<{ Params: IdParam; Querystring: Ordered }>(
     '/:id/children',
-    { schema: getChildren, preHandler: fastify.fetchMemberInSession },
+    { schema: getChildren, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, params: { id }, query: { ordered }, log }) => {
       return itemService.getChildren(member, buildRepositories(), id, ordered);
     },
@@ -107,7 +107,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // get item's descendants
   fastify.get<{ Params: IdParam }>(
     '/:id/descendants',
-    { schema: getDescendants, preHandler: fastify.fetchMemberInSession },
+    { schema: getDescendants, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, params: { id }, log }) => {
       return itemService.getDescendants(member, buildRepositories(), id);
     },
@@ -118,7 +118,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/:id/parents',
     {
       schema: getParents,
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ member, params: { id }, log }) => {
       return itemService.getParents(member, buildRepositories(), id);

--- a/src/services/item/plugins/app/index.ts
+++ b/src/services/item/plugins/app/index.ts
@@ -126,7 +126,7 @@ const plugin: FastifyPluginAsync<AppsPluginOptions> = async (fastify, options) =
       // generate api access token for member + (app-)item.
       fastify.post<{ Params: { itemId: string }; Body: { origin: string } & AppIdentification }>(
         '/:itemId/api-access-token',
-        { schema: generateToken, preHandler: fastify.fetchMemberInSession },
+        { schema: generateToken, preHandler: fastify.attemptVerifyAuthentication },
         async (request) => {
           const {
             member,
@@ -172,7 +172,7 @@ const plugin: FastifyPluginAsync<AppsPluginOptions> = async (fastify, options) =
         '/:itemId/context',
         {
           schema: getContext,
-          preHandler: fastify.fetchMemberInSession,
+          preHandler: fastify.attemptVerifyAuthentication,
         },
         async ({ member, authTokenSubject: requestDetails, params: { itemId }, log }) => {
           const memberId = member ? member.id : requestDetails?.memberId;

--- a/src/services/item/plugins/file/index.ts
+++ b/src/services/item/plugins/file/index.ts
@@ -175,7 +175,7 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
     {
       schema: download,
 
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async (request, reply) => {
       const {

--- a/src/services/item/plugins/importExport/index.ts
+++ b/src/services/item/plugins/importExport/index.ts
@@ -90,7 +90,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     method: 'GET',
     url: '/zip-export/:itemId',
     schema: zipExport,
-    preHandler: fastify.fetchMemberInSession,
+    preHandler: fastify.attemptVerifyAuthentication,
     handler: async ({ member, params: { itemId } }, reply) => {
       return importExportService.export(member, buildRepositories(), {
         itemId,

--- a/src/services/item/plugins/itemCategory/index.ts
+++ b/src/services/item/plugins/itemCategory/index.ts
@@ -16,7 +16,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // get categories
   fastify.get<{ Params: { categoryId: string } }>(
     '/categories',
-    { schema: getCategories, preHandler: fastify.fetchMemberInSession },
+    { schema: getCategories, preHandler: fastify.attemptVerifyAuthentication },
     async ({}) => {
       return categoryService.getAll(undefined, buildRepositories());
     },
@@ -28,7 +28,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     {
       schema: getItemCategories,
 
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ member, params: { itemId }, log }) => {
       return itemCategoryService.getForItem(member, buildRepositories(), itemId);

--- a/src/services/item/plugins/itemFlag/index.ts
+++ b/src/services/item/plugins/itemFlag/index.ts
@@ -17,7 +17,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // get flags
   fastify.get(
     '/flags',
-    { schema: getFlags, preHandler: fastify.fetchMemberInSession },
+    { schema: getFlags, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, log }) => {
       return iFS.getAllFlags(member, buildRepositories());
     },

--- a/src/services/item/plugins/itemLike/index.ts
+++ b/src/services/item/plugins/itemLike/index.ts
@@ -24,7 +24,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // TODO: anonymize private members
   fastify.get<{ Params: { itemId: string } }>(
     '/:itemId/likes',
-    { schema: getLikesForItem, preHandler: fastify.fetchMemberInSession },
+    { schema: getLikesForItem, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, params: { itemId }, log }) => {
       return itemLikeService.getForItem(member, buildRepositories(), itemId);
     },

--- a/src/services/item/plugins/itemTag/index.ts
+++ b/src/services/item/plugins/itemTag/index.ts
@@ -39,7 +39,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // get item tags
   fastify.get<{ Params: { itemId: string } }>(
     '/:itemId/tags',
-    { schema: getItemTags, preHandler: fastify.fetchMemberInSession },
+    { schema: getItemTags, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, params: { itemId }, log }) => {
       return iTS.getForItem(member, buildRepositories(), itemId);
     },
@@ -48,7 +48,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // get item tags for many items
   fastify.get<{ Querystring: IdsParams }>(
     '/tags',
-    { schema: getMany, preHandler: fastify.fetchMemberInSession },
+    { schema: getMany, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, query: { id: ids }, log }) => {
       return iTS.getForManyItems(member, buildRepositories(), ids);
     },

--- a/src/services/item/plugins/published/index.ts
+++ b/src/services/item/plugins/published/index.ts
@@ -26,7 +26,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/collections',
     {
       schema: getCollections,
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ query, member }) => {
       return pIS.getItemsByCategories(member, buildRepositories(), query.categoryId);
@@ -37,7 +37,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/collections/members/:memberId',
     {
       schema: getCollectionsForMember,
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ member, params: { memberId } }) => {
       return pIS.getItemsForMember(member, buildRepositories(), memberId);
@@ -47,7 +47,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: { itemId: string } }>(
     '/collections/:itemId/informations',
     {
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
       schema: getInformations,
     },
     async ({ params, member }) => {
@@ -58,7 +58,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Querystring: { itemId: string[] } }>(
     '/collections/informations',
     {
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
       schema: getManyInformations,
     },
     async ({ member, query: { itemId } }) => {
@@ -69,7 +69,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Querystring: { limit?: number } }>(
     '/collections/liked',
     {
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
       schema: getMostLikedItems,
     },
     async ({ member, query: { limit } }) => {
@@ -106,7 +106,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Querystring: { limit?: number } }>(
     '/collections/recent',
     {
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
       schema: getRecentCollections,
     },
     async ({ member, query: { limit } }) => {

--- a/src/services/item/plugins/published/plugins/search/index.ts
+++ b/src/services/item/plugins/published/plugins/search/index.ts
@@ -21,7 +21,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // range: title, tag, all, author
   fastify.get<{ Querystring: SearchFields }>(
     '/collections/search',
-    { schema: search, preHandler: fastify.fetchMemberInSession },
+    { schema: search, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, query, log }) => {
       return searchService.search(member, buildRepositories(), query);
     },

--- a/src/services/item/plugins/thumbnail/index.ts
+++ b/src/services/item/plugins/thumbnail/index.ts
@@ -99,7 +99,7 @@ const plugin: FastifyPluginAsync<GraaspThumbnailsOptions> = async (fastify, opti
     `/:id${THUMBNAILS_ROUTE_PREFIX}/:size`,
     {
       schema: download,
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ member, params: { size, id: itemId }, query: { replyUrl }, log }, reply) => {
       return thumbnailService

--- a/src/services/itemLogin/index.ts
+++ b/src/services/itemLogin/index.ts
@@ -23,7 +23,7 @@ const plugin: FastifyPluginAsync = async (fastify, options) => {
   // public endpoint
   fastify.get<{ Params: { id: string } }>(
     '/:id/login-schema-type',
-    { schema: getLoginSchemaType, preHandler: fastify.fetchMemberInSession },
+    { schema: getLoginSchemaType, preHandler: fastify.attemptVerifyAuthentication },
     async ({ member, log, params: { id: itemId } }) => {
       const value = (await iLService.getSchemaType(member, buildRepositories(), itemId)) ?? null;
       return value;
@@ -54,7 +54,7 @@ const plugin: FastifyPluginAsync = async (fastify, options) => {
     {
       schema: login,
       // set member in request if exists without throwing
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ body, query, member, session, params }) => {
       return db.transaction(async (manager) => {

--- a/src/services/itemMembership/index.ts
+++ b/src/services/itemMembership/index.ts
@@ -35,7 +35,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       // returns empty for item not found
       fastify.get<{ Querystring: { itemId: string[] } }>(
         '/',
-        { schema: getItems, preHandler: fastify.fetchMemberInSession },
+        { schema: getItems, preHandler: fastify.attemptVerifyAuthentication },
         async ({ member, query: { itemId: ids }, log }) => {
           return itemMembershipService.getForManyItems(member, buildRepositories(), ids);
         },

--- a/src/services/member/plugins/thumbnail/index.ts
+++ b/src/services/member/plugins/thumbnail/index.ts
@@ -94,7 +94,7 @@ const plugin: FastifyPluginAsync<GraaspThumbnailsOptions> = async (fastify, opti
     '/:id/avatar/:size',
     {
       schema: download,
-      preHandler: fastify.fetchMemberInSession,
+      preHandler: fastify.attemptVerifyAuthentication,
     },
     async ({ member, params: { size, id: memberId }, query: { replyUrl }, log }, reply) => {
       return thumbnailService

--- a/test/app.ts
+++ b/test/app.ts
@@ -42,7 +42,7 @@ const build = async ({ member }: { member?: Partial<Member> | null } = { member:
     jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request) => {
       request.member = authenticatedActor;
     });
-    jest.spyOn(app, 'fetchMemberInSession').mockImplementation(async (request) => {
+    jest.spyOn(app, 'attemptVerifyAuthentication').mockImplementation(async (request) => {
       request.session.set('member', authenticatedActor.id);
       request.member = authenticatedActor;
     });


### PR DESCRIPTION
`fetchMemberInSession` only checked the cookie value.

Whereas `attemptVerifyAuthentication` does both `fetchMemberInSession` + `verifyBearerToken` which allows request to correctly get the member from the `Bearer` Authorization.

This effected all the public endpoints (ie. get item, get tags, etc)

close #550 