### PR TITLE
fix: deploy workflow checkout

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,9 +24,11 @@ jobs:
     environment: production
 
     steps:
-      # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+      # Check-out the tag specified in the payload
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.tag }}
 
       # Configure AWS credential and region environment variables for use in next steps
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -24,9 +24,11 @@ jobs:
     environment: staging
 
     steps:
-      # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
+      # Check-out the tag specified in the payload
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.tag }}
 
       # Configure AWS credential and region environment variables for use in next steps
       - name: Configure AWS Credentials


### PR DESCRIPTION
Fix a really bad oversight that caused production deploy to actually deploy code from the main branch instead of code from the specified tag. 

## Description of the problem

When deploying the backend to production using the repository dispatch event, the deployed code is not the one pointed by the tag passed as arguments, but the code present on the main branch at the time of deployment.

## How this happened

When refactoring the deployment workflows, I introduced this bug because I used the dev workflow as a starter.

## Why is this an issue in the staging and production deployments ?

When running the dev deployment workflow, it is usually run from within a branch (mostly main). This means that calling `actions/checkout` checks out the code from the branch from where it was run. Usually this is what you want.

But in the case of the production and staging deployments, this is not the case. The workflows are triggered using a repository dispatch event. This event triggers the workflow to run from the main branch.
This means we need to actively set the checkout action to checkout from the tag passed as workflow event payload. 

This is what was missing. This PR fixes this issue. 