### PR TITLE
refactor: use MAX_TARGETS_FOR_READ_REQUEST for GET item tag

### DIFF
--- a/src/services/file/repositories/s3.ts
+++ b/src/services/file/repositories/s3.ts
@@ -239,7 +239,7 @@ export class S3FileRepository implements FileRepository {
         throw new S3FileNotFound({ filepath, id });
       }
 
-      throw new DownloadFileUnexpectedError({ filepath, id });
+      throw new DownloadFileUnexpectedError({ filepath, id, e });
     }
   }
 

--- a/src/services/file/utils/errors.ts
+++ b/src/services/file/utils/errors.ts
@@ -138,7 +138,7 @@ export class DownloadFileUnexpectedError extends GraaspFileError {
     super(
       {
         code: 'GPFERR011',
-        statusCode: StatusCodes.BAD_REQUEST,
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         // TODO: change message
         message: FAILURE_MESSAGES.DOWNLOAD_FILE_UNEXPECTED_ERROR,
       },

--- a/src/services/item/plugins/itemTag/schemas.ts
+++ b/src/services/item/plugins/itemTag/schemas.ts
@@ -1,8 +1,6 @@
-import { ItemTagType } from '@graasp/sdk';
+import { ItemTagType, MAX_TARGETS_FOR_READ_REQUEST } from '@graasp/sdk';
 
 import { UUID_REGEX } from '../../../../schemas/global';
-
-const MAX_ITEMS_FOR_GET = 30;
 
 export default {
   $id: 'http://graasp.org/item-tags/',
@@ -97,7 +95,10 @@ const getMany = {
   querystring: {
     allOf: [
       { $ref: 'http://graasp.org/#/definitions/idsQuery' },
-      { type: 'object', properties: { id: { type: 'array', maxItems: MAX_ITEMS_FOR_GET } } },
+      {
+        type: 'object',
+        properties: { id: { type: 'array', maxItems: MAX_TARGETS_FOR_READ_REQUEST } },
+      },
     ],
   },
   response: {


### PR DESCRIPTION
I've used the same constant for get item tag.
I've also modify a little bit an error in s3 (to help debugging).

close #548 