### PR TITLE
fix: export a zip use stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "typeorm": "0.3.17",
     "uuid": "9.0.0",
     "ws": "8.13.0",
-    "yarn": "1.22.19"
+    "yarn": "1.22.19",
+    "yazl": "2.5.1"
   },
   "devDependencies": {
     "@commitlint/cli": "17.6.7",
@@ -125,6 +126,7 @@
     "@types/qs": "6.9.7",
     "@types/striptags": "3.1.1",
     "@types/uuid": "9.0.2",
+    "@types/yazl": "2.4.2",
     "@typescript-eslint/eslint-plugin": "5.60.1",
     "@typescript-eslint/parser": "5.60.1",
     "checksum": "1.0.0",

--- a/src/services/item/plugins/importExport/index.ts
+++ b/src/services/item/plugins/importExport/index.ts
@@ -1,4 +1,8 @@
+import * as fs from 'fs';
+import { mkdir } from 'fs/promises';
 import { StatusCodes } from 'http-status-codes';
+import path from 'path';
+import { v4 } from 'uuid';
 
 import fastifyMultipart from '@fastify/multipart';
 import { FastifyPluginAsync } from 'fastify';
@@ -6,7 +10,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { UnauthorizedMember } from '../../../../utils/errors';
 import { buildRepositories } from '../../../../utils/repositories';
 import { DEFAULT_MAX_FILE_SIZE } from '../file/utils/constants';
-import { ZIP_FILE_MIME_TYPES } from './constants';
+import { TMP_EXPORT_ZIP_FOLDER_PATH, ZIP_FILE_MIME_TYPES } from './constants';
 import { FileIsInvalidArchiveError } from './errors';
 import { zipExport, zipImport } from './schema';
 import { ImportExportService } from './service';
@@ -91,12 +95,57 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     url: '/zip-export/:itemId',
     schema: zipExport,
     preHandler: fastify.attemptVerifyAuthentication,
-    handler: async ({ member, params: { itemId }, log }, reply) => {
-      return importExportService.export(member, buildRepositories(), {
-        itemId,
+    handler: async (request, reply) => {
+      const {
+        member,
+        params: { itemId },
+        log,
+      } = request;
+      const repositories = buildRepositories();
+
+      // check item and permission
+      const item = await iS.get(member, repositories, itemId);
+
+      // TODO: The following won't be necessary anymore once h5p stops using the filestorage
+      // path to save files temporarly and save archive
+      // use random id in case many export request happen
+      const fileStorage = path.join(TMP_EXPORT_ZIP_FOLDER_PATH, item.id, v4());
+      await mkdir(fileStorage, { recursive: true });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      request.fileStorage = fileStorage;
+
+      // generate archive stream
+      const archiveStream = await importExportService.export(member, repositories, {
+        item,
         reply,
         log,
+        fileStorage,
       });
+      try {
+        reply.raw.setHeader(
+          'Content-Disposition',
+          `filename="${encodeURIComponent(item.name)}.zip"`,
+        );
+      } catch (e) {
+        // TODO: send sentry error
+        log?.error(e);
+        reply.raw.setHeader('Content-Disposition', 'filename="download.zip"');
+      }
+      reply.type('application/octet-stream');
+      return archiveStream.outputStream;
+    },
+    onResponse: (request) => {
+      // TODO: The following won't be necessary anymore once h5p stops using the filestorage
+      // delete tmp zip folder after endpoint responded
+      // does not delete the full folder since another user could have requested it
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (fs.existsSync(request.fileStorage)) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        fs.rmSync(request.fileStorage, { recursive: true });
+      }
     },
   });
 };

--- a/src/services/item/plugins/importExport/index.ts
+++ b/src/services/item/plugins/importExport/index.ts
@@ -91,10 +91,11 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     url: '/zip-export/:itemId',
     schema: zipExport,
     preHandler: fastify.attemptVerifyAuthentication,
-    handler: async ({ member, params: { itemId } }, reply) => {
+    handler: async ({ member, params: { itemId }, log }, reply) => {
       return importExportService.export(member, buildRepositories(), {
         itemId,
         reply,
+        log,
       });
     },
   });

--- a/src/services/item/plugins/importExport/index.ts
+++ b/src/services/item/plugins/importExport/index.ts
@@ -33,6 +33,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     h5p: h5pService,
   } = fastify;
 
+  // todo: need this line for export storage, remove when we don't use storage anymore
+  fastify.decorateRequest('fileStorage', '');
+
   const importExportService = new ImportExportService(fS, iS, h5pService);
 
   fastify.register(fastifyMultipart, {
@@ -119,7 +122,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       // use random id in case many export request happen
       const fileStorage = path.join(TMP_EXPORT_ZIP_FOLDER_PATH, itemId, v4());
       await mkdir(fileStorage, { recursive: true });
-      fastify.decorateRequest('fileStorage', fileStorage);
+      request.fileStorage = fileStorage;
 
       // generate archive stream
       const archiveStream = await importExportService.export(member, repositories, {

--- a/src/services/item/plugins/importExport/index.ts
+++ b/src/services/item/plugins/importExport/index.ts
@@ -139,12 +139,16 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       // TODO: The following won't be necessary anymore once h5p stops using the filestorage
       // delete tmp zip folder after endpoint responded
       // does not delete the full folder since another user could have requested it
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      if (fs.existsSync(request.fileStorage)) {
+      try {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        fs.rmSync(request.fileStorage, { recursive: true });
+        if (fs.existsSync(request.fileStorage)) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          fs.rmSync(request.fileStorage, { recursive: true });
+        }
+      } catch (e) {
+        request.log.error(e);
       }
     },
   });

--- a/src/services/item/plugins/importExport/service.ts
+++ b/src/services/item/plugins/importExport/service.ts
@@ -1,10 +1,11 @@
-import archiver, { Archiver } from 'archiver';
 import fs, { existsSync } from 'fs';
 import { mkdir, readFile } from 'fs/promises';
 import mime from 'mime-types';
 import mmm from 'mmmagic';
+import fetch from 'node-fetch';
 import path from 'path';
 import util from 'util';
+import yazl, { ZipFile } from 'yazl';
 
 import { FastifyBaseLogger, FastifyReply } from 'fastify';
 
@@ -200,7 +201,7 @@ export class ImportExportService {
       reply;
       item: Item;
       archiveRootPath: string;
-      archive: Archiver;
+      archive: ZipFile;
       fileStorage: string;
     },
   ) {
@@ -208,9 +209,10 @@ export class ImportExportService {
 
     // save description in file
     if (item.description) {
-      archive.append(item.description, {
-        name: path.join(archiveRootPath, `${item.name}${DESCRIPTION_EXTENSION}`),
-      });
+      archive.addBuffer(
+        Buffer.from(item.description),
+        path.join(archiveRootPath, `${item.name}${DESCRIPTION_EXTENSION}`),
+      );
     }
 
     switch (item.type) {
@@ -220,10 +222,9 @@ export class ImportExportService {
         const { mimetype } =
           (item.extra[ItemType.S3_FILE] as S3FileItemExtra) ||
           (item.extra[ItemType.LOCAL_FILE] as LocalFileItemExtra);
-        const fileStream = await this.fileItemService.download(actor, repositories, {
-          fileStorage,
+        const url = (await this.fileItemService.download(actor, repositories, {
           itemId: item.id,
-        });
+        })) as string;
 
         // build filename with extension if does not exist
         let ext = path.extname(item.name);
@@ -234,54 +235,54 @@ export class ImportExportService {
         const filename = `${path.basename(item.name, ext)}${ext}`;
 
         // add file in archive
-        archive.append(fileStream, {
-          name: path.join(archiveRootPath, filename),
-        });
+        const res = await fetch(url);
+        archive.addReadStream(res.body, path.join(archiveRootPath, filename));
 
         break;
       }
       case ItemType.H5P: {
-        const fileStream = await this.h5pService.downloadH5P(
+        // todo: improve, do not save in tmp file
+        const fileStream = (await this.h5pService.downloadH5P(
           item as H5PItemType,
           actor,
           fileStorage,
-        );
+        )) as NodeJS.ReadableStream;
 
-        archive.append(fileStream, {
-          name: path.join(archiveRootPath, item.name),
-        });
+        archive.addReadStream(fileStream, path.join(archiveRootPath, item.name));
 
         break;
       }
-      case ItemType.DOCUMENT:
-        archive.append((item.extra.document as DocumentItemExtraProperties)?.content, {
-          name: path.join(archiveRootPath, `${item.name}${GRAASP_DOCUMENT_EXTENSION}`),
-        });
+      case ItemType.DOCUMENT: {
+        archive.addBuffer(
+          Buffer.from((item.extra.document as DocumentItemExtraProperties)?.content, 'utf-8'),
+          path.join(archiveRootPath, `${item.name}${GRAASP_DOCUMENT_EXTENSION}`),
+        );
         break;
+      }
       case ItemType.LINK:
-        archive.append(
-          buildTextContent(
-            (item.extra.embeddedLink as EmbeddedLinkItemExtraProperties)?.url,
-            ItemType.LINK,
+        archive.addBuffer(
+          Buffer.from(
+            buildTextContent(
+              (item.extra.embeddedLink as EmbeddedLinkItemExtraProperties)?.url,
+              ItemType.LINK,
+            ),
           ),
-          {
-            name: path.join(archiveRootPath, `${item.name}${LINK_EXTENSION}`),
-          },
+          path.join(archiveRootPath, `${item.name}${LINK_EXTENSION}`),
         );
         break;
       case ItemType.APP:
-        archive.append(
-          buildTextContent((item.extra.app as AppItemExtraProperties)?.url, ItemType.APP),
-          {
-            name: path.join(archiveRootPath, `${item.name}${LINK_EXTENSION}`),
-          },
+        archive.addBuffer(
+          Buffer.from(
+            buildTextContent((item.extra.app as AppItemExtraProperties)?.url, ItemType.APP),
+          ),
+          path.join(archiveRootPath, `${item.name}${LINK_EXTENSION}`),
         );
         break;
       case ItemType.FOLDER: {
         // append description
         const folderPath = path.join(archiveRootPath, item.name);
         const children = await repositories.itemRepository.getChildren(item);
-        await Promise.all(
+        const result = await Promise.all(
           children.map((child) =>
             this._addItemToZip(actor, repositories, {
               item: child,
@@ -292,6 +293,10 @@ export class ImportExportService {
             }),
           ),
         );
+        // add empty folder
+        if (!result.length) {
+          archive.addEmptyDirectory(folderPath);
+        }
         break;
       }
     }
@@ -300,21 +305,21 @@ export class ImportExportService {
   async export(
     actor: Actor,
     repositories: Repositories,
-    { itemId, reply }: { itemId: UUID; reply: FastifyReply },
+    { itemId, reply, log }: { itemId: UUID; reply: FastifyReply; log?: FastifyBaseLogger },
   ) {
     // check item and permission
     const item = await this.itemService.get(actor, repositories, itemId);
 
     // init archive
-    const archive = archiver.create('zip', { store: true });
-    archive.on('warning', function (err) {
+    const archive = new yazl.ZipFile();
+    archive.outputStream.on('warning', function (err) {
       if (err.code === 'ENOENT') {
         // log.debug(err);
       } else {
         throw err;
       }
     });
-    archive.on('error', function (err) {
+    archive.outputStream.on('error', function (err) {
       throw err;
     });
 
@@ -323,7 +328,9 @@ export class ImportExportService {
     await mkdir(fileStorage, { recursive: true });
     const zipPath = path.join(fileStorage, item.id + '.zip');
     const zipStream = fs.createWriteStream(zipPath);
-    archive.pipe(zipStream);
+    archive.outputStream.pipe(zipStream).on('close', function () {
+      log?.debug('export done');
+    });
 
     // path used to index files in archive
     const rootPath = path.dirname('./');
@@ -342,7 +349,7 @@ export class ImportExportService {
     // wait for zip to be completely created and send it
     return new Promise((resolve, reject) => {
       zipStream.on('error', (e) => {
-        console.error(e);
+        log?.error(e);
         reject(e);
       });
 
@@ -356,23 +363,22 @@ export class ImportExportService {
           );
         } catch (e) {
           // TODO: send sentry error
-          console.error(e);
+          log?.error(e);
           reply.raw.setHeader('Content-Disposition', 'filename="download.zip"');
         }
         reply.raw.setHeader('Content-Length', Buffer.byteLength(buffer));
         reply.type('application/zip');
 
-        // delete tmp files after endpoint responded
-        if (fs.existsSync(fileStorage)) {
-          fs.rmSync(fileStorage, { recursive: true });
-        } else {
-          //  log?.error(`${fileStorage} was not found, and was not deleted`);
+        // delete tmp zip after endpoint responded
+        // does not delete the full folder since another user could have requested it
+        if (fs.existsSync(zipPath)) {
+          fs.rmSync(zipPath, { recursive: true });
         }
 
         resolve(buffer);
       });
 
-      archive.finalize();
+      archive.end();
     });
   }
 

--- a/src/services/item/plugins/importExport/service.ts
+++ b/src/services/item/plugins/importExport/service.ts
@@ -296,15 +296,8 @@ export class ImportExportService {
   ) {
     // init archive
     const archive = new yazl.ZipFile();
-    archive.outputStream.on('warning', function (err) {
-      if (err.code === 'ENOENT') {
-        // log.debug(err);
-      } else {
-        throw err;
-      }
-    });
     archive.outputStream.on('error', function (err) {
-      throw err;
+      throw new UnexpectedExportError(err);
     });
 
     // path used to index files in archive

--- a/src/services/item/plugins/importExport/test/index.test.ts
+++ b/src/services/item/plugins/importExport/test/index.test.ts
@@ -8,6 +8,7 @@ import waitForExpect from 'wait-for-expect';
 import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../../test/app';
+import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
 import { ItemRepository } from '../../../repository';
 import * as ARCHIVE_CONTENT from './fixtures/archive';
 
@@ -163,6 +164,21 @@ describe('Member routes tests', () => {
       });
 
       expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    });
+  });
+
+  describe('POST /zip-export', () => {
+    it.only('Export successfully if signed in', async () => {
+      ({ app, actor } = await build());
+      const { item } = await saveItemAndMembership({ member: actor });
+
+      const response = await app.inject({
+        method: HttpMethod.GET,
+        url: `/items/zip-export/${item.id}`,
+      });
+
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expect(response.headers['content-disposition']).toContain(item.name);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4448,6 +4448,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/yazl@npm:2.4.2":
+  version: 2.4.2
+  resolution: "@types/yazl@npm:2.4.2"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3be9676f83f2e48e7a2b2ca204cde23f518e65a90d38ff64813804a7d928921c0e9132bb1619077cf19d0d8d86113fa016faf9352813c648e92fef6bf9c960bd
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:5.60.1":
   version: 5.60.1
   resolution: "@typescript-eslint/eslint-plugin@npm:5.60.1"
@@ -7339,6 +7348,7 @@ __metadata:
     "@types/sharp": 0.31.1
     "@types/striptags": 3.1.1
     "@types/uuid": 9.0.2
+    "@types/yazl": 2.4.2
     "@typescript-eslint/eslint-plugin": 5.60.1
     "@typescript-eslint/parser": 5.60.1
     archiver: 5.3.1
@@ -7390,6 +7400,7 @@ __metadata:
     wait-for-expect: 3.0.2
     ws: 8.13.0
     yarn: 1.22.19
+    yazl: 2.5.1
   languageName: unknown
   linkType: soft
 
@@ -12017,6 +12028,15 @@ __metadata:
     buffer-crc32: ~0.2.3
     fd-slicer: ~1.1.0
   checksum: 7f21fe0bbad6e2cb130044a5d1d0d5a0e5bf3d8d4f8c4e6ee12163ce798fee3de7388d22a7a0907f563ac5f9d40f8699a223d3d5c1718da90b0156da6904022b
+  languageName: node
+  linkType: hard
+
+"yazl@npm:2.5.1":
+  version: 2.5.1
+  resolution: "yazl@npm:2.5.1"
+  dependencies:
+    buffer-crc32: ~0.2.3
+  checksum: daec5154b5485d8621bfea359e905ddca0b2f068430a4aa0a802bf5d67391157a383e0c2767acccbf5964264851da643bc740155a9458e2d8dce55b94c1cc2ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR refactor `/zip-export` to use `yazl`. This library is supposed to handle streams, so we don't need to download all the files temporarly.

Currently h5p still saves its own temporary file. But this can be handled in a refactor for the download method of `FileService`.

close #537 
close #516 