### PR TITLE
docs: copy app docs

### DIFF
--- a/src/services/item/plugins/app/docs/api.md
+++ b/src/services/item/plugins/app/docs/api.md
@@ -1,0 +1,244 @@
+# API
+
+All following requests need an authentication token received as described in the [guide](./guide.md).
+
+Therefore, don't forget to use `Authorization: Bearer <token>` in your request's headers.
+
+### Table of Contents
+
+- [App Actions](#app-actions)
+- [App Context](#app-context)
+- [App Data](#app-data)
+- [App Settings](#app-settings)
+- [Parent Window](#parent-window)
+
+### Query strings
+
+Within Graasp, the apps are given some information by query string:
+
+- itemId: item id of the corresponding item
+
+---
+
+<a name="app-actions"></a>
+
+## App Actions
+
+App actions are analytic traces the app might save. They have the following structure:
+
+- `id`: the app action id
+- `memberId`: the member id related to the app action (default: current authenticated member id)
+- `itemId`: the item id corresponding to the current app
+- `data`: object containing any necessary data
+- `type`: the related action related to the data
+- `createdAt`: creation timestamp of the app action
+
+### GET App Action
+
+`GET <apiHost>/app-items/<item-id>/app-action`
+
+- return value: an array of all app data related to `itemId`
+
+### GET App Action for multiple items
+
+`TODO`
+
+### POST App Action
+
+`POST <apiHost>/app-items/<item-id>/app-action`
+
+- body: `{ data: { ... }, type, [memberId], [visibility] }`
+- returned value: created app action
+
+---
+
+<a name="app-data"></a>
+
+## App Data
+
+App data are all data the app might save. They have the following structure:
+
+- `id`: the app data id
+- `memberId`: the member id related to the data (default: current authenticated member id)
+- `itemId`: the item id corresponding to the current app
+- `data`: object containing any necessary data
+- `type`: the related action related to the data
+- `creator`: the member id who created the app data
+- `visibility`: availability of the app data, either `member` or `item` (default: `member`)
+  - `member`: the app data can be managed by the creator and members with admin permission. Members with write permission can view them but cannot modify them.
+  - `item`: the app data can be managed by the creator and members with admin permission. All other members can view them but cannot modify them.
+- `createdAt`: creation timestamp of the app data
+- `updatedAt`: update timestamp of the app data
+
+### GET App Data
+
+`GET <apiHost>/app-items/<item-id>/app-data`
+
+- return value: an array of all app data related to `itemId`
+
+### GET App Data for multiple items
+
+`TODO`
+
+### POST App Data
+
+`POST <apiHost>/app-items/<item-id>/app-data`
+
+- body: `{ data: { ... }, type, [memberId], [visibility] }`
+- returned value: created app data
+
+### PATCH App Data
+
+`PATCH <apiHost>/app-items/<item-id>/app-data/<app-data-id>`
+
+- body: `{ data: { ... } }`
+- returned value: patched app data
+
+### DELETE App Data
+
+`DELETE <apiHost>/app-items/<item-id>/app-data/<app-data-id>`
+
+- returned value: deleted app data
+
+### Upload a file as an app data
+
+`POST <apiHost>/app-items/upload?id=<item-id>`
+
+- it is not possible to patch a file app setting
+- send files as form data, the name of the file will be the name of the app setting
+- returned value: created app setting
+
+### Download a file from an app data
+
+`GET <apiHost>/app-items/<app-data-id>/download`
+
+- returned value: signed url of the file
+
+---
+
+<a name="app-context"></a>
+
+## App Context
+
+The app context contains additional information which might be interesting for your app such as:
+
+- `members`: a list of all the members having access to the app's parent and the app itself
+- `children`: all folder and app items contained in the parent item
+- and all the item's properties such as `ìd`, `name`, `description`, etc
+
+### GET App Action
+
+`GET <apiHost>/app-items/<item-id>/context`
+
+- return value: the context of the corresponding item
+
+---
+
+<a name="app-settings"></a>
+
+## App Settings
+
+App settings store the app configuration. Only members with the admin permission can create, update and delete them. The other members can only fetch the app settings.
+
+If the related item is copied, its app settings are copied alongside, opposed to app data.
+
+App settings have the following structure:
+
+- `id`: the app setting id
+- `name`: the app setting name
+- `itemId`: the item id corresponding to the current app
+- `data`: object containing any necessary setting
+- `creator`: the member id who created the app setting
+- `createdAt`: creation timestamp of the app setting
+- `updatedAt`: update timestamp of the app setting
+
+### GET App Setting
+
+`GET <apiHost>/app-items/<item-id>/app-settings`
+
+- return value: an array of all app settings related to `itemId`
+
+### POST App Setting
+
+`POST <apiHost>/app-items/<item-id>/app-settings`
+
+- body: `{ name, data: { ... } }`
+- returned value: created app setting
+
+### PATCH App Setting
+
+`PATCH <apiHost>/app-items/<item-id>/app-settings/<app-setting-id>`
+
+- body: `{ data: { ... } }`
+- permission: only member with the admin permission can patch an app setting
+- it is not possible to patch a file app setting
+- returned value: patched app setting
+
+### DELETE App Setting
+
+`DELETE <apiHost>/app-items/<item-id>/app-settings/<app-setting-id>`
+
+- returned value: deleted app data
+- permission: only member with the admin permission can delete an app setting
+
+### Upload a file as an app setting
+
+`POST <apiHost>/app-items/app-settings/upload?id=<item-id>`
+
+- it is not possible to patch a file app setting
+- send files as form data, the name of the file will be the name of the app setting
+- returned value: created app setting
+
+### Download a file from an app setting
+
+`GET <apiHost>/app-items/app-settings/<app-setting-id>/download`
+
+- returned value: signed url of the file
+
+---
+
+<a name="parent-window"></a>
+
+## Parent Window
+
+Since apps are embedded in Graasp with an iframe, it is possible to communicate with the parent window using both regular `window.postMessage` and `MessageChannel`. One should first use `window.postMessage` to get the context, as well as the `MessageChannel`'s port to continue the process (see [guide](./guide.md)).
+
+### `window.postMessage`
+
+### GET Context
+
+```js
+postMessage(
+    JSON.stringify({
+      type: 'GET_CONTEXT',
+    }
+);
+```
+
+- return values:
+  - `apiHost`: the api host origin
+  - `context`: where the app is running (eg: `builder`, `explorer`, `standalone`, ...)
+  - `itemId`: item id which corresponds to your app resource id
+  - `lang`: language
+  - `memberId`: the current authenticated user using the app
+  - `permission`: the current member's permission
+  - `settings`: the corresponding item settings
+  - as well as the `port` of the `MessageChannel` you will use from now on to communicate with the parent window.
+
+### `MessageChannel`
+
+### GET Authentication Token
+
+```js
+port.postMessage(
+    JSON.stringify({
+      type: 'GET_AUTH_TOKEN',
+      payload: {
+        key: <app key>,
+        origin: <app origin>,
+      },
+    })
+  );
+```
+
+- return value: authentication token

--- a/src/services/item/plugins/app/docs/guide.md
+++ b/src/services/item/plugins/app/docs/guide.md
@@ -1,0 +1,60 @@
+# Graasp Apps API Guide
+
+Graasp can embed web applications as a resource. They should be added as an item of type `app` to access the Graasp API and get authenticated with a token.
+
+## Introduction
+
+When an app is added as a resource, it is linked to an item. Therefore, two added apps will correspond to two different items, which leads them to have different item ids, and different app data.
+
+## App Authentication
+
+In order to access the API and get the app token, the apps should fullfil the following requirements:
+
+- be registered as publisher in the database. If you are using our instance, you will need to contact us in order to be added. You will need to provide a `name` and `origin` urls where you will host your applications.
+- have an `APP_ID` provided by Graasp. If you are using our instance, you will need to contact us in order for us to generate a valid key you can use.
+
+### Procedure
+
+Here are the steps to request a token:
+
+1. **Request a context**: The app is iframed in the Graasp platform. It can access it's parent window's context by sending a `postMessage`.
+
+```js
+postMessage(
+    JSON.stringify({
+      type: 'GET_CONTEXT',
+    }
+);
+```
+
+The response will contain one of the `port` of the `MessageChannel` you will use from now on to communicate with the parent window.
+
+This endpoint is available for any apps, even if you don't fullfil the requirements.
+
+2. **Request a token:** Once you have access to the `MessageChannel`'s `port` you can request a token as follows:
+
+```js
+port.postMessage(
+    JSON.stringify({
+      type: 'GET_AUTH_TOKEN',
+      payload: {
+        key: <app key>,
+        origin: <app origin>,
+      },
+    })
+  );
+```
+
+The response will contain `token` you will be using to request your app's data.
+
+3. **Use the API**: From now on you can freely use your token to access the API and fetch various data. See the [API Documentation](./api.md).
+
+4. **Refetch the token**: The token might expire. In this case, redo step 2.
+
+## File Upload
+
+Apps can upload files, as (app) data or (app) setting. App Data are created by a member and are available to in a given scope. App Settings are created and managed by the admins and can be fetched by all the other members.
+
+## React Framework
+
+We are currently working on an app framework, which would ease the token request procedure.


### PR DESCRIPTION
I've copy-pasted the app docs that existed in its own repo. 
The only change is `app` of "app id" to `key`when requesting the api key.