### PR TITLE
fix: use limit and offset for meilisearch pagination

### DIFF
--- a/src/services/item/plugins/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/published/plugins/search/meilisearch.ts
@@ -4,7 +4,6 @@ import MeiliSearch, {
   MeiliSearchApiError,
   MeiliSearchTimeOutError,
   MultiSearchParams,
-  TaskStatus,
   TypoTolerance,
 } from 'meilisearch';
 import { DataSource } from 'typeorm';
@@ -139,7 +138,6 @@ export class MeiliSearchWrapper {
   // WORKS ONLY FOR PUBLISHED ITEMS
   async search(queries: MultiSearchParams) {
     const searchResult = await this.meilisearchClient.multiSearch(queries, {
-      hitsPerPage: 5,
       attributesToHighlight: ['*'],
     });
 

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -78,7 +78,7 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
       .innerJoinAndSelect('item_published.item', 'item')
       .innerJoinAndSelect('item.creator', 'member')
       .orderBy('item.createdAt', 'DESC')
-      .take(limit)
+      .limit(limit)
       .getMany();
 
     return publishedInfos.map(({ item }) => item);


### PR DESCRIPTION
This PR changes the pagination strategy in meilisearch to use limit and offset instead of hitsPerPage and page.
It also changes a usage of `.take()` in typeorm to be `.limit()`.