### PR TITLE
fix: use custom deep link protocol for mobile login password response

### DIFF
--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -4,7 +4,7 @@ import { FastifyPluginAsync } from 'fastify';
 
 import { DEFAULT_LANG, RecaptchaAction } from '@graasp/sdk';
 
-import { MOBILE_AUTH_URL } from '../../../../utils/config';
+import { MOBILE_DEEP_LINK_PROTOCOL } from '../../../../utils/config';
 import { buildRepositories } from '../../../../utils/repositories';
 import { MemberPasswordService } from '../password/service';
 import { mPasswordLogin, mauth, mlogin, mregister } from './schemas';
@@ -94,7 +94,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       );
 
       // redirect to the universal link domain
-      const redirectionUrl = new URL('/auth', MOBILE_AUTH_URL);
+      const redirectionUrl = new URL(`${MOBILE_DEEP_LINK_PROTOCOL}//auth`);
       redirectionUrl.searchParams.set('t', token);
       reply.status(StatusCodes.SEE_OTHER);
 

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -6,7 +6,11 @@ import fetch from 'node-fetch';
 import { HttpMethod, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
 
 import build, { clearDatabase } from '../../../../../test/app';
-import { JWT_SECRET, MOBILE_AUTH_URL, REFRESH_TOKEN_JWT_SECRET } from '../../../../utils/config';
+import {
+  JWT_SECRET,
+  MOBILE_DEEP_LINK_PROTOCOL,
+  REFRESH_TOKEN_JWT_SECRET,
+} from '../../../../utils/config';
 import { MemberNotFound } from '../../../../utils/errors';
 import MemberRepository from '../../../member/repository';
 import { ANNA, BOB, LOUISA, expectMember, saveMember } from '../../../member/test/fixtures/members';
@@ -221,7 +225,7 @@ describe('Mobile Endpoints', () => {
       expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
       const result = await response.json();
       expect(result).toHaveProperty('resource');
-      const url = new URL('/auth', MOBILE_AUTH_URL);
+      const url = new URL(`${MOBILE_DEEP_LINK_PROTOCOL}//auth`);
       url.searchParams.set('t', ''); // we don't know the generated token, but the parameter should exist
       expect(result.resource).toContain(url.toString());
     });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -111,9 +111,12 @@ export const AUTH_CLIENT_HOST = new URL(
  */
 export const PUBLIC_URL = new URL(process.env.PUBLIC_URL ?? HOST);
 
-export const MOBILE_AUTH_URL = new URL(
-  process.env.GRAASP_MOBILE_BUILDER || 'https://mobile.graasp.org',
-);
+export const MOBILE_AUTH_URL = new URL(process.env.MOBILE_AUTH_URL || 'https://mobile.graasp.org');
+
+export const MOBILE_DEEP_LINK_PROTOCOL = new URL(
+  // the domain part below is just an example to check the validity of the URL
+  `${process.env.MOBILE_DEEP_LINK_PROTOCOL || 'graasp-mobile-builder'}://graasp.org`,
+).protocol; // we only use the protocol anyway
 
 export const DISABLE_LOGS = process.env.DISABLE_LOGS === 'true';
 export const DATABASE_LOGS = process.env.DATABASE_LOGS === 'true';


### PR DESCRIPTION
Closes #498 (re-opened after Apple's review)
