### PR TITLE
feat: add auth from mobile to web

### DIFF
--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -117,14 +117,14 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   );
 
   // from user token, set corresponding cookie
-  fastify.get<{ Querystring: { t: string; url: string } }>(
+  fastify.get<{ Querystring: { token: string; url: string } }>(
     '/auth/web',
     { schema: authWeb },
     async ({ query, session }, reply) => {
       const memberId = await mobileService.getMemberIdFromAuthToken(
         undefined,
         buildRepositories(),
-        query.t,
+        query.token,
       );
 
       session.set('member', memberId);

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -467,43 +467,43 @@ describe('Mobile Endpoints', () => {
   describe('GET /m/auth/web', () => {
     it('set cookie for valid token', async () => {
       const member = await saveMember();
-      const t = jwt.sign({ sub: member.id }, AUTH_TOKEN_JWT_SECRET);
+      const token = jwt.sign({ sub: member.id }, AUTH_TOKEN_JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.Get,
         url: '/m/auth/web',
-        query: { t },
+        query: { token },
       });
       expect(response.statusCode).toEqual(StatusCodes.SEE_OTHER);
       expect(response.headers).toHaveProperty('set-cookie');
     });
     it('Throw if token contains undefined member id', async () => {
-      const t = jwt.sign({ sub: undefined }, AUTH_TOKEN_JWT_SECRET);
+      const token = jwt.sign({ sub: undefined }, AUTH_TOKEN_JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.Get,
         url: '/m/auth/web',
-        query: { t },
+        query: { token },
       });
       expect(response.headers).not.toHaveProperty('set-cookie');
       expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
     });
     it('Throw if token contains non-existent member', async () => {
       const memberId = v4();
-      const t = jwt.sign({ sub: memberId }, AUTH_TOKEN_JWT_SECRET);
+      const token = jwt.sign({ sub: memberId }, AUTH_TOKEN_JWT_SECRET);
       const response = await app.inject({
         method: HttpMethod.Get,
         url: '/m/auth/web',
-        query: { t },
+        query: { token },
       });
       expect(response.headers).not.toHaveProperty('set-cookie');
       expect(response.json()).toMatchObject(new MemberNotFound(memberId));
     });
     it('Fail if token is invalid', async () => {
       const member = await saveMember();
-      const t = jwt.sign({ sub: member.id }, 'INVALID_SECRET');
+      const token = jwt.sign({ sub: member.id }, 'INVALID_SECRET');
       const response = await app.inject({
         method: HttpMethod.Get,
         url: '/m/auth/web',
-        query: { t },
+        query: { token },
       });
       expect(response.headers).not.toHaveProperty('set-cookie');
       expect(response.statusCode).toEqual(StatusCodes.UNAUTHORIZED);

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -453,7 +453,7 @@ describe('Mobile Endpoints', () => {
     });
     it('Fail if token is invalid', async () => {
       const member = await saveMember();
-      const t = jwt.sign({ sub: member.id }, 'REFRESH_TOKEN_JWT_SECRET');
+      const t = jwt.sign({ sub: member.id }, 'INVALID_SECRET');
       const response = await app.inject({
         method: HttpMethod.Get,
         url: '/m/auth/refresh',
@@ -499,7 +499,7 @@ describe('Mobile Endpoints', () => {
     });
     it('Fail if token is invalid', async () => {
       const member = await saveMember();
-      const t = jwt.sign({ sub: member.id }, 'AUTH_TOKEN_JWT_SECRET');
+      const t = jwt.sign({ sub: member.id }, 'INVALID_SECRET');
       const response = await app.inject({
         method: HttpMethod.Get,
         url: '/m/auth/web',

--- a/src/services/auth/plugins/mobile/schemas.ts
+++ b/src/services/auth/plugins/mobile/schemas.ts
@@ -68,9 +68,9 @@ export const mauth = {
 export const authWeb = {
   querystring: {
     type: 'object',
-    required: ['t'],
+    required: ['token'],
     properties: {
-      t: { type: 'string' },
+      token: { type: 'string' },
       url: { type: 'string' },
     },
     additionalProperties: false,

--- a/src/services/auth/plugins/mobile/schemas.ts
+++ b/src/services/auth/plugins/mobile/schemas.ts
@@ -64,3 +64,15 @@ export const mauth = {
     additionalProperties: false,
   },
 };
+
+export const authWeb = {
+  querystring: {
+    type: 'object',
+    required: ['t'],
+    properties: {
+      t: { type: 'string' },
+      url: { type: 'string' },
+    },
+    additionalProperties: false,
+  },
+};

--- a/src/services/auth/plugins/mobile/service.ts
+++ b/src/services/auth/plugins/mobile/service.ts
@@ -94,7 +94,7 @@ export class MobileService {
       await repositories.memberRepository.get(memberId);
 
       // TODO: should we fetch/test the member from the DB?
-      return { memberId, ...this.fastify.generateAuthTokensPair(memberId) };
+      return this.fastify.generateAuthTokensPair(memberId);
     } catch (error) {
       if (error instanceof JsonWebTokenError) {
         // return a custom error when the token expired

--- a/src/services/item/plugins/recycled/test/index.test.ts
+++ b/src/services/item/plugins/recycled/test/index.test.ts
@@ -378,7 +378,7 @@ describe('Recycle Bin Tests', () => {
     /**
      * This is a regression test from a real production bug caused by not restoring the soft-deleted children
      */
-    it.only('Restores the subtree successfully if it has children', async () => {
+    it('Restores the subtree successfully if it has children', async () => {
       const { item: parentItem } = await testUtils.saveItemAndMembership({ member: actor });
       const { item: childItem } = await testUtils.saveItemAndMembership({
         member: actor,


### PR DESCRIPTION
I've added an endpoint to allows the user (authenticated with a valid token in mobile) to authenticate on web. Basically it validates your token, and set the corresponding session in the cookie.
I'll use it in mobile to display the map through Builder. 