### PR TITLE
fix: do not fail login with password if score is low

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -88,6 +88,7 @@ declare module 'fastify' {
       request: FastifyRequest,
       captcha: string,
       actionType: RecaptchaActionType,
+      options?: { shouldFail?: boolean },
     ) => Promise<void>;
     attemptVerifyAuthentication: (request: FastifyRequest) => Promise<void>;
     fetchMemberInSession: (request: FastifyRequest) => Promise<void>;

--- a/src/services/auth/plugins/captcha/index.ts
+++ b/src/services/auth/plugins/captcha/index.ts
@@ -26,7 +26,9 @@ const plugin: FastifyPluginAsync<{ secretAccessKey: string }> = async (fastify, 
     request: FastifyRequest,
     captcha: string,
     actionType: RecaptchaActionType,
+    options?: { shouldFail: boolean },
   ) => {
+    const shouldFailIfLowScore = options?.shouldFail ?? true;
     // TODO: find a better solution? to allow dev
     if (DEV) {
       return;
@@ -64,7 +66,7 @@ const plugin: FastifyPluginAsync<{ secretAccessKey: string }> = async (fastify, 
       !data.success ||
       data.action !== actionType ||
       !data.score ||
-      data.score < RECAPTCHA_SCORE_THRESHOLD
+      (shouldFailIfLowScore && data.score < RECAPTCHA_SCORE_THRESHOLD)
     ) {
       console.error(`The captcha verification has thrown with value: '${JSON.stringify(data)}'`);
       throw new AuthenticationError();

--- a/src/services/auth/plugins/captcha/index.ts
+++ b/src/services/auth/plugins/captcha/index.ts
@@ -65,7 +65,8 @@ const plugin: FastifyPluginAsync<{ secretAccessKey: string }> = async (fastify, 
       !data ||
       !data.success ||
       data.action !== actionType ||
-      !data.score ||
+      // data.score should be checked for definition not for boolean value
+      data.score == undefined ||
       (shouldFailIfLowScore && data.score < RECAPTCHA_SCORE_THRESHOLD)
     ) {
       console.error(`The captcha verification has thrown with value: '${JSON.stringify(data)}'`);

--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -83,6 +83,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         request,
         body.captcha,
         RecaptchaAction.SignInWithPasswordMobile,
+        { shouldFail: false },
       );
 
       const token = await memberPasswordService.login(

--- a/src/services/auth/plugins/password/index.ts
+++ b/src/services/auth/plugins/password/index.ts
@@ -24,7 +24,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     const { url } = body;
 
     // validate captcha
-    await fastify.validateCaptcha(request, body.captcha, RecaptchaAction.SignInWithPassword);
+    await fastify.validateCaptcha(request, body.captcha, RecaptchaAction.SignInWithPassword, {
+      shouldFail: false,
+    });
 
     const token = await memberPasswordService.login(undefined, buildRepositories(), body);
     const redirectionUrl = getRedirectionUrl(log, url);


### PR DESCRIPTION
In this PR:
- fix #394 by adding a parameter in `verifyCaptcha` which decides if a low score should fail the request or not.