### PR TITLE
fix: throw if item is not folder for copy move

### DIFF
--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -76,6 +76,11 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
       settings = DEFAULT_ITEM_SETTINGS,
       creator,
     } = args;
+
+    if (parent && !isItemType(parent, ItemType.FOLDER)) {
+      throw new ItemNotFolder(parent);
+    }
+
     // TODO: extra
     // folder's extra can be empty
     let parsedExtra: ItemExtraUnion = extra ? JSON.parse(JSON.stringify(extra)) : {};
@@ -276,6 +281,12 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
     if (parentItem) {
       // attaching tree to new parent item
       const { id: parentItemId, path: parentItemPath } = parentItem;
+
+      // cannot move inside non folder item
+      if (!isItemType(parentItem, ItemType.FOLDER)) {
+        throw new ItemNotFolder(parentItemId);
+      }
+
       // fail if
       if (
         parentItemPath.startsWith(item.path) || // moving into itself or "below" itself
@@ -357,6 +368,11 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
     creator: Member,
     parentItem?: Item,
   ): Promise<{ copyRoot: Item; treeCopyMap: Map<string, { original: Item; copy: Item }> }> {
+    // cannot move inside non folder item
+    if (parentItem && !isItemType(parentItem, ItemType.FOLDER)) {
+      throw new ItemNotFolder(parentItem.id);
+    }
+
     const descendants = await this.getDescendants(item, { ordered: true });
 
     // copy (memberships from origin are not copied/kept)

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -368,7 +368,7 @@ export const ItemRepository = AppDataSource.getRepository(Item).extend({
     creator: Member,
     parentItem?: Item,
   ): Promise<{ copyRoot: Item; treeCopyMap: Map<string, { original: Item; copy: Item }> }> {
-    // cannot move inside non folder item
+    // cannot copy inside non folder item
     if (parentItem && !isItemType(parentItem, ItemType.FOLDER)) {
       throw new ItemNotFolder(parentItem.id);
     }

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -16,6 +16,7 @@ import {
 import { Paginated, PaginationParams } from '../../types';
 import {
   InvalidMembership,
+  ItemNotFolder,
   MemberCannotWriteItem,
   TooManyChildren,
   TooManyDescendants,
@@ -79,8 +80,9 @@ export class ItemService {
       parentItem = await this.get(actor, repositories, parentId, PermissionLevel.Write);
       inheritedMembership = await itemMembershipRepository.getInherited(parentItem, actor, true);
 
+      // quick check, necessary for ts
       if (!isItemType(parentItem, ItemType.FOLDER)) {
-        throw new Error('ITEM NOT FOLDER'); // TODO
+        throw new ItemNotFolder(parentItem.id);
       }
 
       itemRepository.checkHierarchyDepth(parentItem);


### PR DESCRIPTION
check for copy and move whether 