### PR TITLE
fix: add logger to fileService

### DIFF
--- a/src/plugins/decorator.ts
+++ b/src/plugins/decorator.ts
@@ -52,7 +52,7 @@ const decoratorPlugin: FastifyPluginAsync = async (fastify) => {
   });
 
   fastify.decorate('h5p', {
-    service: new H5PService(),
+    service: new H5PService(fastify.log),
   });
 
   fastify.decorate('search', {

--- a/src/services/file/index.ts
+++ b/src/services/file/index.ts
@@ -35,7 +35,7 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
     }
   }
 
-  const fS = new FileService(fileConfigurations, fileItemType);
+  const fS = new FileService(fileConfigurations, fileItemType, fastify.log);
 
   fastify.decorate('files', { service: fS });
 };

--- a/src/services/file/interfaces/fileRepository.ts
+++ b/src/services/file/interfaces/fileRepository.ts
@@ -1,5 +1,7 @@
 import { ReadStream } from 'fs';
 
+import { FastifyBaseLogger } from 'fastify';
+
 export interface FileRepository {
   getFileSize(filepath: string): Promise<number | undefined>;
 
@@ -16,15 +18,18 @@ export interface FileRepository {
   deleteFile(args: { filepath: string }): Promise<void>;
   deleteFolder(args: { folderPath: string }): Promise<void>;
 
-  getFile(args: { filepath: string; id: string }): Promise<ReadStream>;
+  getFile(args: { filepath: string; id: string }, log?: FastifyBaseLogger): Promise<ReadStream>;
 
-  getUrl(args: {
-    filepath: string;
-    // used by s3 to set an expiry link on signed url
-    expiration?: number;
-    // used by local to log
-    id?: string;
-  }): Promise<string>;
+  getUrl(
+    args: {
+      filepath: string;
+      // used by s3 to set an expiry link on signed url
+      expiration?: number;
+      // used by local to log
+      id?: string;
+    },
+    log?: FastifyBaseLogger,
+  ): Promise<string>;
 
   uploadFile(args: {
     fileStream: ReadableStream;
@@ -33,5 +38,4 @@ export interface FileRepository {
     mimetype?: string;
     size?: string;
   }): Promise<void>;
-  // eslint-disable-next-line semi
 }

--- a/src/services/file/service.test.ts
+++ b/src/services/file/service.test.ts
@@ -1,5 +1,7 @@
 import { ReadStream } from 'fs';
 
+import { FastifyBaseLogger } from 'fastify';
+
 import { ItemType } from '@graasp/sdk';
 
 import { Member } from '../member/entities/member';
@@ -27,7 +29,11 @@ const MOCK_S3_CONFIG = {
 
 const member = new Member();
 
-const S3FS = new FileService({ s3: MOCK_S3_CONFIG }, ItemType.S3_FILE);
+const S3FS = new FileService(
+  { s3: MOCK_S3_CONFIG },
+  ItemType.S3_FILE,
+  console as unknown as FastifyBaseLogger,
+);
 
 describe('FileService', () => {
   describe('constructor', () => {
@@ -36,16 +42,28 @@ describe('FileService', () => {
       expect(fS.repository).toBeInstanceOf(S3FileRepository);
     });
     it('use local repository', () => {
-      const fS = new FileService({ local: MOCK_LOCAL_CONFIG }, ItemType.LOCAL_FILE);
+      const fS = new FileService(
+        { local: MOCK_LOCAL_CONFIG },
+        ItemType.LOCAL_FILE,
+        console as unknown as FastifyBaseLogger,
+      );
       expect(fS.repository).toBeInstanceOf(LocalFileRepository);
     });
     it('throws for conflicting settings', () => {
       expect(() => {
-        new FileService({ s3: MOCK_S3_CONFIG }, ItemType.LOCAL_FILE);
+        new FileService(
+          { s3: MOCK_S3_CONFIG },
+          ItemType.LOCAL_FILE,
+          console as unknown as FastifyBaseLogger,
+        );
       }).toThrowError();
 
       expect(() => {
-        new FileService({ local: MOCK_LOCAL_CONFIG }, ItemType.S3_FILE);
+        new FileService(
+          { local: MOCK_LOCAL_CONFIG },
+          ItemType.S3_FILE,
+          console as unknown as FastifyBaseLogger,
+        );
       }).toThrowError();
     });
   });

--- a/src/services/file/service.ts
+++ b/src/services/file/service.ts
@@ -3,7 +3,7 @@ import { ReadStream } from 'fs';
 import { StatusCodes } from 'http-status-codes';
 import { Readable } from 'stream';
 
-import { FastifyReply } from 'fastify';
+import { FastifyBaseLogger, FastifyReply } from 'fastify';
 
 import { FileItemType, ItemType } from '@graasp/sdk';
 
@@ -32,10 +32,12 @@ class FileService {
   type: FileItemType;
 
   config: { s3?: S3FileConfiguration; local?: LocalFileConfiguration };
+  logger: FastifyBaseLogger;
 
   constructor(
     options: { s3?: S3FileConfiguration; local?: LocalFileConfiguration },
     fileItemType: FileItemType,
+    log: FastifyBaseLogger,
   ) {
     this.type = fileItemType;
     switch (fileItemType) {
@@ -54,6 +56,7 @@ class FileService {
         break;
     }
     this.config = options;
+    this.logger = log;
   }
 
   async getFileSize(actor: Actor, filepath: string) {
@@ -100,10 +103,13 @@ class FileService {
       });
     }
 
-    return this.repository.getFile({
-      filepath,
-      id,
-    });
+    return this.repository.getFile(
+      {
+        filepath,
+        id,
+      },
+      this.logger,
+    );
   }
 
   async getUrl(
@@ -122,11 +128,14 @@ class FileService {
       });
     }
 
-    return this.repository.getUrl({
-      expiration,
-      filepath,
-      id,
-    });
+    return this.repository.getUrl(
+      {
+        expiration,
+        filepath,
+        id,
+      },
+      this.logger,
+    );
   }
 
   async delete(member: Member, filepath: string) {

--- a/src/services/item/plugins/html/h5p/service.ts
+++ b/src/services/item/plugins/html/h5p/service.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { v4 } from 'uuid';
 
+import { FastifyBaseLogger } from 'fastify';
+
 import { H5PItemExtra, ItemType } from '@graasp/sdk';
 
 import {
@@ -20,7 +22,7 @@ import { H5PValidator } from './validation/h5p-validator';
  * Implementation for the H5P service
  */
 export class H5PService extends HtmlService {
-  constructor() {
+  constructor(log: FastifyBaseLogger) {
     const h5pValidator = new H5PValidator();
 
     super(
@@ -29,6 +31,7 @@ export class H5PService extends HtmlService {
       H5P_FILE_MIME_TYPE,
       'h5p',
       h5pValidator,
+      log,
     );
   }
 

--- a/src/services/item/plugins/html/service.test.ts
+++ b/src/services/item/plugins/html/service.test.ts
@@ -1,3 +1,5 @@
+import { FastifyBaseLogger } from 'fastify';
+
 import { ItemType } from '@graasp/sdk';
 
 import { S3FileConfiguration } from '../../../file/interfaces/configuration';
@@ -23,10 +25,21 @@ class MockHtmlService extends HtmlService {}
 const validator = new MockValidator();
 
 // todo: improve typing when adding more tests
-const fileService = new FileService({ s3: {} as unknown as S3FileConfiguration }, ItemType.S3_FILE);
+const fileService = new FileService(
+  { s3: {} as unknown as S3FileConfiguration },
+  ItemType.S3_FILE,
+  console as unknown as FastifyBaseLogger,
+);
 
 describe('Html Service', () => {
-  const htmlService = new MockHtmlService(fileService, 'prefix', 'mimetype', 'ext', validator);
+  const htmlService = new MockHtmlService(
+    fileService,
+    'prefix',
+    'mimetype',
+    'ext',
+    validator,
+    console as unknown as FastifyBaseLogger,
+  );
 
   it('builds root path', () => {
     expect(htmlService.buildRootPath('prefix', 'mockId')).toEqual('prefix/mockId');

--- a/src/services/item/plugins/html/service.ts
+++ b/src/services/item/plugins/html/service.ts
@@ -32,6 +32,7 @@ export abstract class HtmlService {
   protected readonly mimetype: string;
   protected readonly extension: string;
   protected readonly pathPrefix: string;
+  protected readonly logger: FastifyBaseLogger;
 
   protected readonly tempDir: string;
 
@@ -47,13 +48,14 @@ export abstract class HtmlService {
     mimetype: string,
     extension: string,
     validator: HtmlValidator,
+    log: FastifyBaseLogger,
   ) {
     if (pathPrefix && pathPrefix.startsWith('/')) {
       throw new Error('path prefix should not start with a "/"!');
     }
-
+    this.logger = log;
     this.extension = extension;
-    this.fileService = new FileService(config, type);
+    this.fileService = new FileService(config, type, this.logger);
     this.mimetype = mimetype;
     this.pathPrefix = pathPrefix;
     this.validator = validator;

--- a/src/services/item/plugins/importExport/index.ts
+++ b/src/services/item/plugins/importExport/index.ts
@@ -22,10 +22,11 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
     actions: { service: aS },
     h5p: h5pService,
+    log: fastifyLogger,
     db,
   } = fastify;
 
-  const importExportService = new ImportExportService(db, fS, iS, h5pService);
+  const importExportService = new ImportExportService(db, fS, iS, h5pService, fastifyLogger);
 
   fastify.register(fastifyMultipart, {
     limits: {
@@ -108,7 +109,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       const archiveStream = await importExportService.export(member, repositories, {
         item,
         reply,
-        log,
       });
 
       // trigger download action for a collection

--- a/src/services/item/plugins/importExport/service.ts
+++ b/src/services/item/plugins/importExport/service.ts
@@ -36,17 +36,20 @@ export class ImportExportService {
   h5pService: H5PService;
   itemService: ItemService;
   db: DataSource;
+  logger: FastifyBaseLogger;
 
   constructor(
     db: DataSource,
     fileItemService: FileItemService,
     itemService: ItemService,
     h5pService: H5PService,
+    log: FastifyBaseLogger,
   ) {
     this.db = db;
     this.fileItemService = fileItemService;
     this.h5pService = h5pService;
     this.itemService = itemService;
+    this.logger = log;
   }
 
   private async _getDescriptionForFilepath(filepath: string): Promise<string> {
@@ -306,7 +309,7 @@ export class ImportExportService {
   async export(
     actor: Actor,
     repositories: Repositories,
-    { item, reply }: { item: Item; reply: FastifyReply; log?: FastifyBaseLogger },
+    { item, reply }: { item: Item; reply: FastifyReply },
   ) {
     // init archive
     const archive = new yazl.ZipFile();


### PR DESCRIPTION
This PR adds a logger to the fileService to remove the ugly `console.error` printouts in aws logs.
fix #699 