### PR TITLE
fix: add test tsconfig and update type-check command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:watch": "yarn test --watchAll",
     "build-ts": "tsc",
     "watch-ts": "tsc -w",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit -p tsconfig.test.json",
     "lint": "eslint '**/*.{js,ts}'",
     "prettier:check": "prettier --check \"{src,test}/**/*.ts\"",
     "prettier:write": "prettier --write \"{src,test}/**/*.ts\"",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR adds a tsconfig to typecheck the whole project to type errors are catched before doing the tests.

fix #744
