### PR TITLE
feat: allow to filter out item by type in accessible

### DIFF
--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -94,11 +94,11 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       if (!member) {
         throw new UnauthorizedMember();
       }
-      const { page, pageSize, creatorId, name, sortBy, ordering, permissions } = query;
+      const { page, pageSize, creatorId, name, sortBy, ordering, permissions, itemType } = query;
       return itemService.getAccessible(
         member,
         buildRepositories(),
-        { creatorId, name, sortBy, ordering, permissions },
+        { creatorId, name, sortBy, ordering, permissions, itemType },
         { page, pageSize },
       );
     },

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -23,9 +23,8 @@ import {
   moveMany,
   updateMany,
 } from './fluent-schema';
-import { Ordered } from './interfaces/requests';
 import { ItemGeolocation } from './plugins/geolocation/ItemGeolocation';
-import { ItemSearchParams } from './types';
+import { ItemChildrenParams, ItemSearchParams } from './types';
 import { ItemOpFeedbackEvent, memberItemsTopic } from './ws/events';
 
 const plugin: FastifyPluginAsync = async (fastify) => {
@@ -94,11 +93,11 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       if (!member) {
         throw new UnauthorizedMember();
       }
-      const { page, pageSize, creatorId, name, sortBy, ordering, permissions, itemType } = query;
+      const { page, pageSize, creatorId, name, sortBy, ordering, permissions, types } = query;
       return itemService.getAccessible(
         member,
         buildRepositories(),
-        { creatorId, name, sortBy, ordering, permissions, itemType },
+        { creatorId, name, sortBy, ordering, permissions, types },
         { page, pageSize },
       );
     },
@@ -126,11 +125,11 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   );
 
   // get item's children
-  fastify.get<{ Params: IdParam; Querystring: Ordered }>(
+  fastify.get<{ Params: IdParam; Querystring: ItemChildrenParams }>(
     '/:id/children',
     { schema: getChildren, preHandler: fastify.attemptVerifyAuthentication },
-    async ({ member, params: { id }, query: { ordered } }) => {
-      return itemService.getChildren(member, buildRepositories(), id, ordered);
+    async ({ member, params: { id }, query: { ordered, types } }) => {
+      return itemService.getChildren(member, buildRepositories(), id, { ordered, types });
     },
   );
 

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -136,7 +136,8 @@ export const getAccessible = {
     .prop('sortBy', S.enum(Object.values(SortBy)))
     .prop('ordering', S.enum(Object.values(Ordering)))
     .prop('creatorId', S.string())
-    .prop('pageSize', S.number().default(ITEMS_PAGE_SIZE)),
+    .prop('pageSize', S.number().default(ITEMS_PAGE_SIZE))
+    .prop('itemType', S.enum(Object.values(ItemType))),
   response: {
     200: S.object()
       .additionalProperties(false)

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -137,7 +137,7 @@ export const getAccessible = {
     .prop('ordering', S.enum(Object.values(Ordering)))
     .prop('creatorId', S.string())
     .prop('pageSize', S.number().default(ITEMS_PAGE_SIZE))
-    .prop('itemType', S.enum(Object.values(ItemType))),
+    .prop('types', S.array().items(S.enum(Object.values(ItemType)))),
   response: {
     200: S.object()
       .additionalProperties(false)
@@ -162,7 +162,10 @@ export const getMany = {
 
 export const getChildren = {
   params: idParam,
-  querystring: S.object().additionalProperties(false).prop('ordered', S.boolean()),
+  querystring: S.object()
+    .additionalProperties(false)
+    .prop('ordered', S.boolean())
+    .prop('types', S.array().items(S.enum(Object.values(ItemType)))),
   response: {
     200: S.array().items(item),
     '4xx': error,

--- a/src/services/item/interfaces/requests.ts
+++ b/src/services/item/interfaces/requests.ts
@@ -1,3 +1,0 @@
-export interface Ordered {
-  ordered?: boolean;
-}

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -30,7 +30,7 @@ import { mapById } from '../utils';
 import { Item, isItemType } from './entities/Item';
 import { ItemGeolocation } from './plugins/geolocation/ItemGeolocation';
 import { PartialItemGeolocation } from './plugins/geolocation/errors';
-import { ItemSearchParams } from './types';
+import { ItemChildrenParams, ItemSearchParams } from './types';
 
 export class ItemService {
   hooks = new HookManager<{
@@ -207,12 +207,17 @@ export class ItemService {
     return filterOutItems(actor, repositories, items);
   }
 
-  async getChildren(actor: Actor, repositories: Repositories, itemId: string, ordered?: boolean) {
+  async getChildren(
+    actor: Actor,
+    repositories: Repositories,
+    itemId: string,
+    params?: ItemChildrenParams,
+  ) {
     const { itemRepository } = repositories;
     const item = await this.get(actor, repositories, itemId);
 
     // TODO optimize?
-    return filterOutItems(actor, repositories, await itemRepository.getChildren(item, ordered));
+    return filterOutItems(actor, repositories, await itemRepository.getChildren(item, params));
   }
 
   async getDescendants(actor: Actor, repositories: Repositories, itemId: UUID) {

--- a/src/services/item/types.ts
+++ b/src/services/item/types.ts
@@ -1,4 +1,4 @@
-import { PermissionLevel } from '@graasp/sdk';
+import { ItemType, PermissionLevel } from '@graasp/sdk';
 
 import { Member } from '../member/entities/member';
 
@@ -23,4 +23,5 @@ export type ItemSearchParams = {
   sortBy?: SortBy;
   ordering?: Ordering;
   permissions?: PermissionLevel[];
+  itemType?: (typeof ItemType)[keyof typeof ItemType];
 };

--- a/src/services/item/types.ts
+++ b/src/services/item/types.ts
@@ -1,4 +1,4 @@
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType, PermissionLevel, UnionOfConst } from '@graasp/sdk';
 
 import { Member } from '../member/entities/member';
 
@@ -23,5 +23,10 @@ export type ItemSearchParams = {
   sortBy?: SortBy;
   ordering?: Ordering;
   permissions?: PermissionLevel[];
-  itemType?: (typeof ItemType)[keyof typeof ItemType];
+  types?: UnionOfConst<typeof ItemType>[];
+};
+
+export type ItemChildrenParams = {
+  ordered?: boolean;
+  types?: UnionOfConst<typeof ItemType>[];
 };

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -107,6 +107,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
       sortBy = SortBy.ItemUpdatedAt,
       ordering = Ordering.desc,
       permissions,
+      itemType,
     }: ItemSearchParams,
     { page = 1, pageSize = ITEMS_PAGE_SIZE }: PaginationParams,
   ): Promise<Paginated<Item>> {
@@ -146,6 +147,10 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
 
     if (permissions) {
       query.andWhere('im.permission IN (:...permissions)', { permissions });
+    }
+
+    if (itemType) {
+      query.andWhere('item.type = :itemType', { itemType });
     }
 
     if (sortBy) {

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -107,7 +107,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
       sortBy = SortBy.ItemUpdatedAt,
       ordering = Ordering.desc,
       permissions,
-      itemType,
+      types,
     }: ItemSearchParams,
     { page = 1, pageSize = ITEMS_PAGE_SIZE }: PaginationParams,
   ): Promise<Paginated<Item>> {
@@ -149,8 +149,8 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
       query.andWhere('im.permission IN (:...permissions)', { permissions });
     }
 
-    if (itemType) {
-      query.andWhere('item.type = :itemType', { itemType });
+    if (types) {
+      query.andWhere('item.type IN (:...types)', { types });
     }
 
     if (sortBy) {


### PR DESCRIPTION
Add the query parameter `types` to allow to filter by item types in GET /items/accessible and /items/:id/children.