### PR TITLE
feat: add websockets feedbacks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -57,23 +57,23 @@ export default async function (instance: FastifyInstance): Promise<void> {
     })
     .register(fp(decoratorPlugin))
     // need to be defined before member and item for auth check
-    .register(fp(authPlugin), { sessionCookieDomain: COOKIE_DOMAIN })
-    .register(fp(websocketsPlugin), {
-      prefix: '/ws',
-      redis: {
-        channelName: 'graasp-realtime-updates',
-        config: {
-          host: REDIS_HOST,
-          port: parseInt(REDIS_PORT ?? '6379'),
-          username: REDIS_USERNAME,
-          password: REDIS_PASSWORD,
-        },
-      },
-    });
+    .register(fp(authPlugin), { sessionCookieDomain: COOKIE_DOMAIN });
 
   instance.register(async (instance) => {
     // core API modules
     await instance
+      .register(fp(websocketsPlugin), {
+        prefix: '/ws',
+        redis: {
+          channelName: 'graasp-realtime-updates',
+          config: {
+            host: REDIS_HOST,
+            port: parseInt(REDIS_PORT ?? '6379'),
+            username: REDIS_USERNAME,
+            password: REDIS_PASSWORD,
+          },
+        },
+      })
       .register(fp(MemberServiceApi))
       .register(fp(ItemServiceApi))
       .register(fp(ItemMembershipServiceApi));

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,6 +62,8 @@ export default async function (instance: FastifyInstance): Promise<void> {
   instance.register(async (instance) => {
     // core API modules
     await instance
+      // the websockets plugin must be registered before but in the same scope as the apis
+      // otherwise tests somehow bypass mocking the authentication through jest.spyOn(app, 'verifyAuthentication')
       .register(fp(websocketsPlugin), {
         prefix: '/ws',
         redis: {

--- a/src/services/authorization.ts
+++ b/src/services/authorization.ts
@@ -187,7 +187,9 @@ export const filterOutItems = async (actor: Actor, repositories, items: Item[]) 
 
   // TODO: optimize with on query
   const { data: memberships } = actor
-    ? await itemMembershipRepository.getForManyItems(items, actor.id)
+    ? await itemMembershipRepository.getForManyItems(items, {
+        memberId: actor.id,
+      })
     : { data: [] };
   const isHidden = await repositories.itemTagRepository.hasForMany(items, ItemTagType.Hidden);
   return items

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -308,7 +308,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('copy', ids, { data: {}, errors: [e] }),
+            ItemOpFeedbackEvent('copy', ids, { error: e }),
           );
         }
       });

--- a/src/services/item/plugins/action/requestExport/service.ts
+++ b/src/services/item/plugins/action/requestExport/service.ts
@@ -96,6 +96,8 @@ export class ActionRequestExportService {
     }
 
     await this._sendExportLinkInMail(member, item, requestExport.createdAt);
+
+    return item;
   }
 
   async _sendExportLinkInMail(actor: Member, item: Item, archiveDate: Date) {

--- a/src/services/item/plugins/action/test/ws.test.ts
+++ b/src/services/item/plugins/action/test/ws.test.ts
@@ -1,0 +1,72 @@
+import { StatusCodes } from 'http-status-codes';
+import waitForExpect from 'wait-for-expect';
+
+import { HttpMethod } from '@graasp/sdk';
+
+import { clearDatabase } from '../../../../../../test/app';
+import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
+import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
+import { setupWsApp } from '../../../../websockets/test/ws-app';
+import { ItemOpFeedbackEvent, memberItemsTopic } from '../../../ws/events';
+import { ActionRequestExportRepository } from '../requestExport/repository';
+
+// mock datasource
+jest.mock('../../../../../plugins/datasource');
+
+describe('asynchronous feedback', () => {
+  let app, actor, address;
+  let ws: TestWsClient;
+
+  beforeEach(async () => {
+    ({ app, actor, address } = await setupWsApp());
+    ws = new TestWsClient(address);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase(app.db);
+    actor = null;
+    app.close();
+    ws.close();
+  });
+
+  it('member that initated the export operation receives success feedback', async () => {
+    const { item } = await saveItemAndMembership({ member: actor });
+    const memberUpdates = await ws.subscribe({ topic: memberItemsTopic, channel: actor.id });
+
+    const response = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/${item.id}/actions/export`,
+    });
+    expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
+
+    await waitForExpect(() => {
+      const [feedbackUpdate] = memberUpdates;
+      expect(feedbackUpdate).toMatchObject(
+        ItemOpFeedbackEvent('export', [item.id], { data: { [item.id]: item }, errors: [] }),
+      );
+    });
+  });
+
+  it('member that initated the export operation receives failure feedback', async () => {
+    const { item } = await saveItemAndMembership({ member: actor });
+    const memberUpdates = await ws.subscribe({ topic: memberItemsTopic, channel: actor.id });
+
+    jest.spyOn(ActionRequestExportRepository, 'getLast').mockImplementation(async () => {
+      throw new Error('mock error');
+    });
+
+    const response = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/${item.id}/actions/export`,
+    });
+    expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
+
+    await waitForExpect(() => {
+      const [feedbackUpdate] = memberUpdates;
+      expect(feedbackUpdate).toMatchObject(
+        ItemOpFeedbackEvent('export', [item.id], { error: new Error('mock error') }),
+      );
+    });
+  });
+});

--- a/src/services/item/plugins/action/test/ws.test.ts
+++ b/src/services/item/plugins/action/test/ws.test.ts
@@ -13,6 +13,38 @@ import { ActionRequestExportRepository } from '../requestExport/repository';
 // mock datasource
 jest.mock('../../../../../plugins/datasource');
 
+const uploadDoneMock = jest.fn(async () => console.debug('aws s3 storage upload'));
+const deleteObjectMock = jest.fn(async () => console.debug('deleteObjectMock'));
+const headObjectMock = jest.fn(async () => console.debug('headObjectMock'));
+const MOCK_SIGNED_URL = 'signed-url';
+jest.mock('@aws-sdk/client-s3', () => {
+  return {
+    GetObjectCommand: jest.fn(),
+    S3: function () {
+      return {
+        deleteObject: deleteObjectMock,
+        putObject: uploadDoneMock,
+        headObject: headObjectMock,
+      };
+    },
+  };
+});
+jest.mock('@aws-sdk/s3-request-presigner', () => {
+  const getSignedUrl = jest.fn(async () => MOCK_SIGNED_URL);
+  return {
+    getSignedUrl,
+  };
+});
+jest.mock('@aws-sdk/lib-storage', () => {
+  return {
+    Upload: jest.fn().mockImplementation(() => {
+      return {
+        done: uploadDoneMock,
+      };
+    }),
+  };
+});
+
 describe('asynchronous feedback', () => {
   let app, actor, address;
   let ws: TestWsClient;

--- a/src/services/item/plugins/recycled/index.ts
+++ b/src/services/item/plugins/recycled/index.ts
@@ -8,14 +8,9 @@ import {
 } from '@graasp/sdk';
 
 import { buildRepositories } from '../../../../utils/repositories';
-import schemas, {
-  getRecycledItemDatas,
-  recycleMany,
-  recycleOne,
-  restoreMany,
-  restoreOne,
-} from './schemas';
+import schemas, { getRecycledItemDatas, recycleMany, restoreMany } from './schemas';
 import { RecycledBinService } from './service';
+import { recycleWsHooks } from './ws/hooks';
 
 export interface RecycledItemDataOptions {
   /** Max number of items to recycle in a request.
@@ -37,6 +32,10 @@ const plugin: FastifyPluginAsync<RecycledItemDataOptions> = async (fastify, opti
   } = options;
 
   const recycleBinService = new RecycledBinService();
+
+  fastify.register(recycleWsHooks, {
+    recycleService: recycleBinService,
+  });
 
   fastify.addSchema(schemas);
 

--- a/src/services/item/plugins/recycled/service.ts
+++ b/src/services/item/plugins/recycled/service.ts
@@ -91,7 +91,7 @@ export class RecycledBinService {
     const descendants = await itemRepository.getManyDescendants(items, { withDeleted: true });
 
     for (const item of items) {
-      this.hooks.runPreHooks('restore', actor, repositories, { item, isRestoredRoot: true });
+      await this.hooks.runPreHooks('restore', actor, repositories, { item, isRestoredRoot: true });
     }
     for (const d of descendants) {
       await this.hooks.runPreHooks('restore', actor, repositories, {
@@ -104,10 +104,13 @@ export class RecycledBinService {
     await recycledItemRepository.restoreMany(items);
 
     for (const item of items) {
-      this.hooks.runPostHooks('restore', actor, repositories, { item, isRestoredRoot: true });
+      await this.hooks.runPostHooks('restore', actor, repositories, { item, isRestoredRoot: true });
     }
     for (const d of descendants) {
-      this.hooks.runPostHooks('restore', actor, repositories, { item: d, isRestoredRoot: false });
+      await this.hooks.runPostHooks('restore', actor, repositories, {
+        item: d,
+        isRestoredRoot: false,
+      });
     }
 
     return result;

--- a/src/services/item/plugins/recycled/service.ts
+++ b/src/services/item/plugins/recycled/service.ts
@@ -35,7 +35,8 @@ export class RecycledBinService {
     }
     const { itemRepository, recycledItemRepository } = repositories;
 
-    const { data: idsToItems } = await itemRepository.getMany(itemIds, { throwOnError: true });
+    const itemsResult = await itemRepository.getMany(itemIds, { throwOnError: true });
+    const { data: idsToItems } = itemsResult;
     const items = Object.values(idsToItems);
 
     // if item is already deleted, it will throw not found here
@@ -65,7 +66,7 @@ export class RecycledBinService {
       await this.hooks.runPostHooks('recycle', actor, repositories, { item, isRecycledRoot: true });
     }
 
-    return result;
+    return itemsResult;
   }
 
   async restoreMany(actor: Actor, repositories: Repositories, itemIds: string[]) {
@@ -74,10 +75,11 @@ export class RecycledBinService {
     }
     const { itemRepository, recycledItemRepository } = repositories;
 
-    const { data: idsToItems } = await itemRepository.getMany(itemIds, {
+    const result = await itemRepository.getMany(itemIds, {
       throwOnError: true,
       withDeleted: true,
     });
+    const { data: idsToItems } = result;
 
     const items = Object.values(idsToItems);
 
@@ -107,5 +109,7 @@ export class RecycledBinService {
     for (const d of descendants) {
       this.hooks.runPostHooks('restore', actor, repositories, { item: d, isRestoredRoot: false });
     }
+
+    return result;
   }
 }

--- a/src/services/item/plugins/recycled/test/index.test.ts
+++ b/src/services/item/plugins/recycled/test/index.test.ts
@@ -26,7 +26,7 @@ import { expectManyRecycledItems } from './fixtures';
 // mock datasource
 jest.mock('../../../../../plugins/datasource');
 
-const saveRecycledItem = async (member: Member, defaultItem?: Item) => {
+export const saveRecycledItem = async (member: Member, defaultItem?: Item) => {
   let item = defaultItem;
   if (!item) {
     ({ item } = await saveItemAndMembership({ member }));

--- a/src/services/item/plugins/recycled/test/ws.test.ts
+++ b/src/services/item/plugins/recycled/test/ws.test.ts
@@ -1,0 +1,94 @@
+import { StatusCodes } from 'http-status-codes';
+import waitForExpect from 'wait-for-expect';
+
+import { FastifyInstance } from 'fastify';
+
+import { HttpMethod } from '@graasp/sdk';
+
+import build, { clearDatabase } from '../../../../../../test/app';
+import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
+import { Member } from '../../../../member/entities/member';
+import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
+import { Item } from '../../../entities/Item';
+import { ItemEvent, SelfItemEvent, itemTopic, memberItemsTopic } from '../../../ws/events';
+import { RecycleBinEvent } from '../ws/events';
+
+// mock datasource
+jest.mock('../../../../../plugins/datasource');
+
+const MAX_PORT = 65535;
+const MIN_PORT = 1025;
+
+function listenOnRandomPort(app: FastifyInstance): Promise<string> {
+  try {
+    return app.listen({
+      port: Math.floor(Math.random() * (MAX_PORT - MIN_PORT)) + MIN_PORT,
+      host: '0.0.0.0',
+    });
+  } catch (error) {
+    if (error.code === 'EADDRINUSE') {
+      return listenOnRandomPort(app);
+    }
+    throw error;
+  }
+}
+
+async function setupWsApp({ member }: { member?: Member | null } = {}) {
+  const { app, actor } = await build(member ? { member } : undefined);
+  await app.ready();
+  const address = await listenOnRandomPort(app);
+  return { app, actor, address };
+}
+
+/**
+ * A custom serializier for items that ignores dates that may frequently change
+ * To be used with toMatchObject
+ */
+function serialize(item: Item): Item {
+  // Dates are not parsed by JSON so ensure that they are all strings
+  const serialized = JSON.parse(JSON.stringify(item));
+  // Ignore dates that may frequently change on the server
+  delete serialized.deletedAt;
+  delete serialized.updatedAt;
+  return serialized;
+}
+
+describe('Recycle websocket hooks', () => {
+  let app, actor, address;
+  let ws: TestWsClient;
+
+  beforeEach(async () => {
+    ({ app, actor, address } = await setupWsApp());
+    ws = new TestWsClient(address);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase(app.db);
+    actor = null;
+    app.close();
+    ws.close();
+  });
+
+  it('receives deletion update when item is recycled', async () => {
+    const { item } = await saveItemAndMembership({ member: actor });
+    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: item.id });
+    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+      topic: memberItemsTopic,
+      channel: actor.id,
+    });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${item.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(() => {
+      const [selfDelete] = itemUpdates;
+      const [ownDelete, recycleCreate] = memberItemsUpdates;
+      expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(item)));
+      expect(recycleCreate).toMatchObject(RecycleBinEvent('create', serialize(item)));
+    });
+  });
+});

--- a/src/services/item/plugins/recycled/test/ws.test.ts
+++ b/src/services/item/plugins/recycled/test/ws.test.ts
@@ -1,18 +1,16 @@
 import { StatusCodes } from 'http-status-codes';
 import waitForExpect from 'wait-for-expect';
 
-import { FastifyInstance } from 'fastify';
-
 import { HttpMethod, PermissionLevel } from '@graasp/sdk';
 
-import build, { clearDatabase } from '../../../../../../test/app';
+import { clearDatabase } from '../../../../../../test/app';
 import {
   saveItemAndMembership,
   saveMembership,
 } from '../../../../itemMembership/test/fixtures/memberships';
-import { Member } from '../../../../member/entities/member';
 import { ANNA, saveMember } from '../../../../member/test/fixtures/members';
 import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
+import { setupWsApp } from '../../../../websockets/test/ws-app';
 import { Item } from '../../../entities/Item';
 import {
   ChildItemEvent,
@@ -23,34 +21,11 @@ import {
   itemTopic,
   memberItemsTopic,
 } from '../../../ws/events';
+import { RecycledItemDataRepository } from '../repository';
 import { RecycleBinEvent } from '../ws/events';
 
 // mock datasource
 jest.mock('../../../../../plugins/datasource');
-
-const MAX_PORT = 65535;
-const MIN_PORT = 1025;
-
-function listenOnRandomPort(app: FastifyInstance): Promise<string> {
-  try {
-    return app.listen({
-      port: Math.floor(Math.random() * (MAX_PORT - MIN_PORT)) + MIN_PORT,
-      host: '0.0.0.0',
-    });
-  } catch (error) {
-    if (error.code === 'EADDRINUSE') {
-      return listenOnRandomPort(app);
-    }
-    throw error;
-  }
-}
-
-async function setupWsApp({ member }: { member?: Member | null } = {}) {
-  const { app, actor } = await build(member ? { member } : undefined);
-  await app.ready();
-  const address = await listenOnRandomPort(app);
-  return { app, actor, address };
-}
 
 /**
  * A custom serializier for items that ignores dates that may frequently change
@@ -82,165 +57,453 @@ describe('Recycle websocket hooks', () => {
     ws.close();
   });
 
-  it('receives deletion update when item is recycled', async () => {
-    const { item } = await saveItemAndMembership({ member: actor });
-    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: item.id });
+  describe('on recycle', () => {
+    it('receives deletion update when item is recycled', async () => {
+      const { item } = await saveItemAndMembership({ member: actor });
+      const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: item.id });
 
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${item.id}`,
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(() => {
+        const [selfDelete] = itemUpdates;
+        expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(item)));
+      });
     });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
 
-    await waitForExpect(() => {
-      const [selfDelete] = itemUpdates;
-      expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(item)));
+    it('item in the recycled subtree receives deletion update when top item is recycled', async () => {
+      const { item: parentItem } = await saveItemAndMembership({ member: actor });
+      const { item: childItem } = await saveItemAndMembership({ member: actor, parentItem });
+      const itemUpdates = await ws.subscribe<ItemEvent>({
+        topic: itemTopic,
+        channel: childItem.id,
+      });
+
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${parentItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(() => {
+        const [selfDelete] = itemUpdates;
+        expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(childItem)));
+      });
+    });
+
+    it('parent item receives child deletion update when child item is recycled', async () => {
+      const { item: parentItem } = await saveItemAndMembership({ member: actor });
+      const { item: childItem } = await saveItemAndMembership({ parentItem, member: actor });
+      const itemUpdates = await ws.subscribe<ItemEvent>({
+        topic: itemTopic,
+        channel: parentItem.id,
+      });
+
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${childItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(() => {
+        const [childDelete] = itemUpdates;
+        expect(childDelete).toMatchObject(ChildItemEvent('delete', serialize(childItem)));
+      });
+    });
+
+    it('parent in the recycled subtree receives deletion update of child when top item is recycled', async () => {
+      const { item: topItem } = await saveItemAndMembership({ member: actor });
+      const { item: parentItem } = await saveItemAndMembership({
+        member: actor,
+        parentItem: topItem,
+      });
+      const { item: childItem } = await saveItemAndMembership({ parentItem, member: actor });
+      const itemUpdates = await ws.subscribe<ItemEvent>({
+        topic: itemTopic,
+        channel: parentItem.id,
+      });
+
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${topItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(() => {
+        const [selfDelete, childDelete] = itemUpdates;
+        expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(parentItem)));
+        expect(childDelete).toMatchObject(ChildItemEvent('delete', serialize(childItem)));
+      });
+    });
+
+    it('creator receives own items deletion update when item is recycled', async () => {
+      const { item } = await saveItemAndMembership({ member: actor });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(() => {
+        const [ownDelete] = memberItemsUpdates;
+        expect(ownDelete).toMatchObject(OwnItemsEvent('delete', serialize(item)));
+      });
+    });
+
+    it('members with memberships receive shared items delete update when item is recycled', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      await saveMembership({ item, member: actor, permission: PermissionLevel.Read });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [sharedDelete] = memberItemsUpdates;
+        expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(item)));
+      });
+    });
+
+    it('members with memberships on item in the recycled subtree receive shared items delete update when top item is recycled', async () => {
+      const anna = await saveMember(ANNA);
+      const { item: parentItem } = await saveItemAndMembership({ member: anna });
+      const { item: childItem } = await saveItemAndMembership({ member: anna, parentItem });
+      await saveMembership({ item: childItem, member: actor, permission: PermissionLevel.Read });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${parentItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [sharedDelete] = memberItemsUpdates;
+        expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(childItem)));
+      });
+    });
+
+    it('members with multiple memberships on related items in the recycled subtree receive shared items delete update on topmost shared item only when top item is recycled', async () => {
+      const anna = await saveMember(ANNA);
+      const { item: topItem } = await saveItemAndMembership({ member: anna });
+      const { item: parentItem } = await saveItemAndMembership({
+        member: anna,
+        parentItem: topItem,
+      });
+      const { item: childItem } = await saveItemAndMembership({ member: anna, parentItem });
+      await saveMembership({ item: parentItem, member: actor, permission: PermissionLevel.Read });
+      await saveMembership({ item: childItem, member: actor, permission: PermissionLevel.Admin });
+
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${topItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [sharedDelete] = memberItemsUpdates;
+        expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(parentItem)));
+      });
+    });
+
+    it('admins receive recycle bin create update when item is recycled', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      await saveMembership({ item, member: actor, permission: PermissionLevel.Admin });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [recycleCreate, sharedDelete] = memberItemsUpdates;
+        expect(recycleCreate).toMatchObject(RecycleBinEvent('create', serialize(item)));
+        expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(item)));
+      });
     });
   });
 
-  it('item in the recycled subtree receives deletion update when top item is recycled', async () => {
-    const { item: parentItem } = await saveItemAndMembership({ member: actor });
-    const { item: childItem } = await saveItemAndMembership({ member: actor, parentItem });
-    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: childItem.id });
+  describe('on restore', () => {
+    it('parent item receives creation update when item is restored', async () => {
+      const { item: parentItem } = await saveItemAndMembership({ member: actor });
+      const { item: childItem } = await saveItemAndMembership({ member: actor, parentItem });
 
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${parentItem.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+      const recycle = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${childItem.id}`,
+      });
+      expect(recycle.statusCode).toBe(StatusCodes.ACCEPTED);
 
-    await waitForExpect(() => {
-      const [selfDelete] = itemUpdates;
-      expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(childItem)));
-    });
-  });
+      await waitForExpect(async () => {
+        expect(await RecycledItemDataRepository.count()).toEqual(1);
+      });
 
-  it('parent item receives child deletion update when child item is recycled', async () => {
-    const { item: parentItem } = await saveItemAndMembership({ member: actor });
-    const { item: childItem } = await saveItemAndMembership({ parentItem, member: actor });
-    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: parentItem.id });
+      const itemUpdates = await ws.subscribe<ItemEvent>({
+        topic: itemTopic,
+        channel: parentItem.id,
+      });
 
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${childItem.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+      const restore = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/restore?id=${childItem.id}`,
+      });
+      expect(restore.statusCode).toBe(StatusCodes.ACCEPTED);
 
-    await waitForExpect(() => {
-      const [childDelete] = itemUpdates;
-      expect(childDelete).toMatchObject(ChildItemEvent('delete', serialize(childItem)));
-    });
-  });
-
-  it('parent in the recycled subtree receives deletion update of child when top item is recycled', async () => {
-    const { item: topItem } = await saveItemAndMembership({ member: actor });
-    const { item: parentItem } = await saveItemAndMembership({
-      member: actor,
-      parentItem: topItem,
-    });
-    const { item: childItem } = await saveItemAndMembership({ parentItem, member: actor });
-    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: parentItem.id });
-
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${topItem.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
-
-    await waitForExpect(() => {
-      const [selfDelete, childDelete] = itemUpdates;
-      expect(childDelete).toMatchObject(ChildItemEvent('delete', serialize(childItem)));
-    });
-  });
-
-  it('creator receives own items deletion update when item is recycled', async () => {
-    const { item } = await saveItemAndMembership({ member: actor });
-    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
-      topic: memberItemsTopic,
-      channel: actor.id,
+      await waitForExpect(async () => {
+        const [childCreate] = itemUpdates;
+        expect(childCreate).toMatchObject(ChildItemEvent('create', serialize(childItem)));
+      });
     });
 
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${item.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+    it('creator receives own items creation update when item is restored', async () => {
+      const { item } = await saveItemAndMembership({ member: actor });
 
-    await waitForExpect(() => {
-      const [ownDelete] = memberItemsUpdates;
-      expect(ownDelete).toMatchObject(OwnItemsEvent('delete', serialize(item)));
-    });
-  });
+      const recycle = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(recycle.statusCode).toBe(StatusCodes.ACCEPTED);
 
-  it('members with memberships receive shared items delete update when item is recycled', async () => {
-    const anna = await saveMember(ANNA);
-    const { item } = await saveItemAndMembership({ member: anna });
-    await saveMembership({ item, member: actor, permission: PermissionLevel.Read });
-    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
-      topic: memberItemsTopic,
-      channel: actor.id,
-    });
+      await waitForExpect(async () => {
+        expect(await RecycledItemDataRepository.count()).toEqual(1);
+      });
 
-    // send recycle request as admin Anna
-    jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
-      request.member = anna;
-    });
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${item.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+      const itemUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
 
-    await waitForExpect(async () => {
-      const [sharedDelete] = memberItemsUpdates;
-      expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(item)));
-    });
-  });
+      const restore = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/restore?id=${item.id}`,
+      });
+      expect(restore.statusCode).toBe(StatusCodes.ACCEPTED);
 
-  it('members with memberships on item in the recycled subtree receive shared items delete update when top item is recycled', async () => {
-    const anna = await saveMember(ANNA);
-    const { item: parentItem } = await saveItemAndMembership({ member: anna });
-    const { item: childItem } = await saveItemAndMembership({ member: anna, parentItem });
-    await saveMembership({ item: childItem, member: actor, permission: PermissionLevel.Read });
-    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
-      topic: memberItemsTopic,
-      channel: actor.id,
+      await waitForExpect(async () => {
+        const [ownCreate] = itemUpdates;
+        expect(ownCreate).toMatchObject(OwnItemsEvent('create', serialize(item)));
+      });
     });
 
-    // send recycle request as admin Anna
-    jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
-      request.member = anna;
-    });
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${parentItem.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+    it('members with memberships receive shared items create update when item is restored', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      await saveMembership({ member: actor, item, permission: PermissionLevel.Read });
 
-    await waitForExpect(async () => {
-      const [sharedDelete] = memberItemsUpdates;
-      expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(childItem)));
-    });
-  });
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
 
-  it('admins receive recycle bin create update when item is recycled', async () => {
-    const anna = await saveMember(ANNA);
-    const { item } = await saveItemAndMembership({ member: anna });
-    await saveMembership({ item, member: actor, permission: PermissionLevel.Admin });
-    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
-      topic: memberItemsTopic,
-      channel: actor.id,
+      await waitForExpect(async () => {
+        expect(await RecycledItemDataRepository.count()).toEqual(1);
+      });
+
+      // send subscription as user
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = actor;
+      });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // send restore request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const restore = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/restore?id=${item.id}`,
+      });
+      expect(restore.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [sharedCreate] = memberItemsUpdates;
+        expect(sharedCreate).toMatchObject(SharedItemsEvent('create', serialize(item)));
+      });
     });
 
-    const res = await app.inject({
-      method: HttpMethod.POST,
-      url: `/items/recycle?id=${item.id}`,
-    });
-    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+    it('members with memberships on item in the recycled subtree receive shared items create update when top item is restored', async () => {
+      const anna = await saveMember(ANNA);
+      const { item: parentItem } = await saveItemAndMembership({ member: anna });
+      const { item: childItem } = await saveItemAndMembership({ member: anna, parentItem });
+      await saveMembership({ member: actor, item: childItem, permission: PermissionLevel.Read });
 
-    await waitForExpect(async () => {
-      const [sharedDeleted, recycleCreate] = memberItemsUpdates;
-      expect(recycleCreate).toMatchObject(RecycleBinEvent('create', serialize(item)));
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${parentItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        expect(await RecycledItemDataRepository.count()).toEqual(1);
+      });
+
+      // send subscription as user
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = actor;
+      });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // send restore request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const restore = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/restore?id=${parentItem.id}`,
+      });
+      expect(restore.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [sharedCreate] = memberItemsUpdates;
+        expect(sharedCreate).toMatchObject(SharedItemsEvent('create', serialize(childItem)));
+      });
+    });
+
+    it('members with multiple memberships on related items in the recycled subtree receive shared items create update on topmost shared item only when top item is recycled', async () => {
+      const anna = await saveMember(ANNA);
+      const { item: topItem } = await saveItemAndMembership({ member: anna });
+      const { item: parentItem } = await saveItemAndMembership({
+        member: anna,
+        parentItem: topItem,
+      });
+      const { item: childItem } = await saveItemAndMembership({ member: anna, parentItem });
+      await saveMembership({ member: actor, item: parentItem, permission: PermissionLevel.Read });
+      await saveMembership({ member: actor, item: childItem, permission: PermissionLevel.Admin });
+
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const res = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${parentItem.id}`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        expect(await RecycledItemDataRepository.count()).toEqual(1);
+      });
+
+      // send subscription as user
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = actor;
+      });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // send restore request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const restore = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/restore?id=${parentItem.id}`,
+      });
+      expect(restore.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [sharedCreate] = memberItemsUpdates;
+        expect(sharedCreate).toMatchObject(SharedItemsEvent('create', serialize(parentItem)));
+      });
+    });
+
+    it('admins receive recycle bin delete update when item is recycled', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      await saveMembership({ item, member: actor, permission: PermissionLevel.Admin });
+
+      // send recycle request as admin Anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const recycle = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/recycle?id=${item.id}`,
+      });
+      expect(recycle.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        expect(await RecycledItemDataRepository.count()).toEqual(1);
+      });
+
+      // send subscription as user
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = actor;
+      });
+      const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      const restore = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items/restore?id=${item.id}`,
+      });
+      expect(restore.statusCode).toBe(StatusCodes.ACCEPTED);
+
+      await waitForExpect(async () => {
+        const [recycleDelete, sharedCreate] = memberItemsUpdates;
+        expect(recycleDelete).toMatchObject(RecycleBinEvent('delete', serialize(item)));
+        expect(sharedCreate).toMatchObject(SharedItemsEvent('create', serialize(item)));
+      });
     });
   });
 });

--- a/src/services/item/plugins/recycled/test/ws.test.ts
+++ b/src/services/item/plugins/recycled/test/ws.test.ts
@@ -3,14 +3,26 @@ import waitForExpect from 'wait-for-expect';
 
 import { FastifyInstance } from 'fastify';
 
-import { HttpMethod } from '@graasp/sdk';
+import { HttpMethod, PermissionLevel } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../../test/app';
-import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
+import {
+  saveItemAndMembership,
+  saveMembership,
+} from '../../../../itemMembership/test/fixtures/memberships';
 import { Member } from '../../../../member/entities/member';
+import { ANNA, saveMember } from '../../../../member/test/fixtures/members';
 import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
 import { Item } from '../../../entities/Item';
-import { ItemEvent, SelfItemEvent, itemTopic, memberItemsTopic } from '../../../ws/events';
+import {
+  ChildItemEvent,
+  ItemEvent,
+  OwnItemsEvent,
+  SelfItemEvent,
+  SharedItemsEvent,
+  itemTopic,
+  memberItemsTopic,
+} from '../../../ws/events';
 import { RecycleBinEvent } from '../ws/events';
 
 // mock datasource
@@ -73,6 +85,76 @@ describe('Recycle websocket hooks', () => {
   it('receives deletion update when item is recycled', async () => {
     const { item } = await saveItemAndMembership({ member: actor });
     const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: item.id });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${item.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(() => {
+      const [selfDelete] = itemUpdates;
+      expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(item)));
+    });
+  });
+
+  it('item in the recycled subtree receives deletion update when top item is recycled', async () => {
+    const { item: parentItem } = await saveItemAndMembership({ member: actor });
+    const { item: childItem } = await saveItemAndMembership({ member: actor, parentItem });
+    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: childItem.id });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${parentItem.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(() => {
+      const [selfDelete] = itemUpdates;
+      expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(childItem)));
+    });
+  });
+
+  it('parent item receives child deletion update when child item is recycled', async () => {
+    const { item: parentItem } = await saveItemAndMembership({ member: actor });
+    const { item: childItem } = await saveItemAndMembership({ parentItem, member: actor });
+    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: parentItem.id });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${childItem.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(() => {
+      const [childDelete] = itemUpdates;
+      expect(childDelete).toMatchObject(ChildItemEvent('delete', serialize(childItem)));
+    });
+  });
+
+  it('parent in the recycled subtree receives deletion update of child when top item is recycled', async () => {
+    const { item: topItem } = await saveItemAndMembership({ member: actor });
+    const { item: parentItem } = await saveItemAndMembership({
+      member: actor,
+      parentItem: topItem,
+    });
+    const { item: childItem } = await saveItemAndMembership({ parentItem, member: actor });
+    const itemUpdates = await ws.subscribe<ItemEvent>({ topic: itemTopic, channel: parentItem.id });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${topItem.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(() => {
+      const [selfDelete, childDelete] = itemUpdates;
+      expect(childDelete).toMatchObject(ChildItemEvent('delete', serialize(childItem)));
+    });
+  });
+
+  it('creator receives own items deletion update when item is recycled', async () => {
+    const { item } = await saveItemAndMembership({ member: actor });
     const memberItemsUpdates = await ws.subscribe<ItemEvent>({
       topic: memberItemsTopic,
       channel: actor.id,
@@ -85,9 +167,79 @@ describe('Recycle websocket hooks', () => {
     expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
 
     await waitForExpect(() => {
-      const [selfDelete] = itemUpdates;
-      const [ownDelete, recycleCreate] = memberItemsUpdates;
-      expect(selfDelete).toMatchObject(SelfItemEvent('delete', serialize(item)));
+      const [ownDelete] = memberItemsUpdates;
+      expect(ownDelete).toMatchObject(OwnItemsEvent('delete', serialize(item)));
+    });
+  });
+
+  it('members with memberships receive shared items delete update when item is recycled', async () => {
+    const anna = await saveMember(ANNA);
+    const { item } = await saveItemAndMembership({ member: anna });
+    await saveMembership({ item, member: actor, permission: PermissionLevel.Read });
+    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+      topic: memberItemsTopic,
+      channel: actor.id,
+    });
+
+    // send recycle request as admin Anna
+    jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+      request.member = anna;
+    });
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${item.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(async () => {
+      const [sharedDelete] = memberItemsUpdates;
+      expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(item)));
+    });
+  });
+
+  it('members with memberships on item in the recycled subtree receive shared items delete update when top item is recycled', async () => {
+    const anna = await saveMember(ANNA);
+    const { item: parentItem } = await saveItemAndMembership({ member: anna });
+    const { item: childItem } = await saveItemAndMembership({ member: anna, parentItem });
+    await saveMembership({ item: childItem, member: actor, permission: PermissionLevel.Read });
+    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+      topic: memberItemsTopic,
+      channel: actor.id,
+    });
+
+    // send recycle request as admin Anna
+    jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+      request.member = anna;
+    });
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${parentItem.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(async () => {
+      const [sharedDelete] = memberItemsUpdates;
+      expect(sharedDelete).toMatchObject(SharedItemsEvent('delete', serialize(childItem)));
+    });
+  });
+
+  it('admins receive recycle bin create update when item is recycled', async () => {
+    const anna = await saveMember(ANNA);
+    const { item } = await saveItemAndMembership({ member: anna });
+    await saveMembership({ item, member: actor, permission: PermissionLevel.Admin });
+    const memberItemsUpdates = await ws.subscribe<ItemEvent>({
+      topic: memberItemsTopic,
+      channel: actor.id,
+    });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `/items/recycle?id=${item.id}`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+
+    await waitForExpect(async () => {
+      const [sharedDeleted, recycleCreate] = memberItemsUpdates;
       expect(recycleCreate).toMatchObject(RecycleBinEvent('create', serialize(item)));
     });
   });

--- a/src/services/item/plugins/recycled/ws/events.ts
+++ b/src/services/item/plugins/recycled/ws/events.ts
@@ -1,0 +1,23 @@
+import { Item } from '../../../entities/Item';
+import { ItemEvent } from '../../../ws/events';
+
+/**
+ * Events that affect the recycle bin
+ */
+interface RecycleBinEvent extends ItemEvent {
+  kind: 'recyclebin';
+  op: 'create' | 'delete';
+  item: Item;
+}
+
+/**
+ * Factory of RecycleBinEvent
+ * @param op operation of the event
+ * @param item value of the item for this event
+ * @returns instance of recycle bin event
+ */
+export const RecycleBinEvent = (op: RecycleBinEvent['op'], item: Item): RecycleBinEvent => ({
+  kind: 'recyclebin',
+  op,
+  item,
+});

--- a/src/services/item/plugins/recycled/ws/events.ts
+++ b/src/services/item/plugins/recycled/ws/events.ts
@@ -5,7 +5,7 @@ import { ItemEvent } from '../../../ws/events';
  * Events that affect the recycle bin
  */
 interface RecycleBinEvent extends ItemEvent {
-  kind: 'recyclebin';
+  kind: 'recycle_bin';
   op: 'create' | 'delete';
   item: Item;
 }
@@ -17,7 +17,7 @@ interface RecycleBinEvent extends ItemEvent {
  * @returns instance of recycle bin event
  */
 export const RecycleBinEvent = (op: RecycleBinEvent['op'], item: Item): RecycleBinEvent => ({
-  kind: 'recyclebin',
+  kind: 'recycle_bin',
   op,
   item,
 });

--- a/src/services/item/plugins/recycled/ws/hooks.ts
+++ b/src/services/item/plugins/recycled/ws/hooks.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 
-import { getParentFromPath } from '@graasp/sdk';
+import { PermissionLevel, getParentFromPath } from '@graasp/sdk';
 
 import { WebsocketService } from '../../../../websockets/ws-service';
 import {
@@ -18,68 +18,79 @@ function registerRecycleWsHooks(
   websockets: WebsocketService,
   recycleBinService: RecycledBinService,
 ) {
-  // on recycle item
-  // - notify item itself of (soft) deletion
-  // - notify parent of (soft) deleted child
-  // - notify own items of creator of (soft) deleted item IF path is root
-  // - notify recycled items of TODO:creator?admins?memberships? of new recycled item IF path is root
-  // - notify members that have memberships on this item of (soft) delete
-  recycleBinService.hooks.setPostHook('recycle', async (member, repositories, { item }) => {
-    websockets.publish(itemTopic, item.id, SelfItemEvent('delete', item));
+  // on recycle of an item, this is executed on each node in the recycled tree of this item
+  // on each visited node:
+  // - notify item node itself of (soft) deletion
+  // - notify parent node of (soft) deleted child
+  // - notify own items of creator of (soft) deleted item IF absolute path of node is root
+  // - notify shared items of members that have memberships on this item node of (soft) delete
+  // - notify recycle bin of admins of new recycled item IF recycled path of node is root
+  recycleBinService.hooks.setPostHook(
+    'recycle',
+    async (member, repositories, { item, isRecycledRoot }) => {
+      websockets.publish(itemTopic, item.id, SelfItemEvent('delete', item));
 
-    const parentId = getParentFromPath(item.path);
-    if (parentId !== undefined) {
-      websockets.publish(itemTopic, parentId, ChildItemEvent('delete', item));
-    } else if (item.creator?.id) {
-      // root item, notify creator
-      websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('delete', item));
+      const parentId = getParentFromPath(item.path);
+      if (parentId !== undefined) {
+        websockets.publish(itemTopic, parentId, ChildItemEvent('delete', item));
+      } else if (item.creator?.id) {
+        // root item, notify creator
+        websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('delete', item));
+      }
 
-      // TODO: should send to item.creator.id? members that have membership? admins only?
-      websockets.publish(memberItemsTopic, item.creator.id, RecycleBinEvent('create', item));
-    }
-
-    // TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for delete operation in item hooks
-    const { data: itemIdsToMemberships } =
-      await repositories.itemMembershipRepository.getForManyItems([item]);
-    if (item.id in itemIdsToMemberships) {
+      // item is already soft-deleted so we need withDeleted=true
+      const { data: itemIdsToMemberships } =
+        await repositories.itemMembershipRepository.getForManyItems([item], { withDeleted: true });
       const memberships = itemIdsToMemberships[item.id];
-      memberships.forEach(({ member }) => {
-        if (member.id !== item.creator?.id) {
-          websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('delete', item));
-        }
-      });
-    }
-  });
+
+      if (memberships) {
+        memberships.forEach(({ member, permission }) => {
+          // remove from shared items of all members that have a memberships on this node
+          if (member.id !== item.creator?.id) {
+            websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('delete', item));
+          }
+
+          // send recycled root to recycle bin of all admins of item
+          if (isRecycledRoot && permission === PermissionLevel.Admin) {
+            websockets.publish(memberItemsTopic, member.id, RecycleBinEvent('create', item));
+          }
+        });
+      }
+    },
+  );
 
   // on restore item
   // - notify parent of (re)created child
   // - notify own items of creator of (re)created item IF path is root
   // - notify recycled items of TODO:creator?admins?memberships? of restored item IF path is root
   // - notify members that have memberships on this item of (re)created item TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for delete operation in item hooks
-  recycleBinService.hooks.setPostHook('restore', async (member, repositories, { item }) => {
-    const parentId = getParentFromPath(item.path);
-    if (parentId !== undefined) {
-      websockets.publish(itemTopic, parentId, ChildItemEvent('create', item));
-    } else if (item.creator?.id) {
-      // root item, notify creator
-      websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('create', item));
+  recycleBinService.hooks.setPostHook(
+    'restore',
+    async (member, repositories, { item, isRestoredRoot }) => {
+      const parentId = getParentFromPath(item.path);
+      if (parentId !== undefined) {
+        websockets.publish(itemTopic, parentId, ChildItemEvent('create', item));
+      } else if (item.creator?.id) {
+        // root item, notify creator
+        websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('create', item));
 
-      // TODO: should send to item.creator.id? members that have memberhsip? admins only?
-      websockets.publish(memberItemsTopic, item.creator.id, RecycleBinEvent('delete', item));
-    }
+        // TODO: should send to item.creator.id? members that have memberhsip? admins only?
+        websockets.publish(memberItemsTopic, item.creator.id, RecycleBinEvent('delete', item));
+      }
 
-    // TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for update operation in item hooks
-    const { data: itemIdsToMemberships } =
-      await repositories.itemMembershipRepository.getForManyItems([item]);
-    if (item.id in itemIdsToMemberships) {
-      const memberships = itemIdsToMemberships[item.id];
-      memberships.forEach(({ member }) => {
-        if (member.id !== item.creator?.id) {
-          websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('create', item));
-        }
-      });
-    }
-  });
+      // TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for update operation in item hooks
+      const { data: itemIdsToMemberships } =
+        await repositories.itemMembershipRepository.getForManyItems([item]);
+      if (item.id in itemIdsToMemberships) {
+        const memberships = itemIdsToMemberships[item.id];
+        memberships.forEach(({ member }) => {
+          if (member.id !== item.creator?.id) {
+            websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('create', item));
+          }
+        });
+      }
+    },
+  );
 }
 
 export const recycleWsHooks: FastifyPluginAsync<{ recycleService: RecycledBinService }> = async (

--- a/src/services/item/plugins/recycled/ws/hooks.ts
+++ b/src/services/item/plugins/recycled/ws/hooks.ts
@@ -28,7 +28,7 @@ export function registerRecycleWsHooks(
     const parentId = getParentFromPath(item.path);
     if (parentId !== undefined) {
       websockets.publish(itemTopic, parentId, ChildItemEvent('delete', item));
-    } else {
+    } else if (item.creator?.id) {
       // root item, notify creator
       websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('delete', item));
 
@@ -42,7 +42,7 @@ export function registerRecycleWsHooks(
     if (item.id in itemIdsToMemberships) {
       const memberships = itemIdsToMemberships[item.id];
       memberships.forEach(({ member }) => {
-        if (member.id !== item.creator.id) {
+        if (member.id !== item.creator?.id) {
           websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('delete', item));
         }
       });
@@ -58,7 +58,7 @@ export function registerRecycleWsHooks(
     const parentId = getParentFromPath(item.path);
     if (parentId !== undefined) {
       websockets.publish(itemTopic, parentId, ChildItemEvent('create', item));
-    } else {
+    } else if (item.creator?.id) {
       // root item, notify creator
       websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('create', item));
 
@@ -72,7 +72,7 @@ export function registerRecycleWsHooks(
     if (item.id in itemIdsToMemberships) {
       const memberships = itemIdsToMemberships[item.id];
       memberships.forEach(({ member }) => {
-        if (member.id !== item.creator.id) {
+        if (member.id !== item.creator?.id) {
           websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('create', item));
         }
       });

--- a/src/services/item/plugins/recycled/ws/hooks.ts
+++ b/src/services/item/plugins/recycled/ws/hooks.ts
@@ -1,3 +1,5 @@
+import { FastifyPluginAsync } from 'fastify';
+
 import { getParentFromPath } from '@graasp/sdk';
 
 import { WebsocketService } from '../../../../websockets/ws-service';
@@ -12,7 +14,7 @@ import {
 import { RecycledBinService } from '../service';
 import { RecycleBinEvent } from './events';
 
-export function registerRecycleWsHooks(
+function registerRecycleWsHooks(
   websockets: WebsocketService,
   recycleBinService: RecycledBinService,
 ) {
@@ -79,3 +81,12 @@ export function registerRecycleWsHooks(
     }
   });
 }
+
+export const recycleWsHooks: FastifyPluginAsync<{ recycleService: RecycledBinService }> = async (
+  fastify,
+  options,
+) => {
+  const { websockets } = fastify;
+  const { recycleService } = options;
+  registerRecycleWsHooks(websockets, recycleService);
+};

--- a/src/services/item/plugins/recycled/ws/hooks.ts
+++ b/src/services/item/plugins/recycled/ws/hooks.ts
@@ -1,0 +1,81 @@
+import { getParentFromPath } from '@graasp/sdk';
+
+import { WebsocketService } from '../../../../websockets/ws-service';
+import {
+  ChildItemEvent,
+  OwnItemsEvent,
+  SelfItemEvent,
+  SharedItemsEvent,
+  itemTopic,
+  memberItemsTopic,
+} from '../../../ws/events';
+import { RecycledBinService } from '../service';
+import { RecycleBinEvent } from './events';
+
+export function registerRecycleWsHooks(
+  websockets: WebsocketService,
+  recycleBinService: RecycledBinService,
+) {
+  // on recycle item
+  // - notify item itself of (soft) deletion
+  // - notify parent of (soft) deleted child
+  // - notify own items of creator of (soft) deleted item IF path is root
+  // - notify recycled items of TODO:creator?admins?memberships? of new recycled item IF path is root
+  // - notify members that have memberships on this item of (soft) delete
+  recycleBinService.hooks.setPostHook('recycle', async (member, repositories, { item }) => {
+    websockets.publish(itemTopic, item.id, SelfItemEvent('delete', item));
+
+    const parentId = getParentFromPath(item.path);
+    if (parentId !== undefined) {
+      websockets.publish(itemTopic, parentId, ChildItemEvent('delete', item));
+    } else {
+      // root item, notify creator
+      websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('delete', item));
+
+      // TODO: should send to item.creator.id? members that have membership? admins only?
+      websockets.publish(memberItemsTopic, item.creator.id, RecycleBinEvent('create', item));
+    }
+
+    // TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for delete operation in item hooks
+    const { data: itemIdsToMemberships } =
+      await repositories.itemMembershipRepository.getForManyItems([item]);
+    if (item.id in itemIdsToMemberships) {
+      const memberships = itemIdsToMemberships[item.id];
+      memberships.forEach(({ member }) => {
+        if (member.id !== item.creator.id) {
+          websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('delete', item));
+        }
+      });
+    }
+  });
+
+  // on restore item
+  // - notify parent of (re)created child
+  // - notify own items of creator of (re)created item IF path is root
+  // - notify recycled items of TODO:creator?admins?memberships? of restored item IF path is root
+  // - notify members that have memberships on this item of (re)created item TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for delete operation in item hooks
+  recycleBinService.hooks.setPostHook('restore', async (member, repositories, { item }) => {
+    const parentId = getParentFromPath(item.path);
+    if (parentId !== undefined) {
+      websockets.publish(itemTopic, parentId, ChildItemEvent('create', item));
+    } else {
+      // root item, notify creator
+      websockets.publish(memberItemsTopic, item.creator.id, OwnItemsEvent('create', item));
+
+      // TODO: should send to item.creator.id? members that have memberhsip? admins only?
+      websockets.publish(memberItemsTopic, item.creator.id, RecycleBinEvent('delete', item));
+    }
+
+    // TODO: in an inherited case, only the top-level for the given membership should emit an event. Same for update operation in item hooks
+    const { data: itemIdsToMemberships } =
+      await repositories.itemMembershipRepository.getForManyItems([item]);
+    if (item.id in itemIdsToMemberships) {
+      const memberships = itemIdsToMemberships[item.id];
+      memberships.forEach(({ member }) => {
+        if (member.id !== item.creator.id) {
+          websockets.publish(memberItemsTopic, member.id, SharedItemsEvent('create', item));
+        }
+      });
+    }
+  });
+}

--- a/src/services/item/plugins/validation/service.ts
+++ b/src/services/item/plugins/validation/service.ts
@@ -92,6 +92,8 @@ export class ItemValidationService {
 
     // create validation and execute for each node recursively
     await this._post(member, repositories, item, iVG);
+
+    return item;
   }
 
   async _post(

--- a/src/services/item/plugins/validation/test/index.test.ts
+++ b/src/services/item/plugins/validation/test/index.test.ts
@@ -1,12 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { v4 } from 'uuid';
 
-import {
-  HttpMethod,
-  ItemValidationProcess,
-  ItemValidationStatus,
-  PermissionLevel,
-} from '@graasp/sdk';
+import { HttpMethod, PermissionLevel } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../../test/app';
 import { ITEMS_ROUTE_PREFIX } from '../../../../../utils/config';
@@ -15,30 +10,12 @@ import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/
 import { BOB, saveMember } from '../../../../member/test/fixtures/members';
 import { ItemValidationGroupNotFound } from '../errors';
 import { ItemValidationGroupRepository } from '../repositories/ItemValidationGroup';
-import { ItemValidationRepository } from '../repositories/itemValidation';
+import { saveItemValidation } from './utils';
 
 const VALIDATION_LOADING_TIME = 2000;
 
 // mock datasource
 jest.mock('../../../../../plugins/datasource');
-
-const saveItemValidation = async ({ item }) => {
-  const group = await ItemValidationGroupRepository.save({ item });
-  const itemValidation = await ItemValidationRepository.save({
-    item,
-    process: ItemValidationProcess.BadWordsDetection,
-    status: ItemValidationStatus.Success,
-    result: '',
-    itemValidationGroup: group,
-  });
-
-  // get full item validation group, since save does not include itemvalidation
-  const fullItemValidationGroup = await ItemValidationGroupRepository.findOne({
-    where: { id: group.id },
-    relations: { itemValidations: true, item: true },
-  });
-  return { itemValidationGroup: fullItemValidationGroup, itemValidation };
-};
 
 const expectItemValidation = (iv, correctIV) => {
   expect(iv.id).toEqual(correctIV.id);

--- a/src/services/item/plugins/validation/test/utils.ts
+++ b/src/services/item/plugins/validation/test/utils.ts
@@ -1,0 +1,22 @@
+import { ItemValidationProcess, ItemValidationStatus } from '@graasp/sdk';
+
+import { ItemValidationGroupRepository } from '../repositories/ItemValidationGroup';
+import { ItemValidationRepository } from '../repositories/itemValidation';
+
+export const saveItemValidation = async ({ item }) => {
+  const group = await ItemValidationGroupRepository.save({ item });
+  const itemValidation = await ItemValidationRepository.save({
+    item,
+    process: ItemValidationProcess.BadWordsDetection,
+    status: ItemValidationStatus.Success,
+    result: '',
+    itemValidationGroup: group,
+  });
+
+  // get full item validation group, since save does not include itemvalidation
+  const fullItemValidationGroup = await ItemValidationGroupRepository.findOne({
+    where: { id: group.id },
+    relations: { itemValidations: true, item: true },
+  });
+  return { itemValidationGroup: fullItemValidationGroup, itemValidation };
+};

--- a/src/services/item/plugins/validation/test/ws.test.ts
+++ b/src/services/item/plugins/validation/test/ws.test.ts
@@ -1,0 +1,91 @@
+import { StatusCodes } from 'http-status-codes';
+import waitForExpect from 'wait-for-expect';
+
+import { HttpMethod } from '@graasp/sdk';
+
+import { clearDatabase } from '../../../../../../test/app';
+import { ITEMS_ROUTE_PREFIX } from '../../../../../utils/config';
+import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
+import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
+import { setupWsApp } from '../../../../websockets/test/ws-app';
+import { ItemEvent, ItemOpFeedbackEvent, memberItemsTopic } from '../../../ws/events';
+import { ItemValidationGroupRepository } from '../repositories/ItemValidationGroup';
+import { saveItemValidation } from './utils';
+
+// mock datasource
+jest.mock('../../../../../plugins/datasource');
+
+describe('asynchronous feedback', () => {
+  let app, actor, address;
+  let ws: TestWsClient;
+
+  beforeEach(async () => {
+    ({ app, actor, address } = await setupWsApp());
+    ws = new TestWsClient(address);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase(app.db);
+    actor = null;
+    app.close();
+    ws.close();
+  });
+
+  it('member that initated the validate operation receives success feedback', async () => {
+    const { item } = await saveItemAndMembership({ member: actor });
+    await saveItemValidation({ item });
+
+    const memberUpdates = await ws.subscribe<ItemEvent>({
+      topic: memberItemsTopic,
+      channel: actor.id,
+    });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `${ITEMS_ROUTE_PREFIX}/${item.id}/validate`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+    expect(res.body).toEqual(item.id);
+
+    await waitForExpect(() => {
+      const [feedbackUpdate] = memberUpdates;
+      expect(feedbackUpdate).toMatchObject(
+        ItemOpFeedbackEvent('validate', [item.id], {
+          data: { [item.id]: item },
+          errors: [],
+        }),
+      );
+    });
+  });
+
+  it('member that initated the validate operation receives failure feedback', async () => {
+    const { item } = await saveItemAndMembership({ member: actor });
+    await saveItemValidation({ item });
+
+    const memberUpdates = await ws.subscribe<ItemEvent>({
+      topic: memberItemsTopic,
+      channel: actor.id,
+    });
+
+    jest.spyOn(ItemValidationGroupRepository, 'post').mockImplementation(async () => {
+      throw new Error('mock error');
+    });
+
+    const res = await app.inject({
+      method: HttpMethod.POST,
+      url: `${ITEMS_ROUTE_PREFIX}/${item.id}/validate`,
+    });
+    expect(res.statusCode).toBe(StatusCodes.ACCEPTED);
+    expect(res.body).toEqual(item.id);
+
+    await waitForExpect(() => {
+      const [feedbackUpdate] = memberUpdates;
+      expect(feedbackUpdate).toMatchObject(
+        ItemOpFeedbackEvent('validate', [item.id], {
+          error: new Error('mock error'),
+        }),
+      );
+    });
+  });
+});

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -166,9 +166,9 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
     const { ordered = false } = options ?? {};
 
     const query = this.createQueryBuilder('item')
-      .leftJoinAndSelect('item_creator', 'creator')
+      .leftJoinAndSelect('item.creator', 'creator')
       .where('item.path <@ :path', { path: item.path })
-      .andWhere('id != :id', { id: item.id });
+      .andWhere('item.id != :id', { id: item.id });
 
     if (ordered) {
       query.orderBy('item.path', 'ASC');

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -177,19 +177,23 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
     return query.getMany();
   },
 
-  async getManyDescendants(items: Item[]): Promise<Item[]> {
+  async getManyDescendants(
+    items: Item[],
+    { withDeleted = false }: { withDeleted?: boolean } = {},
+  ): Promise<Item[]> {
     // TODO: LEVEL depth
-<<<<<<< HEAD
     if (items.length === 0) {
       return [];
     }
-=======
->>>>>>> 532b26e (feat: implement recycle hook)
-    const query = this.createQueryBuilder('item')
-      .leftJoinAndSelect('item.creator', 'creator')
-      .where('item.id NOT IN(:...ids)', {
-        ids: items.map(({ id }) => id),
-      });
+    const query = this.createQueryBuilder('item');
+
+    if (withDeleted) {
+      query.withDeleted();
+    }
+
+    query.leftJoinAndSelect('item.creator', 'creator').where('item.id NOT IN(:...ids)', {
+      ids: items.map(({ id }) => id),
+    });
 
     query.andWhere(
       new Brackets((q) => {

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -166,6 +166,7 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
     const { ordered = false } = options ?? {};
 
     const query = this.createQueryBuilder('item')
+      .leftJoinAndSelect('item_creator', 'creator')
       .where('item.path <@ :path', { path: item.path })
       .andWhere('id != :id', { id: item.id });
 
@@ -178,9 +179,12 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
 
   async getManyDescendants(items: Item[]): Promise<Item[]> {
     // TODO: LEVEL depth
+<<<<<<< HEAD
     if (items.length === 0) {
       return [];
     }
+=======
+>>>>>>> 532b26e (feat: implement recycle hook)
     const query = this.createQueryBuilder('item')
       .leftJoinAndSelect('item.creator', 'creator')
       .where('item.id NOT IN(:...ids)', {

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -262,7 +262,7 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
       .getMany();
   },
 
-  async move(item: Item, parentItem?: Item): Promise<void> {
+  async move(item: Item, parentItem?: Item): Promise<Item> {
     if (parentItem) {
       // attaching tree to new parent item
       const { id: parentItemId, path: parentItemPath } = parentItem;
@@ -290,11 +290,14 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
       ? `'${parentItem.path}' || subpath(path, nlevel('${item.path}') - 1)`
       : `subpath(path, nlevel('${item.path}') - 1)`;
 
-    return this.createQueryBuilder('item')
+    await this.createQueryBuilder('item')
       .update()
       .set({ path: () => pathSql })
       .where('item.path <@ :path', { path: item.path })
       .execute();
+
+    // TODO: is there a better way?
+    return this.get(item.id);
   },
 
   async patch(id: string, data: Partial<Item>): Promise<Item> {

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -468,9 +468,7 @@ export class ItemService {
     itemIds: string[],
     args: { parentId?: UUID },
   ) {
-    const items = await Promise.all(
-      itemIds.map(async (id) => this.copy(actor, repositories, id, args)),
-    );
+    const items = await Promise.all(itemIds.map((id) => this.copy(actor, repositories, id, args)));
     return items;
   }
 }

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -8,6 +8,7 @@ import {
   PermissionLevelCompare,
   ResultOf,
   UUID,
+  getParentFromPath,
 } from '@graasp/sdk';
 
 import {
@@ -31,8 +32,20 @@ export class ItemService {
     delete: { pre: { item: Item }; post: { item: Item } };
     copy: { pre: { original: Item }; post: { original: Item; copy: Item } };
     move: {
-      pre: { source: Item; destination: Item };
-      post: { source: Item; destination: Item; updated: Item };
+      pre: {
+        /** the item to be moved itself */
+        source: Item;
+        /** the parent item where the item will be moved */
+        destinationParent?: Item;
+      };
+      post: {
+        /** the item before it was moved */
+        source: Item;
+        /** id of the previous parent */
+        sourceParentId?: UUID;
+        /** the item itself once moved */
+        destination: Item;
+      };
     };
   }>();
 
@@ -329,21 +342,18 @@ export class ItemService {
     // question: invoque on all items?
     await this.hooks.runPreHooks('move', actor, repositories, {
       source: item,
-      destination: parentItem,
+      destinationParent: parentItem,
     });
 
-    await this._move(actor, repositories, item, parentItem);
-
-    const afterMove = await itemRepository.get(itemId);
+    const result = await this._move(actor, repositories, item, parentItem);
 
     await this.hooks.runPostHooks('move', actor, repositories, {
       source: item,
-      destination: parentItem,
-      updated: afterMove,
+      sourceParentId: getParentFromPath(item.path),
+      destination: result,
     });
 
-    // TODO: optimize
-    return afterMove;
+    return result;
   }
 
   // TODO: optimize
@@ -379,7 +389,7 @@ export class ItemService {
       parentItem,
     );
 
-    await itemRepository.move(item, parentItem);
+    const result = await itemRepository.move(item, parentItem);
 
     // adjust memberships to keep the constraints
     if (inserts.length) {
@@ -388,6 +398,8 @@ export class ItemService {
     if (deletes.length) {
       await itemMembershipRepository.deleteMany(deletes);
     }
+
+    return result;
   }
 
   /////// -------- COPY

--- a/src/services/item/test/index.test.ts
+++ b/src/services/item/test/index.test.ts
@@ -1117,6 +1117,7 @@ describe('Item routes tests', () => {
 
     describe('Public', () => {
       it('Returns successfully', async () => {
+        const actor = await MEMBERS_FIXTURES.saveMember(MEMBERS_FIXTURES.BOB);
         ({ app } = await build({ member: null }));
         const parent = await savePublicItem({ item: getDummyItem(), actor });
         const child1 = await savePublicItem({

--- a/src/services/item/test/ws.test.ts
+++ b/src/services/item/test/ws.test.ts
@@ -1,0 +1,139 @@
+import { StatusCodes } from 'http-status-codes';
+import waitForExpect from 'wait-for-expect';
+
+import { HttpMethod, Websocket, parseStringToDate } from '@graasp/sdk';
+
+import { clearDatabase } from '../../../../test/app';
+import { MemberCannotAccess } from '../../../utils/errors';
+import {
+  saveItemAndMembership,
+  saveMembership,
+} from '../../itemMembership/test/fixtures/memberships';
+import { ANNA, saveMember } from '../../member/test/fixtures/members';
+import { TestWsClient } from '../../websockets/test/test-websocket-client';
+import { setupWsApp } from '../../websockets/test/ws-app';
+import { ChildItemEvent, OwnItemsEvent, itemTopic, memberItemsTopic } from '../ws/events';
+import { expectItem, getDummyItem } from './fixtures/items';
+
+// mock datasource
+jest.mock('../../../plugins/datasource');
+
+describe('Item websocket hooks', () => {
+  let app, actor, address;
+  let ws: TestWsClient;
+
+  beforeEach(async () => {
+    ({ app, actor, address } = await setupWsApp());
+    ws = new TestWsClient(address);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase(app.db);
+    actor = null;
+    app.close();
+    ws.close();
+  });
+
+  describe('Subscribe to item', () => {
+    it('subscribes to own item successfully', async () => {
+      const { item } = await saveItemAndMembership({ member: actor });
+      const request = {
+        realm: Websocket.Realms.Notif,
+        topic: itemTopic,
+        channel: item.id,
+        action: Websocket.ClientActions.Subscribe,
+      };
+
+      const res = await ws.send(request);
+      expect(res).toEqual({
+        realm: Websocket.Realms.Notif,
+        type: Websocket.ServerMessageTypes.Response,
+        status: Websocket.ResponseStatuses.Success,
+        request: request,
+      });
+    });
+
+    it('subscribes to item with membership successfully', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      await saveMembership({ item, member: actor });
+      const request = {
+        realm: Websocket.Realms.Notif,
+        topic: itemTopic,
+        channel: item.id,
+        action: Websocket.ClientActions.Subscribe,
+      };
+
+      const res = await ws.send(request);
+      expect(res).toEqual({
+        realm: Websocket.Realms.Notif,
+        type: Websocket.ServerMessageTypes.Response,
+        status: Websocket.ResponseStatuses.Success,
+        request: request,
+      });
+    });
+
+    it('cannot subscribe to item with no membership', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      const request = {
+        realm: Websocket.Realms.Notif,
+        topic: itemTopic,
+        channel: item.id,
+        action: Websocket.ClientActions.Subscribe,
+      };
+
+      const res = await ws.send(request);
+      expect(res).toEqual({
+        realm: Websocket.Realms.Notif,
+        type: Websocket.ServerMessageTypes.Response,
+        status: Websocket.ResponseStatuses.Error,
+        request: request,
+        error: new MemberCannotAccess(item.id),
+      });
+    });
+  });
+
+  describe('on create item', () => {
+    it('parent item receives child item create update', async () => {
+      const { item: parent } = await saveItemAndMembership({ member: actor });
+
+      const itemUpdates = await ws.subscribe({ topic: itemTopic, channel: parent.id });
+
+      const child = getDummyItem();
+      const response = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items?parentId=${parent.id}`,
+        payload: child,
+      });
+      const res = response.json();
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expectItem(res, child, actor, parent);
+
+      await waitForExpect(() => {
+        const [childCreate] = itemUpdates;
+        expect(childCreate).toMatchObject(ChildItemEvent('create', parseStringToDate(res)));
+      });
+    });
+
+    it('creator receives own item create update', async () => {
+      const itemUpdates = await ws.subscribe({ topic: memberItemsTopic, channel: actor.id });
+
+      const item = getDummyItem();
+      const response = await app.inject({
+        method: HttpMethod.POST,
+        url: `/items`,
+        payload: item,
+      });
+      const res = response.json();
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expectItem(res, item, actor);
+
+      await waitForExpect(() => {
+        const [childCreate] = itemUpdates;
+        expect(childCreate).toMatchObject(OwnItemsEvent('create', parseStringToDate(res)));
+      });
+    });
+  });
+});

--- a/src/services/item/ws/events.ts
+++ b/src/services/item/ws/events.ts
@@ -1,7 +1,7 @@
 /**
  * Item websocket events are registered under these topics
  */
-import { Item } from '../entities/Item';
+import { Item, ResultOf } from '@graasp/sdk';
 
 // changes on item entities
 export const itemTopic = 'item';
@@ -90,13 +90,48 @@ interface SharedItemsEvent extends ItemEvent {
 }
 
 /**
- * Facctory of SharedItemsEvent
+ * Factory of SharedItemsEvent
  * @param op operation of the event
  * @param item  value of the item for this event
- * @returns instnace of shared items event
+ * @returns instance of shared items event
  */
 export const SharedItemsEvent = (op: SharedItemsEvent['op'], item: Item): SharedItemsEvent => ({
   kind: 'shared',
   op,
   item,
+});
+
+/**
+ * Events from asynchronous background operations on given items
+ */
+interface ItemOpFeedbackEvent {
+  kind: 'feedback';
+  op: 'update' | 'delete' | 'move' | 'copy' | 'export' | 'recycle' | 'restore' | 'validate';
+  resource: Item['id'][];
+  result:
+    | {
+        error: Error;
+      }
+    | ResultOf<Item>;
+}
+
+/**
+ * Factory of ItemOpFeedbackEvent
+ * @param op operation of the event
+ * @param resource original item ids on which the operation was performed
+ * @param result result of the asynchronous operation
+ * @returns
+ */
+export const ItemOpFeedbackEvent = (
+  op: ItemOpFeedbackEvent['op'],
+  resource: ItemOpFeedbackEvent['resource'],
+  result: ItemOpFeedbackEvent['result'],
+): ItemOpFeedbackEvent => ({
+  kind: 'feedback',
+  op,
+  resource,
+  result: result['error']
+    ? // monkey patch because somehow JSON.stringify(e: Error) will always result in {}
+      { error: { name: result['error'].name, message: result['error'].message } }
+    : result,
 });

--- a/src/services/item/ws/events.ts
+++ b/src/services/item/ws/events.ts
@@ -11,7 +11,7 @@ export const memberItemsTopic = 'item/member';
 /**
  * All websocket events for items will have this shape
  */
-interface ItemEvent {
+export interface ItemEvent {
   kind: string;
   op: string;
   item: Item;
@@ -72,7 +72,7 @@ interface OwnItemsEvent extends ItemEvent {
  * Factory of OwnItemsEvent
  * @param op operation of the event
  * @param item  value of the item for this event
- * @returns instnace of own items event
+ * @returns instance of own items event
  */
 export const OwnItemsEvent = (op: OwnItemsEvent['op'], item: Item): OwnItemsEvent => ({
   kind: 'own',

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -60,10 +60,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
   async get(id: string): Promise<ItemMembership> {
     const item = await this.findOne({
       where: { id },
-      relations: {
-        member: true,
-        item: true,
-      },
+      relations: ['member', 'item', 'item.creator'],
     });
 
     if (!item) {

--- a/src/services/itemMembership/test/ws.test.ts
+++ b/src/services/itemMembership/test/ws.test.ts
@@ -1,0 +1,152 @@
+import { StatusCodes } from 'http-status-codes';
+import waitForExpect from 'wait-for-expect';
+
+import { HttpMethod, PermissionLevel, Websocket } from '@graasp/sdk';
+
+import { clearDatabase } from '../../../../test/app';
+import { MemberCannotAccess } from '../../../utils/errors';
+import { SharedItemsEvent, memberItemsTopic } from '../../item/ws/events';
+import { ANNA, saveMember } from '../../member/test/fixtures/members';
+import { TestWsClient } from '../../websockets/test/test-websocket-client';
+import { setupWsApp } from '../../websockets/test/ws-app';
+import { itemMembershipsTopic } from '../ws/events';
+import { saveItemAndMembership } from './fixtures/memberships';
+
+// mock datasource
+jest.mock('../../../plugins/datasource');
+
+describe('Item websocket hooks', () => {
+  let app, actor, address;
+  let ws: TestWsClient;
+
+  beforeEach(async () => {
+    ({ app, actor, address } = await setupWsApp());
+    ws = new TestWsClient(address);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase(app.db);
+    actor = null;
+    app.close();
+    ws.close();
+  });
+
+  describe('Subscribe to membership', () => {
+    it('subscribes to item memberships successfully', async () => {
+      const { item } = await saveItemAndMembership({ member: actor });
+
+      const request = {
+        realm: Websocket.Realms.Notif,
+        topic: itemMembershipsTopic,
+        channel: item.id,
+        action: Websocket.ClientActions.Subscribe,
+      };
+
+      const res = await ws.send(request);
+      expect(res).toEqual({
+        realm: Websocket.Realms.Notif,
+        type: Websocket.ServerMessageTypes.Response,
+        status: Websocket.ResponseStatuses.Success,
+        request: request,
+      });
+    });
+
+    it('cannot subscribe to item memberships with no membership', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      const request = {
+        realm: Websocket.Realms.Notif,
+        topic: itemMembershipsTopic,
+        channel: item.id,
+        action: Websocket.ClientActions.Subscribe,
+      };
+
+      const res = await ws.send(request);
+      expect(res).toEqual({
+        realm: Websocket.Realms.Notif,
+        type: Websocket.ServerMessageTypes.Response,
+        status: Websocket.ResponseStatuses.Error,
+        request: request,
+        error: new MemberCannotAccess(item.id),
+      });
+    });
+  });
+
+  describe('on create membership', () => {
+    it('member receives shared item create event', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+
+      const memberUpdates = await ws.subscribe({ topic: memberItemsTopic, channel: actor.id });
+
+      // perform request as anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+
+      const response = await app.inject({
+        method: HttpMethod.POST,
+        url: `/item-memberships/${item.id}`,
+        payload: { memberships: [{ memberId: actor.id, permission: PermissionLevel.Read }] },
+      });
+      expect(response.statusCode).toBe(StatusCodes.OK);
+
+      await waitForExpect(() => {
+        const [sharedCreate] = memberUpdates;
+        expect(sharedCreate).toMatchObject(SharedItemsEvent('create', item));
+      });
+    });
+
+    // it('receives item membership create event', async () => {
+    //   const anna = await saveMember(ANNA);
+    //   const bob = await saveMember(BOB);
+    //   const { item } = await saveItemAndMembership({ member: anna });
+    //   await saveMembership({ item, member: bob, permission: PermissionLevel.Read });
+
+    //   /* TODO: wtf??? the mock verifyAuthentication in buildApp is used and not overridden below??? */
+
+    //   // subscribe as bob
+    //   jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+    //     request.member = bob;
+    //   });
+    //   const membershipUpdates = await ws.subscribe({
+    //     topic: itemMembershipsTopic,
+    //     channel: item.id,
+    //   });
+
+    //   // perform request as anna
+    //   jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+    //     request.member = anna;
+    //   });
+    //   const response = await app.inject({
+    //     method: HttpMethod.POST,
+    //     url: `/item-memberships/${item.id}`,
+    //     payload: { memberships: [{ memberId: actor.id, permission: PermissionLevel.Read }] },
+    //   });
+    //   expect(response.statusCode).toBe(StatusCodes.OK);
+    //   const membership = response.json();
+
+    //   await waitForExpect(() => {
+    //     const [sharedCreate] = membershipUpdates;
+    //     expect(sharedCreate).toMatchObject(ItemMembershipEvent('create', membership));
+    //   });
+    // });
+  });
+
+  describe('on update membership', () => {
+    it('receives item membership update event', async () => {
+      // TODO:
+    });
+  });
+
+  describe('on delete membership', () => {
+    it('member receives item membership delete event', async () => {
+      // TODO:
+    });
+
+    it('receives item membership delete event', async () => {
+      // TODO:
+    });
+  });
+});

--- a/src/services/itemMembership/test/ws.test.ts
+++ b/src/services/itemMembership/test/ws.test.ts
@@ -1,16 +1,16 @@
 import { StatusCodes } from 'http-status-codes';
 import waitForExpect from 'wait-for-expect';
 
-import { HttpMethod, PermissionLevel, Websocket } from '@graasp/sdk';
+import { HttpMethod, PermissionLevel, Websocket, parseStringToDate } from '@graasp/sdk';
 
 import { clearDatabase } from '../../../../test/app';
 import { MemberCannotAccess } from '../../../utils/errors';
-import { SharedItemsEvent, memberItemsTopic } from '../../item/ws/events';
-import { ANNA, saveMember } from '../../member/test/fixtures/members';
+import { ItemEvent, SharedItemsEvent, memberItemsTopic } from '../../item/ws/events';
+import { ANNA, BOB, saveMember } from '../../member/test/fixtures/members';
 import { TestWsClient } from '../../websockets/test/test-websocket-client';
 import { setupWsApp } from '../../websockets/test/ws-app';
-import { itemMembershipsTopic } from '../ws/events';
-import { saveItemAndMembership } from './fixtures/memberships';
+import { ItemMembershipEvent, MembershipEvent, itemMembershipsTopic } from '../ws/events';
+import { saveItemAndMembership, saveMembership } from './fixtures/memberships';
 
 // mock datasource
 jest.mock('../../../plugins/datasource');
@@ -78,7 +78,10 @@ describe('Item websocket hooks', () => {
       const anna = await saveMember(ANNA);
       const { item } = await saveItemAndMembership({ member: anna });
 
-      const memberUpdates = await ws.subscribe({ topic: memberItemsTopic, channel: actor.id });
+      const memberUpdates = await ws.subscribe<ItemEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
 
       // perform request as anna
       jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
@@ -98,55 +101,137 @@ describe('Item websocket hooks', () => {
       });
     });
 
-    // it('receives item membership create event', async () => {
-    //   const anna = await saveMember(ANNA);
-    //   const bob = await saveMember(BOB);
-    //   const { item } = await saveItemAndMembership({ member: anna });
-    //   await saveMembership({ item, member: bob, permission: PermissionLevel.Read });
+    it('receives item membership create event', async () => {
+      const anna = await saveMember(ANNA);
+      const bob = await saveMember(BOB);
+      const { item } = await saveItemAndMembership({ member: anna });
+      await saveMembership({
+        item,
+        member: actor,
+        permission: PermissionLevel.Read,
+      });
 
-    //   /* TODO: wtf??? the mock verifyAuthentication in buildApp is used and not overridden below??? */
+      const membershipUpdates = await ws.subscribe<MembershipEvent>({
+        topic: itemMembershipsTopic,
+        channel: item.id,
+      });
 
-    //   // subscribe as bob
-    //   jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
-    //     request.member = bob;
-    //   });
-    //   const membershipUpdates = await ws.subscribe({
-    //     topic: itemMembershipsTopic,
-    //     channel: item.id,
-    //   });
+      // perform request as anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const response = await app.inject({
+        method: HttpMethod.POST,
+        url: `/item-memberships/${item.id}`,
+        payload: { memberships: [{ memberId: bob.id, permission: PermissionLevel.Read }] },
+      });
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      const [membership] = response.json();
 
-    //   // perform request as anna
-    //   jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
-    //     request.member = anna;
-    //   });
-    //   const response = await app.inject({
-    //     method: HttpMethod.POST,
-    //     url: `/item-memberships/${item.id}`,
-    //     payload: { memberships: [{ memberId: actor.id, permission: PermissionLevel.Read }] },
-    //   });
-    //   expect(response.statusCode).toBe(StatusCodes.OK);
-    //   const membership = response.json();
-
-    //   await waitForExpect(() => {
-    //     const [sharedCreate] = membershipUpdates;
-    //     expect(sharedCreate).toMatchObject(ItemMembershipEvent('create', membership));
-    //   });
-    // });
+      await waitForExpect(() => {
+        const [membershipCreate] = membershipUpdates;
+        expect(membershipCreate).toMatchObject(
+          ItemMembershipEvent('create', parseStringToDate(membership)),
+        );
+      });
+    });
   });
 
   describe('on update membership', () => {
     it('receives item membership update event', async () => {
-      // TODO:
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      const membership = await saveMembership({
+        item,
+        member: actor,
+        permission: PermissionLevel.Read,
+      });
+
+      const membershipUpdates = await ws.subscribe<MembershipEvent>({
+        topic: itemMembershipsTopic,
+        channel: item.id,
+      });
+
+      // perform request as anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const response = await app.inject({
+        method: HttpMethod.PATCH,
+        url: `/item-memberships/${membership.id}`,
+        payload: { permission: PermissionLevel.Admin },
+      });
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      const result = response.json();
+
+      await waitForExpect(() => {
+        const [membershipUpdate] = membershipUpdates;
+        expect(membershipUpdate).toMatchObject(
+          ItemMembershipEvent('update', parseStringToDate(result)),
+        );
+      });
     });
   });
 
   describe('on delete membership', () => {
-    it('member receives item membership delete event', async () => {
-      // TODO:
+    it('member receives shared items delete event', async () => {
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      const membership = await saveMembership({
+        item,
+        member: actor,
+        permission: PermissionLevel.Read,
+      });
+
+      const memberUpdates = await ws.subscribe<MembershipEvent>({
+        topic: memberItemsTopic,
+        channel: actor.id,
+      });
+
+      // perform request as anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const response = await app.inject({
+        method: HttpMethod.DELETE,
+        url: `/item-memberships/${membership.id}`,
+      });
+      expect(response.statusCode).toBe(StatusCodes.OK);
+
+      await waitForExpect(() => {
+        const [membershipDelete] = memberUpdates;
+        expect(membershipDelete).toMatchObject(SharedItemsEvent('delete', item));
+      });
     });
 
     it('receives item membership delete event', async () => {
-      // TODO:
+      const anna = await saveMember(ANNA);
+      const { item } = await saveItemAndMembership({ member: anna });
+      const membership = await saveMembership({
+        item,
+        member: actor,
+        permission: PermissionLevel.Read,
+      });
+
+      const membershipUpdates = await ws.subscribe<MembershipEvent>({
+        topic: itemMembershipsTopic,
+        channel: item.id,
+      });
+
+      // perform request as anna
+      jest.spyOn(app, 'verifyAuthentication').mockImplementation(async (request: any) => {
+        request.member = anna;
+      });
+      const response = await app.inject({
+        method: HttpMethod.DELETE,
+        url: `/item-memberships/${membership.id}`,
+      });
+      expect(response.statusCode).toBe(StatusCodes.OK);
+
+      await waitForExpect(() => {
+        const [membershipUpdate] = membershipUpdates;
+        expect(membershipUpdate).toMatchObject(ItemMembershipEvent('delete', membership));
+      });
     });
   });
 });

--- a/src/services/itemMembership/ws/events.ts
+++ b/src/services/itemMembership/ws/events.ts
@@ -9,7 +9,7 @@ export const itemMembershipsTopic = 'memberships/item';
 /**
  * All websocket events for memberships will have this shape
  */
-interface MembershipEvent {
+export interface MembershipEvent {
   kind: string;
   op: string;
   membership: ItemMembership;

--- a/src/services/itemMembership/ws/hooks.ts
+++ b/src/services/itemMembership/ws/hooks.ts
@@ -1,8 +1,7 @@
 import { FastifyPluginAsync } from 'fastify';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { Repositories, buildRepositories } from '../../../utils/repositories';
+import { recycleWsHooks } from '../../item/plugins/recycled/ws/hooks';
 import ItemService from '../../item/service';
 import { SharedItemsEvent, memberItemsTopic } from '../../item/ws/events';
 import { WebsocketService } from '../../websockets/ws-service';
@@ -18,13 +17,16 @@ export function registerItemMembershipWsHooks(
   websockets.register(itemMembershipsTopic, async (req) => {
     const { channel: itemId, member } = req;
     // item must exist with read permission, else exception is thrown
-    await itemService.get(member, repositories, itemId, PermissionLevel.Read);
+    await itemService.get(member, repositories, itemId);
   });
 
   // on create:
   // - notify member of new shared item IF creator != member
   // - notify item itself of new membership
   itemMembershipService.hooks.setPostHook('create', async (member, repositories, membership) => {
+    // TODO: it should probably check that there is no other memberships for this member on the item ancestors
+    // example: if an ancestor already has a membership, then this item should not appear at the top of the member's shared items
+    /** see similar to {@link recycleWsHooks} */
     if (membership.member.id !== membership.item?.creator?.id) {
       websockets.publish(
         memberItemsTopic,
@@ -32,36 +34,60 @@ export function registerItemMembershipWsHooks(
         SharedItemsEvent('create', membership.item),
       );
     }
+
+    // TODO: should it also check that there is no stronger or equal permission for this member on the item ancestors?
+    // example: it should not be possible to create a weaker permission in the subtree of an ancestor that already has a membership
+    /** see similar to {@link recycleWsHooks} */
     websockets.publish(
       itemMembershipsTopic,
       membership.item.id,
       ItemMembershipEvent('create', membership),
     );
+
+    // TODO: should it also iterate over the descendants and send a new membership on each of them IF there is no stronger permission for this member on each?
+    // example: when viewing an item in the subtree of this item, should it receive this permission since it inherits from it? However, this should only be done if this new permission is stronger or equal to any existing one on the child
   });
 
   // on update notify item itself of updated membership
   itemMembershipService.hooks.setPostHook('update', async (member, repositories, membership) => {
+    // TODO: should it check if the change is weaker than a membership on the item ancestors and thus "replace" it with the stronger ancestor one?
+    // example: if an ancestor of this item has permission write, it should not be possible for this child item permission to be changed from admin to write
+    /** see similar to {@link recycleWsHooks} */
     websockets.publish(
       itemMembershipsTopic,
       membership.item.id,
       ItemMembershipEvent('update', membership),
     );
+
+    // TODO: should it also iterate over the descendants and update the membership on each of them IF there is no stronger permission for this member on each?
+    // example: an item in the subtree should inherit this permission update, but if it already had a stronger permission, the latter should take precedence
   });
 
   // on delete
   // - notify member of deleted shared item
   // - notify item itself of deleted membership
   itemMembershipService.hooks.setPostHook('delete', async (member, repositories, membership) => {
+    // TODO: it should probably check that there is no other memberships for this member on the item ancestors
+    // example: if an ancestor already has a membership, then this item was not displayed at the shared root of this member anyway
+    // Deletion is idempotent so we can just ignore in front-end for now
+    /** see similar to {@link recycleWsHooks} */
     websockets.publish(
       memberItemsTopic,
       membership.member.id,
       SharedItemsEvent('delete', membership.item),
     );
+
+    // TODO: should it also check that there is no stronger or equal permission for this member on the item ancestors and thus "replace" it with the stronger ancestor one?
+    // example: if an ancestor of this item has permission write, and the current permission being deleted is admin, then the item should have already received the former membership instead
+    /** see similar to {@link recycleWsHooks} */
     websockets.publish(
       itemMembershipsTopic,
       membership.item.id,
       ItemMembershipEvent('delete', membership),
     );
+
+    // TODO: should it also iterate over the descendants and remove the membership on each of them IF there is no stronger permission for this member on each?
+    // example: an item in the subtree was inheriting this permission, so if it's removed then it should removed from the child item as well, unless there already is a stronger permission on it
   });
 }
 

--- a/src/services/websockets/test/test-utils.ts
+++ b/src/services/websockets/test/test-utils.ts
@@ -6,6 +6,7 @@
 import WebSocket from 'ws';
 
 import fastify from 'fastify';
+import fp from 'fastify-plugin';
 import { FastifyInstance } from 'fastify/types/instance';
 
 import { Websocket } from '@graasp/sdk';
@@ -150,7 +151,7 @@ export async function createWsFastifyInstance(
     // plugin must be registered inside this function parameter as it cannot be
     // added after the instance has already booted
     await setupFn(instance);
-    await instance.register(graaspWebSockets, config);
+    await instance.register(fp(graaspWebSockets), config);
   });
 }
 

--- a/src/services/websockets/test/test-websocket-client.ts
+++ b/src/services/websockets/test/test-websocket-client.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 
-import { Websocket } from '@graasp/sdk';
+import { Websocket, parseStringToDate } from '@graasp/sdk';
 import { ServerUpdate } from '@graasp/sdk/dist/services/websockets/api/server';
 
 /**
@@ -8,15 +8,22 @@ import { ServerUpdate } from '@graasp/sdk/dist/services/websockets/api/server';
  */
 export class TestWsClient {
   private readonly ws: WebSocket;
+  private readonly ready: Promise<void>;
 
   constructor(address: string) {
     this.ws = new WebSocket(address.replace('http', 'ws') + '/ws');
+    this.ready = new Promise((resolve) => {
+      this.ws.on('open', () => {
+        resolve();
+      });
+    });
   }
 
   /**
    * Sends any {@link Websocket.ClientMessage} and return a promise with the response of the server
    */
   async send(payload: Websocket.ClientMessage): Promise<Websocket.ServerResponse> {
+    await this.ready;
     return new Promise((resolve, reject) => {
       const handler = (data) => {
         const message = JSON.parse(data.toString());
@@ -56,7 +63,7 @@ export class TestWsClient {
         update.channel === channel &&
         update.topic === topic
       ) {
-        updates.push(update.body);
+        updates.push(parseStringToDate(update.body));
       }
     });
 

--- a/src/services/websockets/test/test-websocket-client.ts
+++ b/src/services/websockets/test/test-websocket-client.ts
@@ -1,0 +1,60 @@
+import WebSocket from 'ws';
+
+import { Websocket } from '@graasp/sdk';
+import { ServerUpdate } from '@graasp/sdk/dist/services/websockets/api/server';
+
+export class TestWsClient {
+  private readonly ws: WebSocket;
+
+  constructor(address: string) {
+    this.ws = new WebSocket(address.replace('http', 'ws') + '/ws');
+  }
+
+  async send(payload: Websocket.ClientMessage): Promise<Websocket.ServerResponse> {
+    return new Promise((resolve, reject) => {
+      const handler = (data) => {
+        const message = JSON.parse(data.toString());
+        if (message.type === Websocket.ServerMessageTypes.Response) {
+          resolve(message);
+        }
+        this.ws.off('message', handler);
+      };
+
+      this.ws.on('message', handler);
+      this.ws.send(JSON.stringify(payload));
+    });
+  }
+
+  async subscribe<UpdatesType>({ topic, channel }: { topic: string; channel: string }) {
+    const res = await this.send({
+      realm: Websocket.Realms.Notif,
+      action: Websocket.ClientActions.Subscribe,
+      topic,
+      channel,
+    });
+
+    if (res.status !== Websocket.ResponseStatuses.Success) {
+      throw res;
+    }
+
+    /** Ordering is guaranteed in each channel through HTTP semantics */
+    const updates: Array<UpdatesType> = [];
+
+    this.ws.on('message', (data) => {
+      const update: ServerUpdate<UpdatesType> = JSON.parse(data.toString());
+      if (
+        update.type === Websocket.ServerMessageTypes.Update &&
+        update.channel === channel &&
+        update.topic === topic
+      ) {
+        updates.push(update.body);
+      }
+    });
+
+    return updates;
+  }
+
+  close() {
+    this.ws.close();
+  }
+}

--- a/src/services/websockets/test/test-websocket-client.ts
+++ b/src/services/websockets/test/test-websocket-client.ts
@@ -3,6 +3,9 @@ import WebSocket from 'ws';
 import { Websocket } from '@graasp/sdk';
 import { ServerUpdate } from '@graasp/sdk/dist/services/websockets/api/server';
 
+/**
+ * A helper class to mock a purely WS client for the Graasp protocol
+ */
 export class TestWsClient {
   private readonly ws: WebSocket;
 
@@ -10,6 +13,9 @@ export class TestWsClient {
     this.ws = new WebSocket(address.replace('http', 'ws') + '/ws');
   }
 
+  /**
+   * Sends any {@link Websocket.ClientMessage} and return a promise with the response of the server
+   */
   async send(payload: Websocket.ClientMessage): Promise<Websocket.ServerResponse> {
     return new Promise((resolve, reject) => {
       const handler = (data) => {
@@ -25,6 +31,9 @@ export class TestWsClient {
     });
   }
 
+  /**
+   * Sends a subscription to the given topic / channel pair and returns a mutable array of received updates
+   */
   async subscribe<UpdatesType>({ topic, channel }: { topic: string; channel: string }) {
     const res = await this.send({
       realm: Websocket.Realms.Notif,

--- a/src/services/websockets/test/ws-app.ts
+++ b/src/services/websockets/test/ws-app.ts
@@ -1,0 +1,28 @@
+import { FastifyInstance } from 'fastify';
+
+import build from '../../../../test/app';
+import { Member } from '../../member/entities/member';
+
+const MAX_PORT = 65535;
+const MIN_PORT = 1025;
+
+function listenOnRandomPort(app: FastifyInstance): Promise<string> {
+  try {
+    return app.listen({
+      port: Math.floor(Math.random() * (MAX_PORT - MIN_PORT)) + MIN_PORT,
+      host: '0.0.0.0',
+    });
+  } catch (error) {
+    if (error.code === 'EADDRINUSE') {
+      return listenOnRandomPort(app);
+    }
+    throw error;
+  }
+}
+
+export async function setupWsApp({ member }: { member?: Member | null } = {}) {
+  const { app, actor } = await build(member ? { member } : undefined);
+  await app.ready();
+  const address = await listenOnRandomPort(app);
+  return { app, actor, address };
+}

--- a/src/services/websockets/test/ws-app.ts
+++ b/src/services/websockets/test/ws-app.ts
@@ -6,9 +6,9 @@ import { Member } from '../../member/entities/member';
 const MAX_PORT = 65535;
 const MIN_PORT = 1025;
 
-function listenOnRandomPort(app: FastifyInstance): Promise<string> {
+async function listenOnRandomPort(app: FastifyInstance): Promise<string> {
   try {
-    return app.listen({
+    return await app.listen({
       port: Math.floor(Math.random() * (MAX_PORT - MIN_PORT)) + MIN_PORT,
       host: '0.0.0.0',
     });


### PR DESCRIPTION
Adds websockets feedback for missing operations

- [x] Closes #447 (and duplicate #266)
- [x] Closes #265
- [x] Closes #579 
- [x] Item updates (on patch), closes #547 
- [x] Closes #68 
- [x] Async operations (e.g. many) + errors
- [x] Add front-end changes