### PR TITLE
fix: add CORS on status endpoint

### DIFF
--- a/src/plugins/meta.ts
+++ b/src/plugins/meta.ts
@@ -1,3 +1,4 @@
+import { rejects } from 'assert';
 import fetch from 'node-fetch';
 import { EntityManager } from 'typeorm';
 
@@ -65,7 +66,7 @@ class UnHealthyStatus extends ServiceStatus {
 }
 
 const plugin: FastifyPluginAsync = async (fastify) => {
-  fastify.get('/status', async () => {
+  fastify.get('/status', async (_, reply) => {
     const {
       db,
       search: { service: searchService },
@@ -75,6 +76,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     const etherpad = (await getEtherpadStatusCheck()).format();
     const meilisearch = (await getSearchStatusCheck(searchService)).format();
     const iframely = (await getIframelyStatusCheck()).format();
+
+    // allow request cross origin
+    reply.header('Access-Control-Allow-Origin', '*');
     return {
       api,
       database,

--- a/src/plugins/meta.ts
+++ b/src/plugins/meta.ts
@@ -1,4 +1,3 @@
-import { rejects } from 'assert';
 import fetch from 'node-fetch';
 import { EntityManager } from 'typeorm';
 


### PR DESCRIPTION
Add CORS headers on `/status` endpoint to allow querying the status from Auth frontend.