### PR TITLE
fix: workflows again

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.tag }}
 
       # Configure AWS credential and region environment variables for use in next steps
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.tag }}
 
       # Configure AWS credential and region environment variables for use in next steps
       - name: Configure AWS credentials


### PR DESCRIPTION
I had forgotten to set the tag to checkout also in the deploy part of the action. This is not as bad, as only the task definitions are pulled. And they do not usually change that frequently. But for consistency we should checkout the same tag.