### PR TITLE
fix: align file name truncation with item name limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/view": "7.4.1",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "github:graasp/graasp-sdk#260-add-maximum-item-name-length-constant",
+    "@graasp/sdk": "1.4.0",
     "@graasp/translations": "1.15.0",
     "@sentry/node": "7.64.0",
     "@sentry/tracing": "7.64.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/view": "7.4.1",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "1.2.0",
+    "@graasp/sdk": "github:graasp/graasp-sdk#260-add-maximum-item-name-length-constant",
     "@graasp/translations": "1.15.0",
     "@sentry/node": "7.64.0",
     "@sentry/tracing": "7.64.0",

--- a/src/services/item/constants.ts
+++ b/src/services/item/constants.ts
@@ -1,1 +1,0 @@
-export const MAX_ITEM_NAME_LENGTH = 500;

--- a/src/services/item/constants.ts
+++ b/src/services/item/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_ITEM_NAME_LENGTH = 500;

--- a/src/services/item/entities/Item.ts
+++ b/src/services/item/entities/Item.ts
@@ -27,6 +27,7 @@ import {
 } from '@graasp/sdk';
 
 import { Member } from '../../member/entities/member';
+import { MAX_ITEM_NAME_LENGTH } from '../constants';
 import { DocumentExtra } from '../plugins/document';
 
 export type ItemExtra =
@@ -49,7 +50,7 @@ export class Item extends BaseEntity implements GraaspItem {
   id: string = v4();
 
   @Column({
-    length: 500,
+    length: MAX_ITEM_NAME_LENGTH,
     nullable: false,
   })
   name: string;

--- a/src/services/item/entities/Item.ts
+++ b/src/services/item/entities/Item.ts
@@ -22,12 +22,12 @@ import {
   ItemSettings,
   ItemType,
   LocalFileItemExtra,
+  MAX_ITEM_NAME_LENGTH,
   S3FileItemExtra,
   ShortcutItemExtra,
 } from '@graasp/sdk';
 
 import { Member } from '../../member/entities/member';
-import { MAX_ITEM_NAME_LENGTH } from '../constants';
 import { DocumentExtra } from '../plugins/document';
 
 export type ItemExtra =

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -3,12 +3,12 @@ import S, { JSONSchema, ObjectSchema } from 'fluent-json-schema';
 
 import {
   ItemType,
+  MAX_ITEM_NAME_LENGTH,
   MAX_TARGETS_FOR_MODIFY_REQUEST,
   MAX_TARGETS_FOR_READ_REQUEST,
 } from '@graasp/sdk';
 
 import { error, idParam, idsQuery, uuid } from '../../schemas/fluent-schema';
-import { MAX_ITEM_NAME_LENGTH } from './constants';
 
 /**
  * for serialization

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -8,6 +8,7 @@ import {
 } from '@graasp/sdk';
 
 import { error, idParam, idsQuery, uuid } from '../../schemas/fluent-schema';
+import { MAX_ITEM_NAME_LENGTH } from './constants';
 
 /**
  * for serialization
@@ -53,7 +54,7 @@ export const item = S.object()
 // type 'base' (empty extra {})
 export const baseItemCreate = S.object()
   .additionalProperties(false)
-  .prop('name', S.string().minLength(1).pattern('^\\S[ \\S]*$'))
+  .prop('name', S.string().minLength(1).maxLength(MAX_ITEM_NAME_LENGTH).pattern('^\\S[ \\S]*$'))
   .prop('description', S.string())
   .prop('type', S.const('base'))
   .prop('extra', S.object().additionalProperties(false))

--- a/src/services/item/plugins/app/appSetting/plugins/file/service.ts
+++ b/src/services/item/plugins/app/appSetting/plugins/file/service.ts
@@ -9,12 +9,11 @@ import { ItemNotFound, UnauthorizedMember } from '../../../../../../../utils/err
 import { Repositories } from '../../../../../../../utils/repositories';
 import FileService from '../../../../../../file/service';
 import { Member } from '../../../../../../member/entities/member';
+import { MAX_ITEM_NAME_LENGTH } from '../../../../../constants';
 import ItemService from '../../../../../service';
 import { AppSetting } from '../../appSettings';
 import { NotAppSettingFile } from '../../errors';
 import { AppSettingService } from '../../service';
-
-const ORIGINAL_FILENAME_TRUNCATE_LIMIT = 20;
 
 class AppSettingFileService {
   appSettingService: AppSettingService;
@@ -68,7 +67,7 @@ class AppSettingFileService {
           (fields[key] as unknown as { value: string })?.value,
         ]),
       );
-      name = fileBody?.name?.substring(0, ORIGINAL_FILENAME_TRUNCATE_LIMIT) ?? 'file';
+      name = fileBody?.name?.substring(0, MAX_ITEM_NAME_LENGTH) ?? 'file';
     }
     // TODO: REMOVE???
     // remove undefined values

--- a/src/services/item/plugins/app/appSetting/plugins/file/service.ts
+++ b/src/services/item/plugins/app/appSetting/plugins/file/service.ts
@@ -3,13 +3,12 @@ import { v4 } from 'uuid';
 
 import { MultipartFile } from '@fastify/multipart';
 
-import { FileItemProperties, UUID } from '@graasp/sdk';
+import { FileItemProperties, MAX_ITEM_NAME_LENGTH, UUID } from '@graasp/sdk';
 
 import { ItemNotFound, UnauthorizedMember } from '../../../../../../../utils/errors';
 import { Repositories } from '../../../../../../../utils/repositories';
 import FileService from '../../../../../../file/service';
 import { Member } from '../../../../../../member/entities/member';
-import { MAX_ITEM_NAME_LENGTH } from '../../../../../constants';
 import ItemService from '../../../../../service';
 import { AppSetting } from '../../appSettings';
 import { NotAppSettingFile } from '../../errors';

--- a/src/services/item/plugins/file/service.ts
+++ b/src/services/item/plugins/file/service.ts
@@ -12,11 +12,10 @@ import FileService from '../../../file/service';
 import { UploadEmptyFileError } from '../../../file/utils/errors';
 import { Actor, Member } from '../../../member/entities/member';
 import { randomHexOf4 } from '../../../utils';
+import { MAX_ITEM_NAME_LENGTH } from '../../constants';
 import ItemService from '../../service';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { StorageExceeded } from './utils/errors';
-
-const ORIGINAL_FILENAME_TRUNCATE_LIMIT = 500;
 
 type Options = {
   maxMemberStorage: number;
@@ -120,7 +119,7 @@ class FileItemService {
       }
 
       // create item from file properties
-      const name = filename.substring(0, ORIGINAL_FILENAME_TRUNCATE_LIMIT);
+      const name = filename.substring(0, MAX_ITEM_NAME_LENGTH);
       const item = {
         name,
         description,

--- a/src/services/item/plugins/file/service.ts
+++ b/src/services/item/plugins/file/service.ts
@@ -1,31 +1,22 @@
 import path from 'path';
 import { PassThrough, Readable } from 'stream';
 
-import { MultipartFields, MultipartFile } from '@fastify/multipart';
+import { MultipartFields } from '@fastify/multipart';
 import { FastifyReply } from 'fastify';
 
-import {
-  FileItemProperties,
-  ItemType,
-  LocalFileItemExtra,
-  MimeTypes,
-  PermissionLevel,
-  S3FileItemExtra,
-} from '@graasp/sdk';
+import { FileItemProperties, ItemType, MimeTypes, PermissionLevel } from '@graasp/sdk';
 
-import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import { validatePermission } from '../../../authorization';
 import FileService from '../../../file/service';
 import { UploadEmptyFileError } from '../../../file/utils/errors';
 import { Actor, Member } from '../../../member/entities/member';
 import { randomHexOf4 } from '../../../utils';
-import { Item } from '../../entities/Item';
 import ItemService from '../../service';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { StorageExceeded } from './utils/errors';
 
-const ORIGINAL_FILENAME_TRUNCATE_LIMIT = 20;
+const ORIGINAL_FILENAME_TRUNCATE_LIMIT = 500;
 
 type Options = {
   maxMemberStorage: number;

--- a/src/services/item/plugins/file/service.ts
+++ b/src/services/item/plugins/file/service.ts
@@ -4,7 +4,13 @@ import { PassThrough, Readable } from 'stream';
 import { MultipartFields } from '@fastify/multipart';
 import { FastifyReply } from 'fastify';
 
-import { FileItemProperties, ItemType, MimeTypes, PermissionLevel } from '@graasp/sdk';
+import {
+  FileItemProperties,
+  ItemType,
+  MAX_ITEM_NAME_LENGTH,
+  MimeTypes,
+  PermissionLevel,
+} from '@graasp/sdk';
 
 import { Repositories } from '../../../../utils/repositories';
 import { validatePermission } from '../../../authorization';
@@ -12,7 +18,6 @@ import FileService from '../../../file/service';
 import { UploadEmptyFileError } from '../../../file/utils/errors';
 import { Actor, Member } from '../../../member/entities/member';
 import { randomHexOf4 } from '../../../utils';
-import { MAX_ITEM_NAME_LENGTH } from '../../constants';
 import ItemService from '../../service';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { StorageExceeded } from './utils/errors';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,9 +2336,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#260-add-maximum-item-name-length-constant":
-  version: 1.3.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=05bec5e217cd2aa09c2180d9b75b059241af3740"
+"@graasp/sdk@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@graasp/sdk@npm:1.4.0"
   dependencies:
     "@aws-sdk/client-s3": 3.370.0
     "@fastify/secure-session": 6.1.0
@@ -2351,7 +2351,7 @@ __metadata:
     typeorm: 0.3.17
     uuid: 9.0.0
     validator: 13.11.0
-  checksum: a23e97f995746e1dcb2dfc176caaf0719c32e28d0765add4232c320fb52c932ed0968ab8be2281ecc90dc57e2837bf07ff432f83a6cd875325dc0b38a26a7df8
+  checksum: 224ed990ed7b68fe4b463d2d1e24fc503c5f5434703cb818a54d22ee9aa8e9997c3a02768ceec082bea604853aa4804ac4d454c746e38089e3e327e0ffcd4c27
   languageName: node
   linkType: hard
 
@@ -7132,7 +7132,7 @@ __metadata:
     "@fastify/view": 7.4.1
     "@fastify/websocket": 7.2.0
     "@graasp/etherpad-api": 2.1.1
-    "@graasp/sdk": "github:graasp/graasp-sdk#260-add-maximum-item-name-length-constant"
+    "@graasp/sdk": 1.4.0
     "@graasp/translations": 1.15.0
     "@sentry/node": 7.64.0
     "@sentry/tracing": 7.64.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,22 +2336,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@graasp/sdk@npm:1.2.0"
+"@graasp/sdk@github:graasp/graasp-sdk#260-add-maximum-item-name-length-constant":
+  version: 1.3.0
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=05bec5e217cd2aa09c2180d9b75b059241af3740"
   dependencies:
     "@aws-sdk/client-s3": 3.370.0
     "@fastify/secure-session": 6.1.0
     "@graasp/etherpad-api": 2.1.1
     fastify: 4.18.0
     fluent-json-schema: 4.1.0
-    immutable: 4.3.1
+    immutable: 4.3.2
     js-cookie: 3.0.5
     qs: 6.11.2
     typeorm: 0.3.17
     uuid: 9.0.0
-    validator: 13.9.0
-  checksum: 478eeff4f2c505876b6e555c64ab41176c636d971c2012ffbf7196d242ed04807286b34f281f5aa063e5cc82b14eb47a7fb6ba631073906ae78aea31807e53eb
+    validator: 13.11.0
+  checksum: a23e97f995746e1dcb2dfc176caaf0719c32e28d0765add4232c320fb52c932ed0968ab8be2281ecc90dc57e2837bf07ff432f83a6cd875325dc0b38a26a7df8
   languageName: node
   linkType: hard
 
@@ -7132,7 +7132,7 @@ __metadata:
     "@fastify/view": 7.4.1
     "@fastify/websocket": 7.2.0
     "@graasp/etherpad-api": 2.1.1
-    "@graasp/sdk": 1.2.0
+    "@graasp/sdk": "github:graasp/graasp-sdk#260-add-maximum-item-name-length-constant"
     "@graasp/translations": 1.15.0
     "@sentry/node": 7.64.0
     "@sentry/tracing": 7.64.0
@@ -7496,10 +7496,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:4.3.1":
-  version: 4.3.1
-  resolution: "immutable@npm:4.3.1"
-  checksum: a3a5ba29bd43f3f9a2e4d599763d7455d11a0ea57e50bf43f2836672fc80003e90d69f2a4f5b589f1f3d6986faf97f08ce1e253583740dd33c00adebab88b217
+"immutable@npm:4.3.2":
+  version: 4.3.2
+  resolution: "immutable@npm:4.3.2"
+  checksum: bb1d0f3eb8ebef04aa9e2c698ba1a248976a4dc0257fa2f1bffaaae575f891395fe9ef39eaf49856d6c4edd31704e300ec563ed44ea9d7c7996186deab91d0ff
   languageName: node
   linkType: hard
 
@@ -11616,10 +11616,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:13.9.0":
-  version: 13.9.0
-  resolution: "validator@npm:13.9.0"
-  checksum: e2c936f041f61faa42bafd17c6faddf939498666cd82e88d733621c286893730b008959f4cb12ab3e236148a4f3805c30b85e3dcf5e0efd8b0cbcd36c02bfc0c
+"validator@npm:13.11.0":
+  version: 13.11.0
+  resolution: "validator@npm:13.11.0"
+  checksum: d1e0c27022681420756da25bc03eb08d5f0c66fb008f8ff02ebc95812b77c6be6e03d3bd05cf80ca702e23eeb73dadd66b4b3683173ea2a0bc7cc72820bee131
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR aligns the truncation length of uploaded file names to match the item name limit. The limit is now `500`.