### PR TITLE
fix(test): set a valid url in fixtures and remove html in response

### DIFF
--- a/src/services/item/plugins/embeddedLink/index.ts
+++ b/src/services/item/plugins/embeddedLink/index.ts
@@ -8,6 +8,7 @@ import { Item } from '../../entities/Item';
 import { LinkQueryParameterIsRequired } from './errors';
 import { createSchema } from './schemas';
 import { EmbeddedLinkService } from './service';
+import { ensureProtocol } from './utils';
 
 interface GraaspEmbeddedLinkItemOptions {
   /** \<protocol\>://\<hostname\>:\<port\> */
@@ -36,8 +37,12 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
         throw new LinkQueryParameterIsRequired();
       }
 
-      const metadata = await embeddedLinkService.getLinkMetadata(iframelyHrefOrigin, link);
-      const isEmbeddingAllowed = await embeddedLinkService.checkEmbeddingAllowed(link, log);
+      const url = ensureProtocol(link);
+      const { html: _html, ...metadata } = await embeddedLinkService.getLinkMetadata(
+        iframelyHrefOrigin,
+        url,
+      );
+      const isEmbeddingAllowed = await embeddedLinkService.checkEmbeddingAllowed(url, log);
 
       return {
         ...metadata,

--- a/src/services/item/plugins/embeddedLink/test/fixtures.ts
+++ b/src/services/item/plugins/embeddedLink/test/fixtures.ts
@@ -2,7 +2,7 @@ export const METADATA = {
   title: 'title',
   description: 'description',
 };
-export const FAKE_URL = 'https://fake-href.local';
+export const FAKE_URL = 'https://example.com';
 const THUMBNAIL_HREF = `${FAKE_URL}/24.png`;
 const ICON_HREF = `${FAKE_URL}/icon`;
 const HTML = 'html';


### PR DESCRIPTION
A set of tests was broken, but the code #1009 was merged in main using the merging queue.
This PR fix the url used in these broken tests.