### PR TITLE
feat: allow user to enable/disable saving actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/view": "7.4.1",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "4.6.0",
+    "@graasp/sdk": "4.7.0",
     "@graasp/translations": "1.23.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.64.0",

--- a/src/migrations/1712230247740-enable-save-actions.ts
+++ b/src/migrations/1712230247740-enable-save-actions.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1712230247740 implements MigrationInterface {
+  name = 'enable-save-actions-1712230247740';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "member" ADD "enable_save_actions" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "member" DROP COLUMN "enable_save_actions"`);
+  }
+}

--- a/src/migrations/1712241391870-enable-save-actions.ts
+++ b/src/migrations/1712241391870-enable-save-actions.ts
@@ -4,7 +4,9 @@ export class Migrations1712241391870 implements MigrationInterface {
   name = 'enable-save-actions-1712241391870';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "member" ADD "enable_save_actions" boolean`);
+    await queryRunner.query(
+      `ALTER TABLE "member" ADD "enable_save_actions" boolean NOT NULL DEFAULT true`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1712241391870-enable-save-actions.ts
+++ b/src/migrations/1712241391870-enable-save-actions.ts
@@ -1,12 +1,10 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class Migrations1712230247740 implements MigrationInterface {
-  name = 'enable-save-actions-1712230247740';
+export class Migrations1712241391870 implements MigrationInterface {
+  name = 'enable-save-actions-1712241391870';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "member" ADD "enable_save_actions" boolean NOT NULL DEFAULT false`,
-    );
+    await queryRunner.query(`ALTER TABLE "member" ADD "enable_save_actions" boolean`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/services/action/services/action.test.ts
+++ b/src/services/action/services/action.test.ts
@@ -46,6 +46,7 @@ describe('ActionService', () => {
       expect(await rawRepository.count()).toEqual(actions.length);
     });
 
+    // TODO: check if this enableSaveActions is used or not.
     it('does not post actions if member disable analytics', async () => {
       ({ app, actor } = await build({
         member: MemberFactory({ extra: { enableSaveActions: false } }),

--- a/src/services/action/services/action.test.ts
+++ b/src/services/action/services/action.test.ts
@@ -46,10 +46,9 @@ describe('ActionService', () => {
       expect(await rawRepository.count()).toEqual(actions.length);
     });
 
-    // TODO: check if this enableSaveActions is used or not.
     it('does not post actions if member disable analytics', async () => {
       ({ app, actor } = await build({
-        member: MemberFactory({ extra: { enableSaveActions: false } }),
+        member: MemberFactory({ enableSaveActions: false }),
       }));
       const actions = [ActionFactory(), ActionFactory(), ActionFactory()] as unknown as Action[];
       const request = MOCK_REQUEST;

--- a/src/services/action/services/action.ts
+++ b/src/services/action/services/action.ts
@@ -25,6 +25,7 @@ export class ActionService {
   ): Promise<void> {
     const { headers } = request;
 
+    // TODO: check this enableSaveActions too.
     // prevent saving if member disabled
     const enableMemberSaving = member?.extra?.enableSaveActions ?? true;
     if (!enableMemberSaving) {

--- a/src/services/action/services/action.ts
+++ b/src/services/action/services/action.ts
@@ -26,9 +26,7 @@ export class ActionService {
     const { headers } = request;
 
     // prevent saving if member disabled
-    const enableMemberSaving = member?.enableSaveActions ?? true;
-    if (!enableMemberSaving) {
-      // TODO: should we throw something here?
+    if (!member?.enableSaveActions) {
       return;
     }
 

--- a/src/services/action/services/action.ts
+++ b/src/services/action/services/action.ts
@@ -25,10 +25,10 @@ export class ActionService {
   ): Promise<void> {
     const { headers } = request;
 
-    // TODO: check this enableSaveActions too.
     // prevent saving if member disabled
-    const enableMemberSaving = member?.extra?.enableSaveActions ?? true;
+    const enableMemberSaving = member?.enableSaveActions ?? true;
     if (!enableMemberSaving) {
+      // TODO: should we throw something here?
       return;
     }
 

--- a/src/services/action/services/action.ts
+++ b/src/services/action/services/action.ts
@@ -25,8 +25,8 @@ export class ActionService {
   ): Promise<void> {
     const { headers } = request;
 
-    // prevent saving if member disabled
-    if (!member?.enableSaveActions) {
+    // prevent saving if member is defined and has disabled saveActions
+    if (member?.enableSaveActions === false) {
       return;
     }
 

--- a/src/services/auth/plugins/magicLink/index.ts
+++ b/src/services/auth/plugins/magicLink/index.ts
@@ -25,7 +25,13 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   await fastify.register(async function (fastify) {
     // register
     fastify.post<{
-      Body: { name: string; email: string; captcha: string; url?: string };
+      Body: {
+        name: string;
+        email: string;
+        captcha: string;
+        url?: string;
+        enableSaveActions?: boolean;
+      };
       Querystring: { lang?: string };
     }>('/register', { schema: register }, async (request, reply) => {
       const {

--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -121,8 +121,8 @@ describe('Auth routes tests', () => {
       expectMember(m, { name, email });
       expect(m?.enableSaveActions).toBe(false);
       // ensure that the user agreements are set for new registration
-      expect(m?.userAgreements).toBeDefined();
-      expect(m?.userAgreements).toBeInstanceOf(Date);
+      expect(m?.userAgreementsDate).toBeDefined();
+      expect(m?.userAgreementsDate).toBeInstanceOf(Date);
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });
 
@@ -149,8 +149,8 @@ describe('Auth routes tests', () => {
       expectMember(m, { name, email });
       expect(m?.enableSaveActions).toBe(enableSaveActions);
       // ensure that the user agreements are set for new registration
-      expect(m?.userAgreements).toBeDefined();
-      expect(m?.userAgreements).toBeInstanceOf(Date);
+      expect(m?.userAgreementsDate).toBeDefined();
+      expect(m?.userAgreementsDate).toBeInstanceOf(Date);
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });
 

--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -99,15 +99,16 @@ describe('Auth routes tests', () => {
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });
 
-    it('Save actions is disabled by default', async () => {
+    it('Save actions is disabled when explicitly asked', async () => {
       const email = 'someemail@email.com';
       const name = 'anna';
+      const enableSaveActions = false;
 
       const mockSendEmail = jest.spyOn(app.mailer, 'sendEmail');
       const response = await app.inject({
         method: HttpMethod.Post,
         url: `/register`,
-        payload: { email, name, captcha: MOCK_CAPTCHA },
+        payload: { email, name, captcha: MOCK_CAPTCHA, enableSaveActions },
       });
 
       expect(mockSendEmail).toHaveBeenCalledWith(
@@ -119,7 +120,7 @@ describe('Auth routes tests', () => {
       );
       const m = await MemberRepository.findOneBy({ email, name });
       expectMember(m, { name, email });
-      expect(m?.enableSaveActions).toBe(false);
+      expect(m?.enableSaveActions).toBe(enableSaveActions);
       // ensure that the user agreements are set for new registration
       expect(m?.userAgreementsDate).toBeDefined();
       expect(m?.userAgreementsDate).toBeInstanceOf(Date);

--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -118,7 +118,8 @@ describe('Auth routes tests', () => {
         expect.anything(),
       );
       const m = await MemberRepository.findOneBy({ email, name });
-      expectMember(m, { name, email, enableSaveActions: false });
+      expectMember(m, { name, email });
+      expect(m?.enableSaveActions).toBe(false);
       // ensure that the user agreements are set for new registration
       expect(m?.userAgreements).toBeDefined();
       expect(m?.userAgreements).toBeInstanceOf(Date);
@@ -145,7 +146,8 @@ describe('Auth routes tests', () => {
         expect.anything(),
       );
       const m = await MemberRepository.findOneBy({ email, name });
-      expectMember(m, { name, email, enableSaveActions });
+      expectMember(m, { name, email });
+      expect(m?.enableSaveActions).toBe(enableSaveActions);
       // ensure that the user agreements are set for new registration
       expect(m?.userAgreements).toBeDefined();
       expect(m?.userAgreements).toBeInstanceOf(Date);

--- a/src/services/auth/plugins/magicLink/schemas.ts
+++ b/src/services/auth/plugins/magicLink/schemas.ts
@@ -10,6 +10,7 @@ export const register = {
         type: 'string',
         format: 'uri',
       },
+      enableSaveActions: { type: 'boolean' },
     },
     additionalProperties: false,
   },

--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -40,7 +40,13 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.decorateRequest('memberId', null);
 
   fastify.post<{
-    Body: { name: string; email: string; challenge: string; captcha: string };
+    Body: {
+      name: string;
+      email: string;
+      challenge: string;
+      captcha: string;
+      enableSaveActions?: boolean;
+    };
     Querystring: { lang?: string };
   }>('/register', { schema: mregister }, async (request, reply) => {
     const {

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -104,6 +104,41 @@ describe('Mobile Endpoints', () => {
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });
 
+    it('Save actions is disabled by default', async () => {
+      const email = 'someemail@email.com';
+      const name = 'anna';
+
+      const mockSendEmail = jest.spyOn(app.mailer, 'sendEmail');
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: '/m/register',
+        payload: { email, name, challenge, captcha: MOCK_CAPTCHA },
+      });
+
+      const m = await MemberRepository.findOneBy({ email });
+      expectMember(m, { email, name, enableSaveActions: false });
+      expect(mockSendEmail).toHaveBeenCalled();
+      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+    });
+
+    it('Enable save actions when explicitly asked', async () => {
+      const email = 'someemail@email.com';
+      const name = 'anna';
+      const enableSaveActions = true;
+
+      const mockSendEmail = jest.spyOn(app.mailer, 'sendEmail');
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: '/m/register',
+        payload: { email, name, challenge, enableSaveActions, captcha: MOCK_CAPTCHA },
+      });
+
+      const m = await MemberRepository.findOneBy({ email });
+      expectMember(m, { email, name, enableSaveActions });
+      expect(mockSendEmail).toHaveBeenCalled();
+      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+    });
+
     it('Sign Up fallback to login for already register member', async () => {
       const member = await saveMember();
 

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -116,7 +116,8 @@ describe('Mobile Endpoints', () => {
       });
 
       const m = await MemberRepository.findOneBy({ email });
-      expectMember(m, { email, name, enableSaveActions: false });
+      expectMember(m, { email, name });
+      expect(m?.enableSaveActions).toBe(false);
       expect(mockSendEmail).toHaveBeenCalled();
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });
@@ -134,7 +135,8 @@ describe('Mobile Endpoints', () => {
       });
 
       const m = await MemberRepository.findOneBy({ email });
-      expectMember(m, { email, name, enableSaveActions });
+      expectMember(m, { email, name });
+      expect(m?.enableSaveActions).toBe(enableSaveActions);
       expect(mockSendEmail).toHaveBeenCalled();
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -104,20 +104,21 @@ describe('Mobile Endpoints', () => {
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });
 
-    it('Save actions is disabled by default', async () => {
+    it('Save actions is disabled when explicitly asked', async () => {
       const email = 'someemail@email.com';
       const name = 'anna';
+      const enableSaveActions = false;
 
       const mockSendEmail = jest.spyOn(app.mailer, 'sendEmail');
       const response = await app.inject({
         method: HttpMethod.Post,
         url: '/m/register',
-        payload: { email, name, challenge, captcha: MOCK_CAPTCHA },
+        payload: { email, name, challenge, captcha: MOCK_CAPTCHA, enableSaveActions },
       });
 
       const m = await MemberRepository.findOneBy({ email });
       expectMember(m, { email, name });
-      expect(m?.enableSaveActions).toBe(false);
+      expect(m?.enableSaveActions).toBe(enableSaveActions);
       expect(mockSendEmail).toHaveBeenCalled();
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
     });

--- a/src/services/auth/plugins/mobile/schemas.ts
+++ b/src/services/auth/plugins/mobile/schemas.ts
@@ -7,6 +7,7 @@ export const mregister = {
       email: { type: 'string', format: 'email' },
       challenge: { type: 'string' },
       captcha: { type: 'string' },
+      enableSaveActions: { type: 'boolean' },
     },
     additionalProperties: false,
   },

--- a/src/services/auth/plugins/mobile/service.ts
+++ b/src/services/auth/plugins/mobile/service.ts
@@ -37,7 +37,12 @@ export class MobileService {
   async register(
     actor: Actor,
     repositories: Repositories,
-    { name, email, challenge }: { name: string; email: string; challenge: string },
+    {
+      name,
+      email,
+      challenge,
+      enableSaveActions,
+    }: { name: string; email: string; challenge: string; enableSaveActions?: boolean },
     lang = DEFAULT_LANG,
   ) {
     const { memberRepository } = repositories;
@@ -50,6 +55,7 @@ export class MobileService {
         name,
         email,
         extra: { lang },
+        enableSaveActions,
       };
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/services/item/plugins/invitation/service.ts
+++ b/src/services/item/plugins/invitation/service.ts
@@ -7,6 +7,7 @@ import { ItemType, PermissionLevel } from '@graasp/sdk';
 
 import type { MailerDecoration } from '../../../../plugins/mailer';
 import { MAIL } from '../../../../plugins/mailer/langs/constants';
+import { GRAASP_LANDING_PAGE_ORIGIN } from '../../../../utils/constants';
 import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import { validatePermission } from '../../../authorization';
@@ -69,6 +70,14 @@ export class InvitationService {
     const html = `
       ${this.mailer.buildText(text)}
       ${this.mailer.buildButton(link, t(MAIL.SIGN_UP_BUTTON_TEXT))}
+      ${this.mailer.buildText(
+        t(MAIL.USER_AGREEMENTS_MAIL_TEXT, {
+          signUpButtonText: t(MAIL.SIGN_UP_BUTTON_TEXT),
+          graaspLandingPageOrigin: GRAASP_LANDING_PAGE_ORIGIN,
+        }),
+        // Add margin top of -15px to remove 15px margin bottom of the button.
+        { 'text-align': 'center', 'font-size': '10px', 'margin-top': '-15px' },
+      )}
     `;
     const title = t(MAIL.INVITATION_TITLE, {
       itemName: item.name,

--- a/src/services/member/entities/member.ts
+++ b/src/services/member/entities/member.ts
@@ -47,8 +47,9 @@ export class Member extends BaseEntity {
   userAgreementsDate: Date;
 
   @Column({
-    nullable: true,
+    nullable: false,
     name: 'enable_save_actions',
+    default: true,
   })
   enableSaveActions: boolean;
 

--- a/src/services/member/entities/member.ts
+++ b/src/services/member/entities/member.ts
@@ -47,8 +47,7 @@ export class Member extends BaseEntity {
   userAgreementsDate: Date;
 
   @Column({
-    nullable: false,
-    default: false,
+    nullable: true,
     name: 'enable_save_actions',
   })
   enableSaveActions: boolean;

--- a/src/services/member/entities/member.ts
+++ b/src/services/member/entities/member.ts
@@ -46,6 +46,13 @@ export class Member extends BaseEntity {
   })
   userAgreementsDate: Date;
 
+  @Column({
+    nullable: false,
+    default: false,
+    name: 'enable_save_actions',
+  })
+  enableSaveActions: boolean;
+
   @CreateDateColumn({
     update: false,
     name: 'created_at',

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -75,7 +75,7 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
       newData.extra = Object.assign({}, body?.extra, body.extra);
     }
 
-    if (body.enableSaveActions === true || body.enableSaveActions === false) {
+    if (typeof body.enableSaveActions === 'boolean') {
       newData.enableSaveActions = body.enableSaveActions;
     }
 

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -95,7 +95,12 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
     // The auth frontend only blocks the user to create an account without checking the boxes.
     // The frontend avoids sending agreement data to prevent manipulation of the agreement date.
     // The agreements links are included in the registration email as a reminder.
-    const createdMember = await this.insert({ ...data, email, userAgreementsDate: new Date() });
+    const userAgreements = new Date();
+    // enableSaveActions defaults to null in the database.
+    // This allows us to differentiate existing users who haven't explicitly agreed to saving actions
+    // from new users who explicitly accept (true) or deny (false).
+    const enableSaveActions = data.enableSaveActions ?? false;
+    const createdMember = await this.insert({ ...data, email, userAgreements, enableSaveActions });
 
     // TODO: better solution?
     // query builder returns creator as id and extra as string

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -95,13 +95,18 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
     // The auth frontend only blocks the user to create an account without checking the boxes.
     // The frontend avoids sending agreement data to prevent manipulation of the agreement date.
     // The agreements links are included in the registration email as a reminder.
-    const userAgreements = new Date();
+    const userAgreementsDate = new Date();
     // enableSaveActions defaults to null in the database.
     // This allows us to differentiate existing users who haven't explicitly agreed to saving actions
     // from new users who explicitly accept (true) or deny (false).
     const enableSaveActions = data.enableSaveActions ?? false;
     console.log('creating new user with', data, enableSaveActions);
-    const createdMember = await this.insert({ ...data, email, userAgreements, enableSaveActions });
+    const createdMember = await this.insert({
+      ...data,
+      email,
+      userAgreementsDate,
+      enableSaveActions,
+    });
 
     // TODO: better solution?
     // query builder returns creator as id and extra as string

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -57,7 +57,10 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
     });
   },
 
-  async patch(id: UUID, body: Partial<Pick<Member, 'extra' | 'email' | 'name'>>) {
+  async patch(
+    id: UUID,
+    body: Partial<Pick<Member, 'extra' | 'email' | 'name' | 'enableSaveActions'>>,
+  ) {
     const newData: Partial<Member> = {};
 
     if (body.name) {
@@ -70,6 +73,10 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
 
     if (body.extra) {
       newData.extra = Object.assign({}, body?.extra, body.extra);
+    }
+
+    if (body.enableSaveActions === true || body.enableSaveActions === false) {
+      newData.enableSaveActions = body.enableSaveActions;
     }
 
     // TODO: throw if newData is empty

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -100,6 +100,7 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
     // This allows us to differentiate existing users who haven't explicitly agreed to saving actions
     // from new users who explicitly accept (true) or deny (false).
     const enableSaveActions = data.enableSaveActions ?? false;
+    console.log('creating new user with', data, enableSaveActions);
     const createdMember = await this.insert({ ...data, email, userAgreements, enableSaveActions });
 
     // TODO: better solution?

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -100,7 +100,6 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
     // This allows us to differentiate existing users who haven't explicitly agreed to saving actions
     // from new users who explicitly accept (true) or deny (false).
     const enableSaveActions = data.enableSaveActions ?? false;
-    console.log('creating new user with', data, enableSaveActions);
     const createdMember = await this.insert({
       ...data,
       email,

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -96,15 +96,10 @@ export const MemberRepository = AppDataSource.getRepository(Member).extend({
     // The frontend avoids sending agreement data to prevent manipulation of the agreement date.
     // The agreements links are included in the registration email as a reminder.
     const userAgreementsDate = new Date();
-    // enableSaveActions defaults to null in the database.
-    // This allows us to differentiate existing users who haven't explicitly agreed to saving actions
-    // from new users who explicitly accept (true) or deny (false).
-    const enableSaveActions = data.enableSaveActions ?? false;
     const createdMember = await this.insert({
       ...data,
       email,
       userAgreementsDate,
-      enableSaveActions,
     });
 
     // TODO: better solution?

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -28,6 +28,7 @@ export default {
         createdAt: { type: 'string' },
         updatedAt: { type: 'string' },
         userAgreementsDate: { type: 'string' },
+        enableSaveActions: { type: 'boolean' },
         extra: { type: 'object', additionalProperties: true },
       },
       additionalProperties: false,
@@ -39,6 +40,7 @@ export default {
       properties: {
         name: { type: 'string', minLength: 1, pattern: '^\\S+( \\S+)*$' },
         extra: { type: 'object', additionalProperties: true },
+        enableSaveActions: { type: 'boolean' },
       },
       additionalProperties: false,
     },
@@ -51,6 +53,7 @@ export default {
           anyOf: [
             { type: 'object', required: ['name'] },
             { type: 'object', required: ['extra'] },
+            { type: 'object', required: ['enableSaveActions'] },
           ],
         },
       ],

--- a/src/services/member/service.ts
+++ b/src/services/member/service.ts
@@ -62,7 +62,7 @@ export class MemberService {
     actor: Actor,
     { memberRepository }: Repositories,
     id: UUID,
-    body: Partial<Pick<Member, 'extra' | 'email' | 'name'>>,
+    body: Partial<Pick<Member, 'extra' | 'email' | 'name' | 'enableSaveActions'>>,
   ) {
     if (!actor || actor.id !== id) {
       throw new CannotModifyOtherMembers(id);
@@ -71,7 +71,12 @@ export class MemberService {
     const m = await memberRepository.get(id);
     const extra = Object.assign({}, m.extra, body?.extra);
 
-    return memberRepository.patch(id, { name: body.name, email: body.email, extra });
+    return memberRepository.patch(id, {
+      name: body.name,
+      email: body.email,
+      extra,
+      enableSaveActions: body.enableSaveActions,
+    });
   }
 
   async deleteOne(actor: Actor, { memberRepository }: Repositories, id: UUID) {

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -482,9 +482,6 @@ describe('Member routes tests', () => {
 
       it('Enable save actions successfully', async () => {
         const enableSaveActions = true;
-        const memberBeforePatch = await MemberRepository.findOneBy({ id: actor.id });
-        expect(memberBeforePatch?.enableSaveActions).toBe(false);
-
         const response = await app.inject({
           method: HttpMethod.Patch,
           url: `/members/${actor.id}`,

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -480,6 +480,48 @@ describe('Member routes tests', () => {
         // todo: test whether extra is correctly modified (extra is not returned)
       });
 
+      it('Enable save actions successfully', async () => {
+        const enableSaveActions = true;
+        const memberBeforePatch = await MemberRepository.findOneBy({ id: actor.id });
+        expect(memberBeforePatch?.enableSaveActions).toBe(false);
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/members/${actor.id}`,
+          payload: { enableSaveActions },
+        });
+
+        const m = await MemberRepository.findOneBy({ id: actor.id });
+        expect(m?.enableSaveActions).toEqual(enableSaveActions);
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        expect(response.json().enableSaveActions).toEqual(enableSaveActions);
+      });
+
+      it('Disable save actions successfully', async () => {
+        // Start by enabling save actions
+        await app.inject({
+          method: HttpMethod.Patch,
+          url: `/members/${actor.id}`,
+          payload: { enableSaveActions: true },
+        });
+        const memberBeforePatch = await MemberRepository.findOneBy({ id: actor.id });
+        expect(memberBeforePatch?.enableSaveActions).toBe(true);
+
+        const enableSaveActions = false;
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/members/${actor.id}`,
+          payload: { enableSaveActions },
+        });
+
+        const m = await MemberRepository.findOneBy({ id: actor.id });
+        expect(m?.enableSaveActions).toEqual(enableSaveActions);
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        expect(response.json().enableSaveActions).toEqual(enableSaveActions);
+      });
+
       it('Current member cannot modify another member', async () => {
         const member = await saveMember();
         const newName = 'new name';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,9 +2024,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:4.6.0":
-  version: 4.6.0
-  resolution: "@graasp/sdk@npm:4.6.0"
+"@graasp/sdk@npm:4.7.0":
+  version: 4.7.0
+  resolution: "@graasp/sdk@npm:4.7.0"
   dependencies:
     "@faker-js/faker": "npm:8.4.1"
     js-cookie: "npm:3.0.5"
@@ -2034,7 +2034,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3
     uuid: ^9
-  checksum: 10/85456a68c8498375b298c7677db1aa221deb9c73406204b84bf15da6a699cee4f992600c0fd2b2280b71aff442c2afe7c5bfa92dbea2e4863e6edca70e49e9e3
+  checksum: 10/333460e2c74dcff4f9146e6683d72da45a6f9b5844d21d7a423240a3c39dc5957db4f830d437fdf38161c7f8c5f7bd2012cbfaf30dfbc4a135aa31a37b6982d7
   languageName: node
   linkType: hard
 
@@ -6702,7 +6702,7 @@ __metadata:
     "@fastify/view": "npm:7.4.1"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:4.6.0"
+    "@graasp/sdk": "npm:4.7.0"
     "@graasp/translations": "npm:1.23.0"
     "@rapideditor/country-coder": "npm:5.2.2"
     "@sentry/node": "npm:7.64.0"


### PR DESCRIPTION

This PR:
- allows new users to enable or disable saving actions
- existing users have enableSaveActions to null
  - This allows to facilitate what to do with existing users like:
     - Stop saving actions until they explicitly accept it
     - Continue saving actions
     - Also allows to ask the user to choose 
  - This wouldn't be possible if default value would be set to false
- allows all users to update this option
- ensure that actions can't be saved if the option is not true (or null if wanted, should be decided)

