### PR TITLE
fix(types): fileStream argument has incompatible typing

### DIFF
--- a/src/services/file/repositories/s3.ts
+++ b/src/services/file/repositories/s3.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import { StatusCodes } from 'http-status-codes';
 import fetch from 'node-fetch';
 import path from 'path';
+import Readable from 'stream';
 
 import { FastifyReply } from 'fastify';
 
@@ -255,7 +256,7 @@ export class S3FileRepository implements FileRepository {
     filepath,
     mimetype,
   }: {
-    fileStream: ReadableStream;
+    fileStream: Readable;
     memberId: string;
     filepath: string;
     mimetype?: string;


### PR DESCRIPTION
This PR fixes an issue with the typings.
This fix is coherent with the input typing https://github.com/graasp/graasp/blob/20d59793c97ccf3beb83fb8be6cb7af94d0bdd98/src/services/file/service.ts#L58