### PR TITLE
fix: password login should return `MemberNotSignedUp` if email has no account

### DIFF
--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import { v4 } from 'uuid';
 
 import { HttpMethod, MemberFactory, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
+import { FAILURE_MESSAGES } from '@graasp/translations';
 
 import build, { clearDatabase } from '../../../../../test/app';
 import { AUTH_CLIENT_HOST, JWT_SECRET } from '../../../../utils/config';
@@ -203,6 +204,20 @@ describe('Auth routes tests', () => {
 
       expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+    });
+
+    it('Bad request for non registered email', async () => {
+      // email is not registered
+      const email = 'tim@graasp.org';
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: '/login',
+        payload: { email, captcha: MOCK_CAPTCHA },
+      });
+
+      // ensure the message is `member not signed up`
+      expect(response.json().message).toEqual(FAILURE_MESSAGES.MEMBER_NOT_SIGNED_UP);
+      expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
     });
   });
 

--- a/src/services/auth/plugins/password/test/password.test.ts
+++ b/src/services/auth/plugins/password/test/password.test.ts
@@ -2,6 +2,7 @@ import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import fetch, { type Response } from 'node-fetch';
 
 import { HttpMethod, MemberFactory, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
+import { FAILURE_MESSAGES } from '@graasp/translations';
 
 import build, { clearDatabase } from '../../../../../../test/app';
 import { saveMember } from '../../../../member/test/fixtures/members';
@@ -139,6 +140,7 @@ describe('Password routes tests', () => {
       });
 
       expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
+      expect(response.json().message).toEqual(FAILURE_MESSAGES.MEMBER_NOT_SIGNED_UP);
       expect(response.statusMessage).toEqual(ReasonPhrases.NOT_FOUND);
     });
 


### PR DESCRIPTION
In this PR I fix a bug where calling `/login-password` with an email that is not associated with an account return `Account not found`.
To align with the behaviour of the `/login` endpoint it should return `Member not sign up`.
fix #940 