### PR TITLE
fix: do not expose port 1025 to the local machine

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -188,7 +188,6 @@ services:
   mailer:
     image: schickling/mailcatcher
     ports:
-      - "1025:1025"
       - "1080:1080"
 
 volumes:


### PR DESCRIPTION
This PR removed the exposed port `1025` and reduces it to be accessible only inside docker network. We do not need this port to be exposed publicly on the machine and it can be seen as a security vulnerability. 