### PR TITLE
fix: add `item.creator` in item like response

### DIFF
--- a/src/services/item/plugins/itemLike/repository.ts
+++ b/src/services/item/plugins/itemLike/repository.ts
@@ -21,6 +21,7 @@ export const ItemLikeRepository = AppDataSource.getRepository(ItemLike).extend({
   async getForMember(memberId: string): Promise<ItemLike[]> {
     const itemLikes = await this.createQueryBuilder('itemLike')
       .innerJoinAndSelect('itemLike.item', 'item')
+      .innerJoinAndSelect('item.creator', 'member')
       .where('itemLike.creator = :memberId', { memberId })
       .getMany();
     return itemLikes;


### PR DESCRIPTION
~~This PR also corrects a wrong import from #640 which makes the build fail. [Ref](https://github.com/graasp/graasp/pull/640#discussion_r1355155818)~~

Explanation of the change:
We need to manually do the join on `item.creator` with the `member` table for the creator to be included in the response. TypeORM does not include nested relations by default.

Related PRs that previously fixed a similar issue: #502 #524

This bug was discovered from the "quote inside avatar" bug in the library:
<img width="1014" alt="Screenshot 2023-10-11 at 15 18 55" src="https://github.com/graasp/graasp/assets/39373170/bdfebe6f-7e6f-464f-a73c-1dc08bd6bc7f">
