### PR TITLE
fix: local file bugs and add a localfiles server

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -169,7 +169,6 @@ services:
     ports:
       - 1081:80
 
-
   # necessary for graasp-embedded-link-item
   iframely:
     container_name: graasp-iframely

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       PUBLIC_URL: http://localhost:3000
       # temporary storage for files inside the container
       FILE_STORAGE_ROOT_PATH: /tmp/graasp-file-item-storage
+      # the localfile config host points to the static file server defined below
+      FILE_STORAGE_HOST: http://localhost:1081
       # the DB config is set by the "db" service below
       DB_NAME: docker
       DB_USERNAME: docker
@@ -154,6 +156,19 @@ services:
       - AWS_DEFAULT_REGION=us-east-1
     ports:
       - 4566-4583:4566-4583
+
+  localfile:
+    image: joseluisq/static-web-server:2
+    environment:
+      # Note: those envs are customizable but also optional
+      # - SERVER_HOST=127.0.0.1
+      - SERVER_PORT=80
+      - SERVER_ROOT=/tmp/graasp-file-item-storage
+    volumes:
+      - ../tmp:/tmp/graasp-file-item-storage
+    ports:
+      - 1081:80
+
 
   # necessary for graasp-embedded-link-item
   iframely:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ REFRESH_TOKEN_EXPIRATION_IN_MINUTES=86400
 # Graasp file item file storage path
 # File item storage is set by ./.devcontainer/docker-compose.yml
 # FILE_STORAGE_ROOT_PATH=
+FILE_STORAGE_HOST=http://localhost:1081
 
 # Graasp s3 file item
 S3_FILE_ITEM_PLUGIN=false

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This will create 10 containers :
 - `graasp-localstack` : Localstack instance use to fake S3 storage locally
 - `graasp-iframely` : Iframely instance used to get embeds for links
 - `mailer-1` : Simple mailer instance used to receive emails locally (see the [Utilities section](#utilities))
+- `localfile-1` : Simple static file server to get files stored in graasp when using the `local` storage otpion (see the [Utilities section](#utilities))
 
 > **Important**
 > To use localstack with the Docker installation, it is necessary to edit your `/etc/hosts` with the following line `127.0.0.1 localstack`. This is necessary because the backend creates signed urls with the localstack container hostname. Without changing the hosts, the developpement machine cannot resolve the `http://localstack` hostname.
@@ -147,7 +148,7 @@ REFRESH_TOKEN_EXPIRATION_IN_MINUTES=86400
 # Graasp file item file storage path
 # File item storage is set by ./.devcontainer/docker-compose.yml
 # FILE_STORAGE_ROOT_PATH=
-FILE_STORAGE_HOST=http://localhost:1081
+# FILE_STORAGE_HOST=http://localhost:1081
 
 # Graasp s3 file item
 S3_FILE_ITEM_PLUGIN=false
@@ -225,6 +226,8 @@ To run the application, use `yarn watch`. If any file change, the application wi
 ## Utilities
 
 The development [docker-compose.yml](.devcontainer/docker-compose.yml) provides an instance of [mailcatcher](https://mailcatcher.me/), which emulates a SMTP server for sending e-mails. When using the email authentication flow, the mailbox web UI is accessible at [http://localhost:1080](http://localhost:1080). If you do not want to use mailcatcher, set the `MAILER_CONFIG_SMTP_HOST` variable in your `.env.development` to some random value (e.g. empty string). This will log the authentication links in the server console instead.
+
+The development [docker-compose.yml](.devcontainer/docker-compose.yml) provides a [static file server](https://static-web-server.net/) for serving files when using the `local` storage option (alternative to the `s3` option). This option has the added benefit of being persistent when used locally in opposition to localstack (see the [known issues section](#known-issues) for more informations). The server is available at `http://localhost:1081`.
 
 ## Testing
 

--- a/src/services/file/index.ts
+++ b/src/services/file/index.ts
@@ -23,6 +23,9 @@ const basePlugin: FastifyPluginAsync<GraaspPluginFileOptions> = async (fastify, 
   ) {
     throw new Error('graasp-plugin-file: local service storageRootPath is malformed');
   }
+  if (fileItemType === ItemType.LOCAL_FILE && !fileConfigurations?.local?.localFilesHost) {
+    throw new Error('graasp-plugin-file: local service localFilesHost is not defined');
+  }
 
   if (fileItemType === ItemType.S3_FILE) {
     if (

--- a/src/services/file/repositories/local.ts
+++ b/src/services/file/repositories/local.ts
@@ -18,7 +18,7 @@ export class LocalFileRepository implements FileRepository {
   buildFullPath = (filepath: string) => path.join(this.options.storageRootPath, filepath);
 
   async getFileSize(filepath: string) {
-    const metadata = fs.statSync(filepath);
+    const metadata = fs.statSync(this.buildFullPath(filepath));
     return metadata.size;
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -212,6 +212,7 @@ export const MAILER_CONFIG_FROM_EMAIL =
 // Graasp file item
 // TODO: should this be here?
 export const FILE_STORAGE_ROOT_PATH = process.env.FILE_STORAGE_ROOT_PATH || process.env.TMPDIR;
+export const FILE_STORAGE_HOST = process.env.FILE_STORAGE_HOST;
 
 // Graasp S3 file item
 // TODO: should this be here?
@@ -326,7 +327,10 @@ export const DB_PORT = process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) :
 // validation
 export const IMAGE_CLASSIFIER_API = process.env.IMAGE_CLASSIFIER_API;
 
-export const FILE_ITEM_PLUGIN_OPTIONS = { storageRootPath: FILE_STORAGE_ROOT_PATH ?? 'root' };
+export const FILE_ITEM_PLUGIN_OPTIONS: LocalFileConfiguration = {
+  storageRootPath: FILE_STORAGE_ROOT_PATH ?? 'root',
+  localFilesHost: FILE_STORAGE_HOST,
+};
 
 export const ITEMS_ROUTE_PREFIX = '/items';
 export const APP_ITEMS_PREFIX = '/app-items';


### PR DESCRIPTION
In this PR:
- fix #841 
- fix: use fullpath when reading file size locally
- fix: add a static file server for local files

I added a local files server for when you use the local file system.
This has the advantage that:
- files are local, they should stay between re-boots. they will be removed if you delete the graasp folder on your machine.
- the static server is there to simply serve the files. Before there was not way to access the files that were stored on the device. This tries to mimic how it works with signed urls from s3 but much simpler. 
- the static file server is very small.

Let me know what you think. Also if you think more documentation should be added to document this (dev) feature.
