### PR TITLE
fix: fix library link in email

### DIFF
--- a/src/services/item/plugins/published/constants.ts
+++ b/src/services/item/plugins/published/constants.ts
@@ -3,8 +3,12 @@ import { Context } from '@graasp/sdk';
 import { CLIENT_HOSTS } from '../../../../utils/config';
 import { Item } from '../../entities/Item';
 
-export const buildPublishedItemLink = (item: Item) => {
-  const library = CLIENT_HOSTS.find(({ name }) => name === Context.Library);
-  const target = new URL(item.id, library?.url);
+export const buildPublishedItemLink = (item: Item): string | null => {
+  const library = CLIENT_HOSTS.find(({ name }) => name === Context.Library)?.url;
+  if (!library) {
+    return null;
+  }
+
+  const target = new URL(`/${item.id}`, library.origin);
   return target.toString();
 };

--- a/src/services/item/plugins/published/constants.ts
+++ b/src/services/item/plugins/published/constants.ts
@@ -1,14 +1,7 @@
-import { Context } from '@graasp/sdk';
-
-import { CLIENT_HOSTS } from '../../../../utils/config';
+import { LIBRARY_HOST } from '../../../../utils/config';
 import { Item } from '../../entities/Item';
 
-export const buildPublishedItemLink = (item: Item): string | null => {
-  const library = CLIENT_HOSTS.find(({ name }) => name === Context.Library)?.url;
-  if (!library) {
-    return null;
-  }
-
-  const target = new URL(`/${item.id}`, library.origin);
+export const buildPublishedItemLink = (item: Item): string => {
+  const target = new URL(`/collections/${item.id}`, LIBRARY_HOST.url);
   return target.toString();
 };

--- a/src/services/item/plugins/published/service.ts
+++ b/src/services/item/plugins/published/service.ts
@@ -34,10 +34,7 @@ export class ItemPublishedService {
       .map(({ member }) => member);
 
     const link = buildPublishedItemLink(item);
-    if (!link) {
-      console.error('cannot send published email with undefined link');
-      return;
-    }
+
     for (const member of contributors) {
       const lang = member.lang;
       const t = this.mailer.translate(lang);

--- a/src/services/item/plugins/published/service.ts
+++ b/src/services/item/plugins/published/service.ts
@@ -34,7 +34,10 @@ export class ItemPublishedService {
       .map(({ member }) => member);
 
     const link = buildPublishedItemLink(item);
-
+    if (!link) {
+      console.error('cannot send published email with undefined link');
+      return;
+    }
     for (const member of contributors) {
       const lang = member.lang;
       const t = this.mailer.translate(lang);
@@ -44,7 +47,6 @@ export class ItemPublishedService {
         ${this.mailer.buildText(text)}
         ${this.mailer.buildButton(link, t(MAIL.PUBLISH_ITEM_BUTTON_TEXT))}
       `;
-
       const title = t(MAIL.PUBLISH_ITEM_TITLE, { itemName: item.name });
       await this.mailer.sendEmail(title, member.email, link, html).catch((err) => {
         this.log.warn(err, `mailer failed. published link: ${link}`);

--- a/src/services/item/plugins/published/test/index.test.ts
+++ b/src/services/item/plugins/published/test/index.test.ts
@@ -448,7 +448,7 @@ describe('Item Published', () => {
         expect(res.statusCode).toBe(StatusCodes.OK);
         expectPublishedEntry(res.json(), { item, creator: actor });
 
-        waitForExpect(() => {
+        await waitForExpect(() => {
           expect(sendEmailMock).toHaveBeenCalledTimes(2);
           expect(sendEmailMock).toHaveBeenCalledWith(
             expect.stringContaining(item.name),

--- a/src/services/item/plugins/published/test/index.test.ts
+++ b/src/services/item/plugins/published/test/index.test.ts
@@ -1,14 +1,18 @@
 import { StatusCodes } from 'http-status-codes';
 import qs from 'qs';
 import { v4 } from 'uuid';
+import waitForExpect from 'wait-for-expect';
 
 import { HttpMethod, ItemPublished, ItemTagType, PermissionLevel } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../../test/app';
 import { ITEMS_ROUTE_PREFIX } from '../../../../../utils/config';
 import { ItemNotFound, MemberCannotAdminItem } from '../../../../../utils/errors';
-import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
-import { BOB, saveMember } from '../../../../member/test/fixtures/members';
+import {
+  saveItemAndMembership,
+  saveMembership,
+} from '../../../../itemMembership/test/fixtures/memberships';
+import { ANNA, BOB, CEDRIC, saveMember } from '../../../../member/test/fixtures/members';
 import { MEMBERS } from '../../../../member/test/fixtures/members';
 import { saveMembers } from '../../../../member/test/fixtures/members';
 import { Item } from '../../../entities/Item';
@@ -412,6 +416,53 @@ describe('Item Published', () => {
         });
         expect(res.statusCode).toBe(StatusCodes.OK);
         expectPublishedEntry(res.json(), { item, creator: actor });
+      });
+
+      it('Publish item with admin rights and send notification', async () => {
+        const sendEmailMock = jest.spyOn(app.mailer, 'sendEmail');
+
+        const member = await saveMember(BOB);
+        const { item } = await saveItemAndMembership({
+          creator: member,
+          member: actor,
+          permission: PermissionLevel.Admin,
+        });
+        const anna = await saveMember(ANNA);
+        await saveMembership({
+          item,
+          member: anna,
+          permission: PermissionLevel.Admin,
+        });
+        const cedric = await saveMember(CEDRIC);
+        await saveMembership({
+          item,
+          member: cedric,
+          permission: PermissionLevel.Admin,
+        });
+        await ItemTagRepository.save({ item, type: ItemTagType.Public, creator: member });
+
+        const res = await app.inject({
+          method: HttpMethod.POST,
+          url: `${ITEMS_ROUTE_PREFIX}/collections/${item.id}/publish`,
+        });
+        expect(res.statusCode).toBe(StatusCodes.OK);
+        expectPublishedEntry(res.json(), { item, creator: actor });
+
+        waitForExpect(() => {
+          expect(sendEmailMock).toHaveBeenCalledTimes(2);
+          expect(sendEmailMock).toHaveBeenCalledWith(
+            expect.stringContaining(item.name),
+            anna.email,
+            expect.stringContaining(item.id),
+            expect.anything(),
+          );
+          expect(sendEmailMock).toHaveBeenCalledWith(
+            expect.stringContaining(item.name),
+            cedric.email,
+            expect.stringContaining(item.id),
+            expect.anything(),
+          );
+        }, 1000);
       });
 
       it('Cannot publish private item', async () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -44,6 +44,11 @@ export const TEST = ENVIRONMENT === Environment.test;
 
 const DEFAULT_HOST = 'http://localhost:3000';
 
+export const LIBRARY_HOST = {
+  name: Context.Library,
+  url: new URL(process.env.EXPLORER_CLIENT_HOST ?? DEFAULT_HOST),
+};
+
 export const CLIENT_HOSTS = [
   {
     name: Context.Builder,
@@ -53,10 +58,7 @@ export const CLIENT_HOSTS = [
     name: Context.Player,
     url: new URL(process.env.PLAYER_CLIENT_HOST ?? DEFAULT_HOST),
   },
-  {
-    name: Context.Library,
-    url: new URL(process.env.EXPLORER_CLIENT_HOST ?? DEFAULT_HOST),
-  },
+  LIBRARY_HOST,
 ];
 
 export const PROTOCOL = process.env.PROTOCOL || 'http';


### PR DESCRIPTION
The link was broken because we provided a `URL` object in another `URL` object.

fix #594 