### PR TITLE
feat: use one transaction per move item and send ws after the transaction

### DIFF
--- a/src/services/action/repositories/action.ts
+++ b/src/services/action/repositories/action.ts
@@ -10,14 +10,24 @@ import { aggregateExpressionNames, buildAggregateExpression } from '../utils/act
  */
 export const ActionRepository = AppDataSource.getRepository(Action).extend({
   /**
-   * Create given action and return it.
-   * @param action Action to create
+   * TODO: remove if it not used.
+   * Create given actions.
+   * @param action Actions to create
    */
   async postMany(actions: Pick<Action, 'member' | 'type'>[]): Promise<void> {
     // save action
     for (const action of actions) {
       await this.insert(action);
     }
+  },
+
+  /**
+   * Create given action.
+   * @param action Action to create
+   */
+  async post(action: Pick<Action, 'member' | 'type'>): Promise<void> {
+    // save action
+    await this.insert(action);
   },
 
   /**

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -24,7 +24,7 @@ import {
   updateMany,
 } from './fluent-schema';
 import { ItemGeolocation } from './plugins/geolocation/ItemGeolocation';
-import { ItemChildrenParams, ItemSearchParams, SeriesPromise } from './types';
+import { ItemChildrenParams, ItemSearchParams, PromiseRunner } from './types';
 import { ItemOpFeedbackEvent, ResultOfFactory, memberItemsTopic } from './ws/events';
 import { ItemWebsocketsService } from './ws/services';
 
@@ -274,7 +274,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       } = request;
       const itemWsService = new ItemWebsocketsService(websockets);
 
-      SeriesPromise.allSettled<Item>(
+      PromiseRunner.inSeries<Item>(
         ids.map((itemId) => {
           return async () => {
             return db
@@ -291,7 +291,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
                 return { source, destination };
               })
-              .then(async ({ source, destination }) => {
+              .then(({ source, destination }) => {
                 itemWsService.publishTopicsForMove({
                   source,
                   destination,
@@ -301,7 +301,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
               });
           };
         }),
-      ).then(async (results) => {
+      ).then((results) => {
         if (member) {
           itemWsService.publishFeedbacksForMove({
             log,

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -25,7 +25,7 @@ import {
 } from './fluent-schema';
 import { ItemGeolocation } from './plugins/geolocation/ItemGeolocation';
 import { ItemChildrenParams, ItemSearchParams, SeriesPromise } from './types';
-import { ItemOpFeedbackEvent, memberItemsTopic } from './ws/events';
+import { ItemOpFeedbackEvent, ResultOfFactory, memberItemsTopic } from './ws/events';
 import { ItemWebsocketsService } from './ws/services';
 
 const plugin: FastifyPluginAsync = async (fastify) => {
@@ -212,7 +212,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('update', ids, { error: e }),
+            ItemOpFeedbackEvent('update', ids, ResultOfFactory.withError(e)),
           );
         }
       });
@@ -253,7 +253,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('delete', ids, { error: e }),
+            ItemOpFeedbackEvent('delete', ids, ResultOfFactory.withError(e)),
           );
         }
       });
@@ -352,7 +352,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('copy', ids, { error: e }),
+            ItemOpFeedbackEvent('copy', ids, ResultOfFactory.withError(e)),
           );
         }
       });

--- a/src/services/item/plugins/action/index.ts
+++ b/src/services/item/plugins/action/index.ts
@@ -20,7 +20,7 @@ import {
   LocalFileConfiguration,
   S3FileConfiguration,
 } from '../../../file/interfaces/configuration';
-import { ItemOpFeedbackEvent, memberItemsTopic } from '../../ws/events';
+import { ItemOpFeedbackEvent, ResultOfFactory, memberItemsTopic } from '../../ws/events';
 import { CannotPostAction } from './errors';
 import { ActionRequestExportService } from './requestExport/service';
 import { exportAction, getAggregateActions, getItemActions, postAction } from './schemas';
@@ -175,7 +175,7 @@ const plugin: FastifyPluginAsync<GraaspActionsOptions> = async (fastify) => {
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('export', [itemId], { error: e }),
+            ItemOpFeedbackEvent('export', [itemId], ResultOfFactory.withError(e)),
           );
         }
       });

--- a/src/services/item/plugins/action/service.ts
+++ b/src/services/item/plugins/action/service.ts
@@ -280,6 +280,7 @@ export class ActionItemService {
     await this.actionService.postMany(member, repositories, request, actions);
   }
 
+  // TODO: remove it if it is never used
   async postManyMoveAction(
     request: FastifyRequest,
     reply: FastifyReply,
@@ -295,6 +296,18 @@ export class ActionItemService {
       extra: { itemId: item.id, body: request.body as any },
     }));
     await this.actionService.postMany(member, repositories, request, actions);
+  }
+
+  async postMoveAction(request: FastifyRequest, repositories: Repositories, item: Item) {
+    const { member } = request;
+    const action = {
+      item,
+      type: ItemActionType.Move,
+      // TODO: remove any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      extra: { itemId: item.id, body: request.body as any },
+    };
+    await this.actionService.post(member, repositories, request, action);
   }
 
   async postManyCopyAction(

--- a/src/services/item/plugins/action/test/ws.test.ts
+++ b/src/services/item/plugins/action/test/ws.test.ts
@@ -7,7 +7,7 @@ import { clearDatabase } from '../../../../../../test/app';
 import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
 import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
 import { setupWsApp } from '../../../../websockets/test/ws-app';
-import { ItemOpFeedbackEvent, memberItemsTopic } from '../../../ws/events';
+import { ItemOpFeedbackEvent, ResultOfFactory, memberItemsTopic } from '../../../ws/events';
 import { ActionRequestExportRepository } from '../requestExport/repository';
 
 // mock datasource
@@ -97,7 +97,11 @@ describe('asynchronous feedback', () => {
     await waitForExpect(() => {
       const [feedbackUpdate] = memberUpdates;
       expect(feedbackUpdate).toMatchObject(
-        ItemOpFeedbackEvent('export', [item.id], { error: new Error('mock error') }),
+        ItemOpFeedbackEvent(
+          'export',
+          [item.id],
+          ResultOfFactory.withError(new Error('mock error')),
+        ),
       );
     });
   });

--- a/src/services/item/plugins/recycled/index.ts
+++ b/src/services/item/plugins/recycled/index.ts
@@ -5,7 +5,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { IdParam, IdsParams, MAX_TARGETS_FOR_READ_REQUEST } from '@graasp/sdk';
 
 import { buildRepositories } from '../../../../utils/repositories';
-import { ItemOpFeedbackEvent, memberItemsTopic } from '../../ws/events';
+import { ItemOpFeedbackEvent, ResultOfFactory, memberItemsTopic } from '../../ws/events';
 import schemas, { getRecycledItemDatas, recycleMany, restoreMany } from './schemas';
 import { RecycledBinService } from './service';
 import { recycleWsHooks } from './ws/hooks';
@@ -88,7 +88,7 @@ const plugin: FastifyPluginAsync<RecycledItemDataOptions> = async (fastify, opti
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('recycle', ids, { error: e }),
+            ItemOpFeedbackEvent('recycle', ids, ResultOfFactory.withError(e)),
           );
         }
       });
@@ -138,7 +138,7 @@ const plugin: FastifyPluginAsync<RecycledItemDataOptions> = async (fastify, opti
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('restore', ids, { error: e }),
+            ItemOpFeedbackEvent('restore', ids, ResultOfFactory.withError(e)),
           );
         }
       });

--- a/src/services/item/plugins/recycled/test/ws.test.ts
+++ b/src/services/item/plugins/recycled/test/ws.test.ts
@@ -18,6 +18,7 @@ import {
   ItemEvent,
   ItemOpFeedbackEvent,
   OwnItemsEvent,
+  ResultOfFactory,
   SelfItemEvent,
   SharedItemsEvent,
   itemTopic,
@@ -710,9 +711,11 @@ describe('Recycle websocket hooks', () => {
       await waitForExpect(() => {
         const [feedbackUpdate] = memberUpdates;
         expect(feedbackUpdate).toMatchObject(
-          ItemOpFeedbackEvent('recycle', [item.id], {
-            error: new Error('mock error'),
-          }),
+          ItemOpFeedbackEvent(
+            'recycle',
+            [item.id],
+            ResultOfFactory.withError(new Error('mock error')),
+          ),
         );
       });
     });
@@ -771,9 +774,11 @@ describe('Recycle websocket hooks', () => {
       await waitForExpect(() => {
         const [feedbackUpdate] = memberUpdates;
         expect(feedbackUpdate).toMatchObject(
-          ItemOpFeedbackEvent('restore', [item.id], {
-            error: new Error('mock error'),
-          }),
+          ItemOpFeedbackEvent(
+            'restore',
+            [item.id],
+            ResultOfFactory.withError(new Error('mock error')),
+          ),
         );
       });
     });

--- a/src/services/item/plugins/validation/index.ts
+++ b/src/services/item/plugins/validation/index.ts
@@ -4,7 +4,7 @@ import { FastifyPluginAsync } from 'fastify';
 
 import { UnauthorizedMember } from '../../../../utils/errors';
 import { buildRepositories } from '../../../../utils/repositories';
-import { ItemOpFeedbackEvent, memberItemsTopic } from '../../ws/events';
+import { ItemOpFeedbackEvent, ResultOfFactory, memberItemsTopic } from '../../ws/events';
 import { itemValidation, itemValidationGroup } from './schemas';
 import { ItemValidationService } from './service';
 
@@ -98,7 +98,7 @@ const plugin: FastifyPluginAsync<GraaspPluginValidationOptions> = async (fastify
           websockets.publish(
             memberItemsTopic,
             member.id,
-            ItemOpFeedbackEvent('validate', [itemId], { error: e }),
+            ItemOpFeedbackEvent('validate', [itemId], ResultOfFactory.withError(e)),
           );
         }
       });

--- a/src/services/item/plugins/validation/test/ws.test.ts
+++ b/src/services/item/plugins/validation/test/ws.test.ts
@@ -8,7 +8,12 @@ import { ITEMS_ROUTE_PREFIX } from '../../../../../utils/config';
 import { saveItemAndMembership } from '../../../../itemMembership/test/fixtures/memberships';
 import { TestWsClient } from '../../../../websockets/test/test-websocket-client';
 import { setupWsApp } from '../../../../websockets/test/ws-app';
-import { ItemEvent, ItemOpFeedbackEvent, memberItemsTopic } from '../../../ws/events';
+import {
+  ItemEvent,
+  ItemOpFeedbackEvent,
+  ResultOfFactory,
+  memberItemsTopic,
+} from '../../../ws/events';
 import { ItemValidationGroupRepository } from '../repositories/ItemValidationGroup';
 import { saveItemValidation } from './utils';
 
@@ -82,9 +87,11 @@ describe('asynchronous feedback', () => {
     await waitForExpect(() => {
       const [feedbackUpdate] = memberUpdates;
       expect(feedbackUpdate).toMatchObject(
-        ItemOpFeedbackEvent('validate', [item.id], {
-          error: new Error('mock error'),
-        }),
+        ItemOpFeedbackEvent(
+          'validate',
+          [item.id],
+          ResultOfFactory.withError(new Error('mock error')),
+        ),
       );
     });
   });

--- a/src/services/item/test/ws.test.ts
+++ b/src/services/item/test/ws.test.ts
@@ -28,6 +28,7 @@ import {
   ItemEvent,
   ItemOpFeedbackEvent,
   OwnItemsEvent,
+  ResultOfFactory,
   SelfItemEvent,
   SharedItemsEvent,
   itemTopic,
@@ -618,7 +619,11 @@ describe('Item websocket hooks', () => {
       await waitForExpect(() => {
         const [feedbackUpdate] = memberUpdates;
         expect(feedbackUpdate).toMatchObject(
-          ItemOpFeedbackEvent('update', [item.id], { error: new Error('mock error') }),
+          ItemOpFeedbackEvent(
+            'update',
+            [item.id],
+            ResultOfFactory.withError(new Error('mock error')),
+          ),
         );
       });
     });
@@ -662,7 +667,11 @@ describe('Item websocket hooks', () => {
       await waitForExpect(() => {
         const [_ownUpdate, _accessibleUpdate, feedbackUpdate] = memberUpdates;
         expect(feedbackUpdate).toMatchObject(
-          ItemOpFeedbackEvent('delete', [item.id], { error: new Error('mock error') }),
+          ItemOpFeedbackEvent(
+            'delete',
+            [item.id],
+            ResultOfFactory.withError(new Error('mock error')),
+          ),
         );
       });
     });
@@ -714,7 +723,11 @@ describe('Item websocket hooks', () => {
       await waitForExpect(() => {
         const [feedbackUpdate] = memberUpdates;
         expect(feedbackUpdate).toMatchObject(
-          ItemOpFeedbackEvent('move', [item.id], { error: new Error('mock error') }),
+          ItemOpFeedbackEvent(
+            'move',
+            [item.id],
+            ResultOfFactory.withError(new Error('mock error')),
+          ),
         );
       });
     });
@@ -764,7 +777,11 @@ describe('Item websocket hooks', () => {
       await waitForExpect(() => {
         const [feedbackUpdate] = memberUpdates;
         expect(feedbackUpdate).toMatchObject(
-          ItemOpFeedbackEvent('copy', [item.id], { error: new Error('mock error') }),
+          ItemOpFeedbackEvent(
+            'copy',
+            [item.id],
+            ResultOfFactory.withError(new Error('mock error')),
+          ),
         );
       });
     });

--- a/src/services/item/test/ws.test.ts
+++ b/src/services/item/test/ws.test.ts
@@ -434,7 +434,7 @@ describe('Item websocket hooks', () => {
       });
       expect(response.statusCode).toBe(StatusCodes.ACCEPTED);
 
-      // When the websocket is not received, indicating that the transaction
+      // When the websocket is not received, indicates that the transaction
       // is still in progress, the item should contain the old path.
       expect((await ItemRepository.findOneBy({ id: childItem.id }))?.path).toContain(
         oldParentItem.path,
@@ -447,7 +447,7 @@ describe('Item websocket hooks', () => {
         );
       });
 
-      // When the websocket is received, indicating that the transaction
+      // When the websocket is received, indicates that the transaction
       // is done, the item should contain the new path.
       expect((await ItemRepository.findOneBy({ id: childItem.id }))?.path).toContain(
         newParentItem.path,
@@ -471,7 +471,7 @@ describe('Item websocket hooks', () => {
       });
       expect(response.statusCode).toBe(StatusCodes.ACCEPTED);
 
-      // When the websocket is not received, indicating that the transaction
+      // When the websocket is not received, indicates that the transaction
       // is still in progress, the item should contain the old path.
       expect((await ItemRepository.findOneBy({ id: childItem.id }))?.path).toContain(
         oldParentItem.path,
@@ -485,7 +485,7 @@ describe('Item websocket hooks', () => {
         );
       });
 
-      // When the websocket is received, indicating that the transaction
+      // When the websocket is received, indicates that the transaction
       // is done, the item should contain the new path.
       expect((await ItemRepository.findOneBy({ id: childItem.id }))?.path).toContain(
         newParentItem.path,
@@ -507,7 +507,7 @@ describe('Item websocket hooks', () => {
       });
       expect(response.statusCode).toBe(StatusCodes.ACCEPTED);
 
-      // When the websocket is not received, indicating that the transaction
+      // When the websocket is not received, indicates that the transaction
       // is still in progress, the item's parent path should be root (undefined).
       const itemBeforeUpdate = await ItemRepository.findOneBy({ id: item.id });
       if (!itemBeforeUpdate) {
@@ -523,7 +523,7 @@ describe('Item websocket hooks', () => {
         );
       });
 
-      // When the websocket is received, indicating that the transaction
+      // When the websocket is received, indicates that the transaction
       // is done, the item should contain the new parent path.
       const itemAfterUpdate = await ItemRepository.findOneBy({ id: item.id });
       if (!itemAfterUpdate) {
@@ -548,7 +548,7 @@ describe('Item websocket hooks', () => {
       });
       expect(response.statusCode).toBe(StatusCodes.ACCEPTED);
 
-      // When the websocket is not received, indicating that the transaction
+      // When the websocket is not received, indicates that the transaction
       // is still in progress, the item should contain the old path.
       expect((await ItemRepository.findOneBy({ id: childItem.id }))?.path).toContain(
         oldParentItem.path,
@@ -560,7 +560,7 @@ describe('Item websocket hooks', () => {
         expect(ownCreate).toMatchObject(OwnItemsEvent('create', parseStringToDate(moved) as Item));
       });
 
-      // When the websocket is received, indicating that the transaction
+      // When the websocket is received, indicates that the transaction
       // is done, the item's parent path should be root (undefined).
       const itemAfterUpdate = await ItemRepository.findOneBy({ id: childItem.id });
       if (!itemAfterUpdate) {

--- a/src/services/item/types.ts
+++ b/src/services/item/types.ts
@@ -30,3 +30,28 @@ export type ItemChildrenParams = {
   ordered?: boolean;
   types?: UnionOfConst<typeof ItemType>[];
 };
+
+export type SeriesPromiseResults<T> = {
+  success: T[];
+  failed: Error[];
+};
+
+export class SeriesPromise {
+  public static async allSettled<T>(
+    promises: (() => Promise<T>)[],
+  ): Promise<SeriesPromiseResults<T>> {
+    const success: SeriesPromiseResults<T>['success'] = [];
+    const failed: SeriesPromiseResults<T>['failed'] = [];
+
+    for (const promise of promises) {
+      try {
+        const result = await promise();
+        success.push(result);
+      } catch (error) {
+        failed.push(error);
+      }
+    }
+
+    return { success, failed };
+  }
+}

--- a/src/services/item/types.ts
+++ b/src/services/item/types.ts
@@ -31,17 +31,31 @@ export type ItemChildrenParams = {
   types?: UnionOfConst<typeof ItemType>[];
 };
 
-export type SeriesPromiseResults<T> = {
+export type PromiseRunnerResults<T> = {
   success: T[];
   failed: Error[];
 };
 
-export class SeriesPromise {
-  public static async allSettled<T>(
+export class PromiseRunner {
+  private static transformPromiseResults = <T>(results: PromiseSettledResult<T>[]) => {
+    const success = results
+      .filter((result) => result.status === 'fulfilled')
+      .map((result) => (result as PromiseFulfilledResult<T>).value);
+
+    const failed = results
+      .filter((result) => result.status === 'rejected')
+      .map((result) => new Error((result as PromiseRejectedResult).reason));
+
+    return { success, failed };
+  };
+
+  public static async inSeries<T>(
     promises: (() => Promise<T>)[],
-  ): Promise<SeriesPromiseResults<T>> {
-    const success: SeriesPromiseResults<T>['success'] = [];
-    const failed: SeriesPromiseResults<T>['failed'] = [];
+  ): Promise<PromiseRunnerResults<T>> {
+    const success: PromiseRunnerResults<T>['success'] = [];
+    const failed: PromiseRunnerResults<T>['failed'] = [];
+
+    const startTime = performance.now();
 
     for (const promise of promises) {
       try {
@@ -51,6 +65,31 @@ export class SeriesPromise {
         failed.push(error);
       }
     }
+
+    const endTime = performance.now();
+    console.log(
+      `Series terminated after ${endTime - startTime} ms for ${promises.length} Promises`,
+      startTime,
+      endTime,
+    );
+
+    return { success, failed };
+  }
+
+  public static async allSettled<T>(
+    promises: (() => Promise<T>)[],
+  ): Promise<PromiseRunnerResults<T>> {
+    const startTime = performance.now();
+
+    const results = await Promise.allSettled(promises.map((promise) => promise()));
+    const { success, failed } = PromiseRunner.transformPromiseResults(results);
+
+    const endTime = performance.now();
+    console.log(
+      `Concurrently terminated after ${endTime - startTime} ms for ${promises.length} Promises`,
+      startTime,
+      endTime,
+    );
 
     return { success, failed };
   }

--- a/src/services/item/utils.ts
+++ b/src/services/item/utils.ts
@@ -89,3 +89,15 @@ export const readPdfContent = async (source: string | URL) => {
     return '';
   }
 };
+
+export const getPromiseResults = <T>(results: PromiseSettledResult<T>[]) => {
+  const success = results
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => (result as PromiseFulfilledResult<T>).value);
+
+  const failed = results
+    .filter((result) => result.status === 'rejected')
+    .map((result) => (result as PromiseRejectedResult).reason);
+
+  return { success, failed };
+};

--- a/src/services/item/utils.ts
+++ b/src/services/item/utils.ts
@@ -89,15 +89,3 @@ export const readPdfContent = async (source: string | URL) => {
     return '';
   }
 };
-
-export const getPromiseResults = <T>(results: PromiseSettledResult<T>[]) => {
-  const success = results
-    .filter((result) => result.status === 'fulfilled')
-    .map((result) => (result as PromiseFulfilledResult<T>).value);
-
-  const failed = results
-    .filter((result) => result.status === 'rejected')
-    .map((result) => (result as PromiseRejectedResult).reason);
-
-  return { success, failed };
-};

--- a/src/services/item/ws/events.ts
+++ b/src/services/item/ws/events.ts
@@ -130,6 +130,11 @@ export const SharedItemsEvent = (op: SharedItemsEvent['op'], item: Item): Shared
   item,
 });
 
+export const ResultOfFactory = {
+  withError: (e: Error) => ResultOfFactory.withErrors([e]),
+  withErrors: (errors: Error[]) => ({ data: {}, errors }),
+};
+
 /**
  * Events from asynchronous background operations on given items
  */
@@ -137,11 +142,7 @@ export interface ItemOpFeedbackEventInterface {
   kind: 'feedback';
   op: 'update' | 'delete' | 'move' | 'copy' | 'export' | 'recycle' | 'restore' | 'validate';
   resource: Item['id'][];
-  result:
-    | {
-        error: Error;
-      }
-    | ResultOf<Item>;
+  result: ResultOf<Item>;
 }
 
 /**
@@ -160,8 +161,12 @@ export const ItemOpFeedbackEvent = (
   kind: 'feedback',
   op,
   resource,
-  result: result['error']
-    ? // monkey patch because somehow JSON.stringify(e: Error) will always result in {}
-      { error: { name: result['error'].name, message: result['error'].message } }
-    : result,
+  result: {
+    data: result.data,
+    // monkey patch because JSON.stringify(e: Error) will always result in {}
+    errors: result.errors.map((e) => ({
+      name: e.name,
+      message: e.message,
+    })),
+  },
 });

--- a/src/services/item/ws/events.ts
+++ b/src/services/item/ws/events.ts
@@ -133,7 +133,7 @@ export const SharedItemsEvent = (op: SharedItemsEvent['op'], item: Item): Shared
 /**
  * Events from asynchronous background operations on given items
  */
-interface ItemOpFeedbackEvent {
+export interface ItemOpFeedbackEventInterface {
   kind: 'feedback';
   op: 'update' | 'delete' | 'move' | 'copy' | 'export' | 'recycle' | 'restore' | 'validate';
   resource: Item['id'][];
@@ -153,10 +153,10 @@ interface ItemOpFeedbackEvent {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const ItemOpFeedbackEvent = (
-  op: ItemOpFeedbackEvent['op'],
-  resource: ItemOpFeedbackEvent['resource'],
-  result: ItemOpFeedbackEvent['result'],
-): ItemOpFeedbackEvent => ({
+  op: ItemOpFeedbackEventInterface['op'],
+  resource: ItemOpFeedbackEventInterface['resource'],
+  result: ItemOpFeedbackEventInterface['result'],
+): ItemOpFeedbackEventInterface => ({
   kind: 'feedback',
   op,
   resource,

--- a/src/services/item/ws/services.ts
+++ b/src/services/item/ws/services.ts
@@ -4,112 +4,129 @@ import { getParentFromPath } from '@graasp/sdk';
 
 import { WebsocketService } from '../../websockets/ws-service';
 import { Item } from '../entities/Item';
-import { getPromiseResults } from '../utils';
+import { SeriesPromiseResults } from '../types';
 import {
   AccessibleItemsEvent,
   ChildItemEvent,
   ItemOpFeedbackEvent,
+  ItemOpFeedbackEventInterface,
   OwnItemsEvent,
   itemTopic,
   memberItemsTopic,
 } from './events';
 
-// on move item:
-// - notify own items of creator of delete IF old location was root
-// - notify own items of creator of create IF new location is root
-const publishMemberItemsTopic = (
-  websockets: WebsocketService,
-  { source, destination, sourceParentId },
-) => {
-  if (sourceParentId === undefined && source.creator) {
-    // root item, notify creator
-    // todo: remove own when we don't use own anymore
-    websockets.publish(memberItemsTopic, source.creator.id, OwnItemsEvent('delete', source));
-    websockets.publish(memberItemsTopic, source.creator.id, AccessibleItemsEvent('delete', source));
-  }
-
-  const destParentId = getParentFromPath(destination.path);
-  if (destParentId === undefined && destination.creator) {
-    // root item, notify creator
-    // todo: remove own when we don't use own anymore
-    websockets.publish(
-      memberItemsTopic,
-      destination.creator.id,
-      OwnItemsEvent('create', destination),
-    );
-    websockets.publish(
-      memberItemsTopic,
-      destination.creator.id,
-      AccessibleItemsEvent('create', destination),
-    );
-  }
+type MoveParams = {
+  source: Item;
+  destination: Item;
+  sourceParentId?: string;
 };
 
-// on move item, notify:
-// - parent of old location of deleted child
-// - parent of new location of new child
-const publishItemTopic = (
-  websockets: WebsocketService,
-  { source, destination, sourceParentId },
-) => {
-  if (sourceParentId !== undefined) {
-    websockets.publish(itemTopic, sourceParentId, ChildItemEvent('delete', source));
+export class ItemWebsocketsService {
+  private websockets;
+
+  constructor(websockets: WebsocketService) {
+    this.websockets = websockets;
   }
 
-  const destParentId = getParentFromPath(destination.path);
-  if (destParentId) {
-    websockets.publish(itemTopic, destParentId, ChildItemEvent('create', destination));
-  }
-};
+  // TODO: update this to send only one ws ? like a warning or success or error ?
+  private publishFeedback({
+    results,
+    itemIds,
+    log,
+    memberId,
+    feedbackOp,
+  }: {
+    results: SeriesPromiseResults<Item>;
+    itemIds: string[];
+    log: FastifyBaseLogger;
+    memberId: string;
+    feedbackOp: ItemOpFeedbackEventInterface['op'];
+  }) {
+    const { success, failed } = results;
+    const successIds = success.map((i) => i.id);
+    const failedIds = itemIds.filter((id) => !successIds.includes(id));
 
-export const publishAfterMoved = (
-  websockets: WebsocketService,
-  { source, destination, sourceParentId },
-) => {
-  publishItemTopic(websockets, { source, destination, sourceParentId });
-  publishMemberItemsTopic(websockets, { source, destination, sourceParentId });
-};
-
-// TODO: update this to send only one ws ? like a warning or success or error ?
-export const publishFeedbackAfterAllMoved = ({
-  websockets,
-  results,
-  itemIds,
-  log,
-  memberId,
-}: {
-  websockets: WebsocketService;
-  results: PromiseSettledResult<Item>[];
-  itemIds: string[];
-  log: FastifyBaseLogger;
-  memberId: string;
-}) => {
-  const { success, failed } = getPromiseResults(results);
-  const successIds = success.map((i) => i.id);
-  const failedIds = itemIds.filter((id) => !successIds.includes(id));
-
-  if (success.length) {
-    websockets.publish(
-      memberItemsTopic,
-      memberId,
-      ItemOpFeedbackEvent(
-        'move',
-        success.map((i) => i.id),
-        {
-          data: Object.fromEntries(success.map((i) => [i.id, i])),
-          errors: [],
-        },
-      ),
-    );
-  }
-  if (failed.length) {
-    failed.forEach((e) => {
-      log.error(e);
-      websockets.publish(
+    if (success.length) {
+      this.websockets.publish(
         memberItemsTopic,
         memberId,
-        ItemOpFeedbackEvent('move', failedIds, { error: e }),
+        ItemOpFeedbackEvent(feedbackOp, successIds, {
+          data: Object.fromEntries(success.map((i) => [i.id, i])),
+          errors: [],
+        }),
       );
+    }
+    if (failed.length) {
+      failed.forEach((e) => {
+        log.error(e);
+        this.websockets.publish(
+          memberItemsTopic,
+          memberId,
+          ItemOpFeedbackEvent(feedbackOp, failedIds, { error: e }),
+        );
+      });
+    }
+  }
+
+  public publishTopicsForMove({ source, destination, sourceParentId }: MoveParams) {
+    const destParentId = getParentFromPath(destination.path);
+
+    // on move item:
+    // - notify own items of creator of delete IF old location was root
+    // - notify own items of creator of create IF new location is root
+    if (sourceParentId === undefined && source.creator) {
+      // root item, notify creator
+      // todo: remove own when we don't use own anymore
+      this.websockets.publish(memberItemsTopic, source.creator.id, OwnItemsEvent('delete', source));
+      this.websockets.publish(
+        memberItemsTopic,
+        source.creator.id,
+        AccessibleItemsEvent('delete', source),
+      );
+    }
+    if (destParentId === undefined && destination.creator) {
+      // root item, notify creator
+      // todo: remove own when we don't use own anymore
+      this.websockets.publish(
+        memberItemsTopic,
+        destination.creator.id,
+        OwnItemsEvent('create', destination),
+      );
+      this.websockets.publish(
+        memberItemsTopic,
+        destination.creator.id,
+        AccessibleItemsEvent('create', destination),
+      );
+    }
+
+    // on move item, notify:
+    // - parent of old location of deleted child
+    // - parent of new location of new child
+    if (sourceParentId !== undefined) {
+      this.websockets.publish(itemTopic, sourceParentId, ChildItemEvent('delete', source));
+    }
+    if (destParentId) {
+      this.websockets.publish(itemTopic, destParentId, ChildItemEvent('create', destination));
+    }
+  }
+
+  public publishFeedbacksForMove({
+    results,
+    itemIds,
+    log,
+    memberId,
+  }: {
+    results: SeriesPromiseResults<Item>;
+    itemIds: string[];
+    log: FastifyBaseLogger;
+    memberId: string;
+  }) {
+    this.publishFeedback({
+      results,
+      itemIds,
+      log,
+      memberId,
+      feedbackOp: 'move',
     });
   }
-};
+}

--- a/src/services/item/ws/services.ts
+++ b/src/services/item/ws/services.ts
@@ -1,0 +1,115 @@
+import { FastifyBaseLogger } from 'fastify';
+
+import { getParentFromPath } from '@graasp/sdk';
+
+import { WebsocketService } from '../../websockets/ws-service';
+import { Item } from '../entities/Item';
+import { getPromiseResults } from '../utils';
+import {
+  AccessibleItemsEvent,
+  ChildItemEvent,
+  ItemOpFeedbackEvent,
+  OwnItemsEvent,
+  itemTopic,
+  memberItemsTopic,
+} from './events';
+
+// on move item:
+// - notify own items of creator of delete IF old location was root
+// - notify own items of creator of create IF new location is root
+const publishMemberItemsTopic = (
+  websockets: WebsocketService,
+  { source, destination, sourceParentId },
+) => {
+  if (sourceParentId === undefined && source.creator) {
+    // root item, notify creator
+    // todo: remove own when we don't use own anymore
+    websockets.publish(memberItemsTopic, source.creator.id, OwnItemsEvent('delete', source));
+    websockets.publish(memberItemsTopic, source.creator.id, AccessibleItemsEvent('delete', source));
+  }
+
+  const destParentId = getParentFromPath(destination.path);
+  if (destParentId === undefined && destination.creator) {
+    // root item, notify creator
+    // todo: remove own when we don't use own anymore
+    websockets.publish(
+      memberItemsTopic,
+      destination.creator.id,
+      OwnItemsEvent('create', destination),
+    );
+    websockets.publish(
+      memberItemsTopic,
+      destination.creator.id,
+      AccessibleItemsEvent('create', destination),
+    );
+  }
+};
+
+// on move item, notify:
+// - parent of old location of deleted child
+// - parent of new location of new child
+const publishItemTopic = (
+  websockets: WebsocketService,
+  { source, destination, sourceParentId },
+) => {
+  if (sourceParentId !== undefined) {
+    websockets.publish(itemTopic, sourceParentId, ChildItemEvent('delete', source));
+  }
+
+  const destParentId = getParentFromPath(destination.path);
+  if (destParentId) {
+    websockets.publish(itemTopic, destParentId, ChildItemEvent('create', destination));
+  }
+};
+
+export const publishAfterMoved = (
+  websockets: WebsocketService,
+  { source, destination, sourceParentId },
+) => {
+  publishItemTopic(websockets, { source, destination, sourceParentId });
+  publishMemberItemsTopic(websockets, { source, destination, sourceParentId });
+};
+
+// TODO: update this to send only one ws ? like a warning or success or error ?
+export const publishFeedbackAfterAllMoved = ({
+  websockets,
+  results,
+  itemIds,
+  log,
+  memberId,
+}: {
+  websockets: WebsocketService;
+  results: PromiseSettledResult<Item>[];
+  itemIds: string[];
+  log: FastifyBaseLogger;
+  memberId: string;
+}) => {
+  const { success, failed } = getPromiseResults(results);
+  const successIds = success.map((i) => i.id);
+  const failedIds = itemIds.filter((id) => !successIds.includes(id));
+
+  if (success.length) {
+    websockets.publish(
+      memberItemsTopic,
+      memberId,
+      ItemOpFeedbackEvent(
+        'move',
+        success.map((i) => i.id),
+        {
+          data: Object.fromEntries(success.map((i) => [i.id, i])),
+          errors: [],
+        },
+      ),
+    );
+  }
+  if (failed.length) {
+    failed.forEach((e) => {
+      log.error(e);
+      websockets.publish(
+        memberItemsTopic,
+        memberId,
+        ItemOpFeedbackEvent('move', failedIds, { error: e }),
+      );
+    });
+  }
+};

--- a/src/services/item/ws/services.ts
+++ b/src/services/item/ws/services.ts
@@ -4,7 +4,7 @@ import { getParentFromPath } from '@graasp/sdk';
 
 import { WebsocketService } from '../../websockets/ws-service';
 import { Item } from '../entities/Item';
-import { SeriesPromiseResults } from '../types';
+import { PromiseRunnerResults } from '../types';
 import {
   AccessibleItemsEvent,
   ChildItemEvent,
@@ -22,7 +22,7 @@ type MoveParams = {
 };
 
 type PublishFeedbackParams = {
-  results: SeriesPromiseResults<Item>;
+  results: PromiseRunnerResults<Item>;
   itemIds: string[];
   log: FastifyBaseLogger;
   memberId: string;


### PR DESCRIPTION
- use one transaction for each move item
- publish websocket post move item after the transaction
- publish websocket feedback after all the transactions

For more details, please see #831 

# Validation of the Implementation

**Protocol of the Test**:

- Run each test five times to obtain an average time.
- The time is computed as the highest end time minus the smallest start time.
    - This is because the maximum number of moves is 20, so to move 100 items, it will require 5 API calls.
- For each test, the items and actions are reset.
    - There are 100 items, each with 10 children => 1000 items.
    - There are 1000 actions per item => 1,000,000 actions.
- For each test with web sockets, the builder is forced to refresh.

**Tests 1 - Parallel vs Series with Multiple Transactions without Intermediate Web Sockets**

|                    | In Series | In Parallel |
|:-------------------|:----------|:------------|
|        Time 1 (ms) |   26,916  |   33,155    |
|        Time 2 (ms) |   24,872  |   27,055    |
|        Time 3 (ms) |   30,011  |   35,195    |
|        Time 4 (ms) |   28,483  |   25,567    |
|        Time 5 (ms) |   29,027  |   34,580    |
| **Avg. Time (ms)** | **27,862**| **31,110**  |

Results: Parallel seems to be slower than in series. Also, in series, the feedback isn’t sent at the end of the 20 items but at the whole end.

> [!IMPORTANT]  
> In parallel, each promise has its own thread freezing the database for the time that the move is run. This is not acceptable.

> [!NOTE]
> Maybe use a thread pool (running 5 threads, in each thread having 20 items to move in series…)

**Test 2 - Only One Transaction, moving items are executed in parallel, without web sockets**

|                    | In Parallel |
|:-------------------|:------------|
|        Time 1 (ms) |   27,455     |
|        Time 2 (ms) |   27,808     |
|        Time 3 (ms) |   26,761     |
|        Time 4 (ms) |   33,306     |
|        Time 5 (ms) |   30,993     |
| **Avg. Time (ms)** | **29,265**  |

**Test 3 - Parallel vs Series with Multiple Transactions and web sockets**

> [!IMPORTANT]  
> Refresh the browser to be sure to have a web socket connection!!!

The problem principally comes from the rerender of the table… Indeed, when disabling the invalidation, the manual manipulations conduct to a re-render, involving the HTTP Requests.

|                    | In Series | In Parallel |
|:-------------------|:----------|:------------|
|        Time 1 (ms) |   71,963  |   54,972    |
|        Time 2 (ms) |   64,392  |   79,857    |
|        Time 3 (ms) |   75,210  |   74,077    |
|        Time 4 (ms) |   68,794  |   40,444    |
|        Time 5 (ms) |   63,661  |   51,855    |
| **Avg. Time (ms)** |   68,804  |   60,241    |

Results: In parallel is a little bit faster.
