### PR TITLE
fix: optimize get published collections for member

### DIFF
--- a/src/services/item/plugins/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/published/plugins/search/meilisearch.ts
@@ -367,13 +367,16 @@ export class MeiliSearchWrapper {
     await this.db.transaction('SERIALIZABLE', async (manager) => {
       const tasks: EnqueuedTask[] = [];
 
+      // instanciate the itempublished repository to use the provided transaction manager
+      const itemPublishedRepository = new ItemPublishedRepository(manager);
       let currentPage = 1;
       let total = 0;
       while (currentPage === 1 || (currentPage - 1) * pageSize < total) {
         // Retrieve a page (i.e. 20 items)
-        const [published, totalCount] = await manager
-          .withRepository(ItemPublishedRepository)
-          .getPaginatedItems(currentPage, pageSize);
+        const [published, totalCount] = await itemPublishedRepository.getPaginatedItems(
+          currentPage,
+          pageSize,
+        );
         this.logger.info(
           `REBUILD INDEX: Page ${currentPage} - ${published.length} items - total count: ${totalCount}`,
         );

--- a/src/services/item/plugins/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/published/plugins/search/meilisearch.ts
@@ -27,7 +27,6 @@ import FileService from '../../../../../file/service';
 import { Item, isItemType } from '../../../../entities/Item';
 import { readPdfContent } from '../../../../utils';
 import { stripHtml } from '../../../validation/utils';
-import { ItemPublishedRepository } from '../../repositories/itemPublished';
 
 const ACTIVE_INDEX = INDEX_NAME;
 const ROTATING_INDEX = `${INDEX_NAME}_tmp`; // Used when reindexing
@@ -368,7 +367,7 @@ export class MeiliSearchWrapper {
       const tasks: EnqueuedTask[] = [];
 
       // instanciate the itempublished repository to use the provided transaction manager
-      const itemPublishedRepository = new ItemPublishedRepository(manager);
+      const { itemPublishedRepository } = buildRepositories(manager);
       let currentPage = 1;
       let total = 0;
       while (currentPage === 1 || (currentPage - 1) * pageSize < total) {

--- a/src/services/item/plugins/published/repositories/itemPublished.test.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.test.ts
@@ -1,0 +1,36 @@
+import build, { clearDatabase } from '../../../../../../test/app';
+import { saveMember } from '../../../../member/test/fixtures/members';
+import { ItemTestUtils, expectManyItems } from '../../../test/fixtures/items';
+import { ItemPublishedRepository } from './itemPublished';
+
+// mock datasource
+jest.mock('../../../../../plugins/datasource');
+const itemPublishedRepository = new ItemPublishedRepository();
+const testUtils = new ItemTestUtils();
+
+describe('ItemPublishedRepository', () => {
+  let app;
+  let actor;
+
+  beforeEach(async () => {
+    ({ app, actor } = await build());
+  });
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase(app.db);
+    actor = null;
+    app.close();
+  });
+
+  describe('getForMember', () => {
+    it('get published items for member', async () => {
+      const items = await testUtils.saveCollections(actor);
+      // noise
+      const member = await saveMember();
+      await testUtils.saveCollections(member);
+
+      const result = await itemPublishedRepository.getForMember(actor.id);
+      expectManyItems(result, items);
+    });
+  });
+});

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -1,14 +1,30 @@
+import { EntityManager, Repository } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+
+import { PermissionLevel } from '@graasp/sdk';
+
 import { AppDataSource } from '../../../../../plugins/datasource';
-import { Actor } from '../../../../member/entities/member';
+import { Actor, Member } from '../../../../member/entities/member';
 import { mapById } from '../../../../utils';
 import { Item } from '../../../entities/Item';
 import { ItemPublished } from '../entities/itemPublished';
 import { ItemPublishedNotFound } from '../errors';
 
-export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished).extend({
+export class ItemPublishedRepository {
+  private repository: Repository<ItemPublished>;
+
+  constructor(manager?: EntityManager) {
+    if (manager) {
+      this.repository = manager.getRepository(ItemPublished);
+    } else {
+      this.repository = AppDataSource.getRepository(ItemPublished);
+    }
+  }
+
   async getForItem(item: Item): Promise<ItemPublished> {
     // this returns the root published item when querying a child item
-    const entry = await this.createQueryBuilder('pi')
+    const entry = await this.repository
+      .createQueryBuilder('pi')
       .innerJoinAndSelect('pi.item', 'item', 'pi.item @> :itemPath', { itemPath: item.path })
       .innerJoinAndSelect('pi.creator', 'member')
       // Order isn't guaranteed so we must force it to avoid flaky results
@@ -20,12 +36,13 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
     }
 
     return entry;
-  },
+  }
 
   async getForItems(items: Item[]) {
     const paths = items.map((i) => i.path);
     const ids = items.map((i) => i.id);
-    const entries = await this.createQueryBuilder('pi')
+    const entries = await this.repository
+      .createQueryBuilder('pi')
       .innerJoinAndSelect('pi.item', 'item', 'pi.item @> ARRAY[:...paths]::ltree[]', {
         paths,
       })
@@ -38,43 +55,69 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
         entries.find((e) => items.find((i) => i.id === id)?.path.startsWith(e.item.path)),
       buildError: (id) => new ItemPublishedNotFound(id),
     });
-  },
+  }
+
+  async getForMember(memberId: Member['id']): Promise<Item[]> {
+    const itemPublished = await this.repository
+      .createQueryBuilder('pi')
+      .innerJoin('item_membership', 'im', 'im.item_path @> pi.item_path')
+      .leftJoin('member', 'm', 'im.member_id = m.id and m.id = :memberId', {
+        memberId,
+      })
+      .innerJoinAndSelect('pi.item', 'item')
+      .innerJoinAndSelect('pi.creator', 'member')
+      .where('im.permission IN (:...permissions)', {
+        permissions: [PermissionLevel.Admin, PermissionLevel.Write],
+      })
+      .getMany();
+
+    return itemPublished.map(({ item, creator }) => {
+      // use creator of publish entry as the creator of the item
+      item.creator = creator;
+      return item;
+    });
+  }
 
   // return public item entry? contains when it was published
   async getAllItems() {
-    const publishedRows = await this.find({ relations: { item: true } });
+    const publishedRows = await this.repository.find({ relations: { item: true } });
     return publishedRows.map(({ item }) => item);
-  },
+  }
 
   // Must Implement a proper Paginated<Type> if more complex pagination is needed in the future
   async getPaginatedItems(
     page: number = 1,
     pageSize: number = 20,
   ): Promise<[ItemPublished[], number]> {
-    const [items, total] = await this.createQueryBuilder('item_published')
+    const [items, total] = await this.repository
+      .createQueryBuilder('item_published')
       .innerJoinAndSelect('item_published.item', 'item') // will ignore soft deleted item
       .innerJoinAndSelect('item.creator', 'member') // will ignore null creator id (deleted account)
       .take(pageSize)
       .skip((page - 1) * pageSize)
       .getManyAndCount();
     return [items, total];
-  },
+  }
 
   async post(creator: Actor, item: Item) {
-    const p = this.create({ item, creator });
-    await this.insert(p);
+    const p = this.repository.create({
+      item: item,
+      creator,
+    }) as QueryDeepPartialEntity<ItemPublished>;
+    await this.repository.insert(p);
     return p;
-  },
+  }
 
   async deleteForItem(item: Item) {
     const entry = await this.getForItem(item);
 
-    await this.delete(entry.id);
+    await this.repository.delete(entry.id);
     return entry;
-  },
+  }
 
   async getRecentItems(limit: number = 10): Promise<Item[]> {
-    const publishedInfos = await this.createQueryBuilder('item_published')
+    const publishedInfos = await this.repository
+      .createQueryBuilder('item_published')
       .innerJoinAndSelect('item_published.item', 'item')
       .innerJoinAndSelect('item.creator', 'member')
       .orderBy('item.createdAt', 'DESC')
@@ -82,20 +125,21 @@ export const ItemPublishedRepository = AppDataSource.getRepository(ItemPublished
       .getMany();
 
     return publishedInfos.map(({ item }) => item);
-  },
+  }
 
   // return public items sorted by most liked
   // bug: does not take into account child items
   async getLikedItems(limit: number = 10): Promise<Item[]> {
-    const itemPublished = await this.createQueryBuilder('item_published')
+    const itemPublished = await this.repository
+      .createQueryBuilder('item_published')
       .innerJoinAndSelect('item_published.item', 'item')
       .innerJoinAndSelect('item.creator', 'member')
       .innerJoin('item_like', 'il', 'il.item_id = item.id')
-      .groupBy(['item.id', 'member.id', 'item_published.id'])
+      .groupBy('item.id, member.id, item_published.id')
       .orderBy('COUNT(il.id)', 'DESC')
       .limit(limit)
       .getMany();
 
     return itemPublished.map(({ item }) => item);
-  },
-});
+  }
+}

--- a/src/services/item/plugins/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/published/repositories/itemPublished.ts
@@ -61,7 +61,7 @@ export class ItemPublishedRepository {
     const itemPublished = await this.repository
       .createQueryBuilder('pi')
       .innerJoin('item_membership', 'im', 'im.item_path @> pi.item_path')
-      .leftJoin('member', 'm', 'im.member_id = m.id and m.id = :memberId', {
+      .innerJoin('member', 'm', 'im.member_id = m.id and m.id = :memberId', {
         memberId,
       })
       .innerJoinAndSelect('pi.item', 'item')

--- a/src/services/item/plugins/published/service.ts
+++ b/src/services/item/plugins/published/service.ts
@@ -155,9 +155,9 @@ export class ItemPublishedService {
     return result;
   }
 
-  async getItemsForMember(actor: Actor, repositories, memberId: UUID) {
-    const { itemRepository } = repositories;
-    return itemRepository.getPublishedItemsForMember(memberId);
+  async getItemsForMember(actor: Actor, repositories: Repositories, memberId: UUID) {
+    const { itemPublishedRepository } = repositories;
+    return itemPublishedRepository.getForMember(memberId);
   }
 
   async getLikedItems(actor: Actor, repositories: Repositories, limit?: number) {
@@ -168,7 +168,6 @@ export class ItemPublishedService {
 
   async getRecentItems(actor: Actor, repositories: Repositories, limit?: number) {
     const { itemPublishedRepository } = repositories;
-
     const items = await itemPublishedRepository.getRecentItems(limit);
 
     return filterOutHiddenItems(repositories, items);

--- a/src/services/item/plugins/published/test/meilisearch.test.ts
+++ b/src/services/item/plugins/published/test/meilisearch.test.ts
@@ -38,7 +38,7 @@ describe('MeilisearchWrapper', () => {
   });
 
   const datasourceManager = {
-    withRepository: jest.fn(),
+    getRepository: jest.fn(),
   } as unknown as jest.Mocked<EntityManager>;
   const logger = {
     info: jest.fn(),
@@ -105,7 +105,7 @@ describe('MeilisearchWrapper', () => {
   const itemPublishedRepositoryMock = {
     getForItem: jest.fn(),
     getPaginatedItems: jest.fn(),
-  } as unknown as jest.Mocked<typeof ItemPublishedRepository>;
+  } as unknown as jest.Mocked<ItemPublishedRepository>;
 
   const itemCategoryRepositoryMock = {
     getForItemOrParent: jest.fn(),
@@ -438,8 +438,6 @@ describe('MeilisearchWrapper', () => {
 
       // prevent finding any PDFs to store because this part is temporary
       jest.spyOn(testUtils.itemRepository, 'findAndCount').mockResolvedValue([[], 0]);
-
-      datasourceManager.withRepository.mockReturnValue(repositories.itemPublishedRepository);
 
       // fake pagination
       itemPublishedRepositoryMock.getPaginatedItems.mockImplementation((page, _) => {

--- a/src/services/item/repository.test.ts
+++ b/src/services/item/repository.test.ts
@@ -709,15 +709,4 @@ describe('ItemRepository', () => {
       expectManyItems(result, items);
     });
   });
-  describe('getPublishedItemsForMember', () => {
-    it('get published items for member', async () => {
-      const items = await testUtils.saveCollections(actor);
-      // noise
-      const member = await saveMember();
-      await testUtils.saveCollections(member);
-
-      const result = await itemRepository.getPublishedItemsForMember(actor.id);
-      expectManyItems(result, items);
-    });
-  });
 });

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -507,25 +507,6 @@ export class ItemRepository {
     return publishedRows;
   }
 
-  /**
-   * Return published items for given member
-   * @param memberId
-   * @returns published items for given member
-   */
-  async getPublishedItemsForMember(memberId: string) {
-    // get for membership write and admin -> createquerybuilder
-    return this.repository
-      .createQueryBuilder('item')
-      .innerJoin('item_published', 'pi', 'pi.item_path = item.path')
-      .innerJoin('item_membership', 'im', 'im.item_path @> item.path')
-      .innerJoinAndSelect('item.creator', 'member')
-      .where('im.member_id = :memberId', { memberId })
-      .andWhere('im.permission IN (:...permissions)', {
-        permissions: [PermissionLevel.Admin, PermissionLevel.Write],
-      })
-      .getMany();
-  }
-
   async findAndCount(args: FindManyOptions<Item>) {
     return this.repository.findAndCount(args);
   }

--- a/src/services/item/test/fixtures/items.ts
+++ b/src/services/item/test/fixtures/items.ts
@@ -21,7 +21,7 @@ import { Actor, Member } from '../../../member/entities/member';
 import { PackedItem } from '../../ItemWrapper';
 import { Item, ItemExtraMap } from '../../entities/Item';
 import { setItemPublic } from '../../plugins/itemTag/test/fixtures';
-import { ItemPublishedRepository } from '../../plugins/published/repositories/itemPublished';
+import { ItemPublished } from '../../plugins/published/entities/itemPublished';
 import { RecycledItemDataRepository } from '../../plugins/recycled/repository';
 import { ItemRepository } from '../../repository';
 
@@ -29,13 +29,13 @@ export class ItemTestUtils {
   public itemRepository: ItemRepository;
   public rawItemRepository: Repository<Item<keyof ItemExtraMap>>;
   recycledItemDataRepository: typeof RecycledItemDataRepository;
-  rawItemPublishedRepository: typeof ItemPublishedRepository;
+  rawItemPublishedRepository: Repository<ItemPublished>;
 
   constructor() {
     this.itemRepository = new ItemRepository();
     this.rawItemRepository = AppDataSource.getRepository(Item);
     this.recycledItemDataRepository = RecycledItemDataRepository;
-    this.rawItemPublishedRepository = ItemPublishedRepository;
+    this.rawItemPublishedRepository = AppDataSource.getRepository(ItemPublished);
   }
 
   createItem(

--- a/src/utils/repositories.ts
+++ b/src/utils/repositories.ts
@@ -48,7 +48,7 @@ export type Repositories = {
   itemLoginRepository: typeof ItemLoginRepository;
   itemLoginSchemaRepository: typeof ItemLoginSchemaRepository;
   itemMembershipRepository: typeof ItemMembershipRepository;
-  itemPublishedRepository: typeof ItemPublishedRepository;
+  itemPublishedRepository: ItemPublishedRepository;
   itemRepository: ItemRepository;
   itemTagRepository: typeof ItemTagRepository;
   itemValidationGroupRepository: typeof ItemValidationGroupRepository;
@@ -72,9 +72,7 @@ export const buildRepositories = (manager?: EntityManager): Repositories => ({
     : ItemMembershipRepository,
   memberRepository: manager ? manager.withRepository(MemberRepository) : MemberRepository,
 
-  itemPublishedRepository: manager
-    ? manager.withRepository(ItemPublishedRepository)
-    : ItemPublishedRepository,
+  itemPublishedRepository: new ItemPublishedRepository(manager),
   itemLoginRepository: manager ? manager.withRepository(ItemLoginRepository) : ItemLoginRepository,
   itemLoginSchemaRepository: manager
     ? manager.withRepository(ItemLoginSchemaRepository)


### PR DESCRIPTION
Resolves #958 
In this PR I try to optimize the get published collections for member.
This query is remarkably slow and is executed for the home page of the library in the first section. 

This is the query execution plan for the query before optimization:
<img width="1470" alt="Screenshot 2024-04-16 at 18 51 04" src="https://github.com/graasp/graasp/assets/39373170/6e1686da-8269-4ed7-9eab-daea5f2074a9">
The execution time is around ~~9 seconds~~ (2 seconds on a hot database probably because of caching), that is unacceptable

This is the execution plan of the new query:
<img width="1470" alt="Screenshot 2024-04-16 at 18 51 35" src="https://github.com/graasp/graasp/assets/39373170/03ebd538-bed0-4220-a4ca-a89887710326">
Execution time is ~~2 seconds~~ (between 2 and 10 miliseconds on a hot DB), better ~~but not as good as it could be with some custom SQL queries~~ actually I compared and the "custom" query below does not run significantly faster than the Typeorm optimized query.

I attache below the query that could be used to reduce even further the execution time:
```sql
SELECT "item"."id" AS "item_id",
  "item"."name" AS "item_name",
  "item"."description" AS "item_description",
  "item"."type" AS "item_type",
  "item"."created_at" AS "item_created_at",
  "item"."updated_at" AS "item_updated_at",
  "item"."deleted_at" AS "item_deleted_at",
  "item"."extra" AS "item_extra",
  "item"."settings" AS "item_settings",
  "item"."path" AS "item_path",
  "item"."creator_id" AS "item_creator_id",
  "member"."id" AS "member_id",
  "member"."name" AS "member_name",
  "member"."email" AS "member_email",
  "member"."type" AS "member_type",
  "member"."extra" AS "member_extra",
  "member"."created_at" AS "member_created_at",
  "member"."updated_at" AS "member_updated_at"
FROM "member" "member"
  INNER JOIN "item_membership" "im" ON "im"."member_id" = "member"."id"
  AND "member"."id" = '049b4f35-f12e-4ec6-8958-586113bbd241'
  RIGHT JOIN "item_published" "pi" ON "im"."item_path" @> "pi"."item_path"
  INNER JOIN "item" "item" ON "item"."path" = "pi"."item_path"
WHERE ("im"."permission" IN ('admin', 'write'))
  AND ("item"."deleted_at" IS NULL);
```
This query can not be used in TypeORM, since we do not have access to right join, and because typeorm needs you to "start" from the entity that you want to get as output. In the case of this query, we start with member as this is what will reduce the size of the joins, but we actually want to get an item back. There is no way to make that query by starting from item or item publish and be as efficient in the size of the joins. 