### PR TITLE
998 env variables are used before initialised by dotenv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,56 @@ on:
 concurrency:
   group: ${{ github.head_ref || github.ref }}
 
+env:
+  CI: true
+  LOG_LEVEL: fatal # avoid unnecessary logging
+  # random keys
+  APPS_JWT_SECRET: ${{ secrets.MOCK_JWT_SECRET }}
+  APPS_PUBLISHER_ID: 9c9cea73-f3b7-48a3-aa6e-ead82c0685e7 # mock uuid
+  AUTH_CLIENT_HOST: 'localhost:3001'
+  AUTH_TOKEN_JWT_SECRET: ${{ secrets.MOCK_AUTH_TOKEN_JWT_SECRET }}
+  BUILDER_CLIENT_HOST: 'http://localhost:3111'
+  ACCOUNT_CLIENT_HOST: 'http://localhost:3114'
+  ANALYTICS_CLIENT_HOST: 'http://localhost:3005'
+  COOKIE_DOMAIN: localhost
+  DB_PASSWORD: docker
+  DB_USERNAME: docker
+  DB_NAME: docker
+  DB_HOST: localhost
+  EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN: 'http://localhost:1234'
+  ETHERPAD_API_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+  ETHERPAD_PUBLIC_URL: 'http://localhost:9001'
+  ETHERPAD_URL: 'http://etherpad:9001'
+  LIBRARY_CLIENT_HOST: 'http://localhost:3113'
+  FILE_STORAGE_ROOT_PATH: /
+  H5P_FILE_STORAGE_TYPE: file
+  H5P_PATH_PREFIX: h5p-content/
+  H5P_STORAGE_ROOT_PATH: /tmp/h5p
+  JWT_SECRET: ${{ secrets.MOCK_JWT_SECRET }}
+  MAILER_CONFIG_PASSWORD: password
+  MAILER_CONFIG_SMTP_HOST: localhost
+  MAILER_CONFIG_USERNAME: username
+  PLAYER_CLIENT_HOST: 'http://localhost:3112'
+  RECAPTCHA_SECRET_ACCESS_KEY: 'iamamockkey'
+  REDIS_HOST: localhost
+  REDIS_PORT: 6379
+  REFRESH_TOKEN_JWT_SECRET: ${{ secrets.MOCK_REFRESH_TOKEN_JWT_SECRET }}
+  S3_FILE_ITEM_ACCESS_KEY_ID: graasp-user
+  S3_FILE_ITEM_BUCKET: graasp
+  S3_FILE_ITEM_PLUGIN: true
+  S3_FILE_ITEM_REGION: us-east-1
+  S3_FILE_ITEM_SECRET_ACCESS_KEY: graasp-pwd
+  SECURE_SESSION_SECRET_KEY: ${{ secrets.MOCK_SECURE_SESSION_SECRET_KEY }}
+  STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+  MEILISEARCH_URL: fake
+  MEILISEARCH_MASTER_KEY: fake
+  JOB_SCHEDULING: false
+  GEOLOCATION_API_KEY: geolocation-key
+  GEOLOCATION_API_HOST: http://localhost:12345
+
 jobs:
   build-node:
     runs-on: ubuntu-latest
-    env:
-      TEST_DB_NAME: docker
-      TEST_DB_USER: docker
-      TEST_DB_PASSWORD: docker
 
     # Service containers to run with `container-job`
     services:
@@ -27,9 +70,9 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-          POSTGRES_USER: ${{ env.TEST_DB_USER }}
-          POSTGRES_DB: ${{ env.TEST_DB_NAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
         ports:
           - 5432:5432 # exposing 5432 port for application to use
         # Set health checks to wait until postgres has started
@@ -68,17 +111,9 @@ jobs:
         run: yarn check
 
       - name: apply migrations on empty database
-        env:
-          DB_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-          DB_USERNAME: ${{ env.TEST_DB_USER }}
-          DB_NAME: ${{ env.TEST_DB_NAME }}
         run: yarn migration:run
 
       - name: check migrations are synced with the current codebase
-        env:
-          DB_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-          DB_USERNAME: ${{ env.TEST_DB_USER }}
-          DB_NAME: ${{ env.TEST_DB_NAME }}
         run: yarn migration:check
 
   test-node:
@@ -87,10 +122,6 @@ jobs:
       matrix:
         shard: [1/4, 2/4, 3/4, 4/4]
     runs-on: ubuntu-latest
-    env:
-      TEST_DB_NAME: docker
-      TEST_DB_USER: docker
-      TEST_DB_PASSWORD: docker
 
     # Service containers to run with `container-job`
     services:
@@ -100,9 +131,9 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-          POSTGRES_USER: ${{ env.TEST_DB_USER }}
-          POSTGRES_DB: ${{ env.TEST_DB_NAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
         ports:
           - 5432:5432 # exposing 5432 port for application to use
         # Set health checks to wait until postgres has started
@@ -117,9 +148,9 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-          POSTGRES_USER: ${{ env.TEST_DB_USER }}
-          POSTGRES_DB: ${{ env.TEST_DB_NAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
         ports:
           - 5433:5432 # exposing 5432 port for application to use
         # Set health checks to wait until postgres has started
@@ -176,49 +207,3 @@ jobs:
 
       - name: yarn test
         run: yarn test:ci --shard=${{ matrix.shard }}
-        env:
-          CI: true
-          LOG_LEVEL: fatal # avoid unnecessary logging
-          # random keys
-          APPS_JWT_SECRET: ${{ secrets.MOCK_JWT_SECRET }}
-          APPS_PUBLISHER_ID: 9c9cea73-f3b7-48a3-aa6e-ead82c0685e7 # mock uuid
-          AUTH_CLIENT_HOST: 'localhost:3001'
-          AUTH_TOKEN_JWT_SECRET: ${{ secrets.MOCK_AUTH_TOKEN_JWT_SECRET }}
-          BUILDER_CLIENT_HOST: 'http://localhost:3111'
-          ACCOUNT_CLIENT_HOST: 'http://localhost:3114'
-          ANALYTICS_CLIENT_HOST: 'http://localhost:3005'
-          COOKIE_DOMAIN: localhost
-          DB_NAME: ${{ env.TEST_DB_NAME }}
-          DB_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-          DB_USERNAME: ${{ env.TEST_DB_USER }}
-          DB_HOST: localhost
-          EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN: 'http://localhost:1234'
-          ETHERPAD_API_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-          ETHERPAD_PUBLIC_URL: 'http://localhost:9001'
-          ETHERPAD_URL: 'http://etherpad:9001'
-          LIBRARY_CLIENT_HOST: 'http://localhost:3113'
-          FILE_STORAGE_ROOT_PATH: /
-          H5P_FILE_STORAGE_TYPE: file
-          H5P_PATH_PREFIX: h5p-content/
-          H5P_STORAGE_ROOT_PATH: /tmp/h5p
-          JWT_SECRET: ${{ secrets.MOCK_JWT_SECRET }}
-          MAILER_CONFIG_PASSWORD: password
-          MAILER_CONFIG_SMTP_HOST: localhost
-          MAILER_CONFIG_USERNAME: username
-          PLAYER_CLIENT_HOST: 'http://localhost:3112'
-          RECAPTCHA_SECRET_ACCESS_KEY: 'iamamockkey'
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
-          REFRESH_TOKEN_JWT_SECRET: ${{ secrets.MOCK_REFRESH_TOKEN_JWT_SECRET }}
-          S3_FILE_ITEM_ACCESS_KEY_ID: graasp-user
-          S3_FILE_ITEM_BUCKET: graasp
-          S3_FILE_ITEM_PLUGIN: true
-          S3_FILE_ITEM_REGION: us-east-1
-          S3_FILE_ITEM_SECRET_ACCESS_KEY: graasp-pwd
-          SECURE_SESSION_SECRET_KEY: ${{ secrets.MOCK_SECURE_SESSION_SECRET_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          MEILISEARCH_URL: fake
-          MEILISEARCH_MASTER_KEY: fake
-          JOB_SCHEDULING: false
-          GEOLOCATION_API_KEY: geolocation-key
-          GEOLOCATION_API_HOST: http://localhost:12345

--- a/src/plugins/__mocks__/datasource.ts
+++ b/src/plugins/__mocks__/datasource.ts
@@ -31,19 +31,26 @@ import { ItemLoginSchema } from '../../services/itemLogin/entities/itemLoginSche
 import { ItemMembership } from '../../services/itemMembership/entities/ItemMembership';
 import { Member } from '../../services/member/entities/member';
 import { MemberProfile } from '../../services/member/plugins/profile/entities/profile';
-import { DB_PORT } from '../../utils/config';
+import {
+  CI,
+  DB_HOST,
+  DB_NAME,
+  DB_PASSWORD,
+  DB_PORT,
+  DB_USERNAME,
+  JEST_WORKER_ID,
+} from '../../utils/config';
 
 // mock data source
 // we could use the original file, but for extra security we keep this file
 // dropSchema and synchronize could kill the database
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  host: process.env.DB_HOST ?? 'graasp-postgres-test',
-  port:
-    process.env.CI === 'true' ? 5432 + parseInt(process.env.JEST_WORKER_ID ?? '1') - 1 : DB_PORT,
-  username: process.env.DB_USERNAME ?? 'docker-test',
-  password: process.env.DB_PASSWORD ?? 'docker-test',
-  database: process.env.DB_NAME ?? 'docker-test',
+  host: DB_HOST ?? 'graasp-postgres-test',
+  port: CI ? 5432 + JEST_WORKER_ID - 1 : DB_PORT,
+  username: DB_USERNAME ?? 'docker-test',
+  password: DB_PASSWORD ?? 'docker-test',
+  database: DB_NAME ?? 'docker-test',
   // This was an attempt to ensure we don't use the same table as the prod/dev one
   // BUT it DOES NOT WORK for test since migrations are based on 'public'
   schema: DB_TEST_SCHEMA,

--- a/src/plugins/datasource.ts
+++ b/src/plugins/datasource.ts
@@ -30,32 +30,37 @@ import { ItemLoginSchema } from '../services/itemLogin/entities/itemLoginSchema'
 import { ItemMembership } from '../services/itemMembership/entities/ItemMembership';
 import { Member } from '../services/member/entities/member';
 import { MemberProfile } from '../services/member/plugins/profile/entities/profile';
-
-const DB_READ_REPLICA_HOSTS = process.env.DB_READ_REPLICA_HOSTS // also takes care of empty string
-  ? process.env.DB_READ_REPLICA_HOSTS.split(',')
-  : [];
+import {
+  DB_CONNECTION_POOL_SIZE,
+  DB_HOST,
+  DB_NAME,
+  DB_PASSWORD,
+  DB_PORT,
+  DB_READ_REPLICA_HOSTS,
+  DB_USERNAME,
+} from '../utils/config';
 
 const slaves = DB_READ_REPLICA_HOSTS.map((host) => ({
   host,
   port: 5432,
-  username: process.env.DB_USERNAME,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
+  username: DB_USERNAME,
+  password: DB_PASSWORD,
+  database: DB_NAME,
 }));
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
   replication: {
     master: {
-      host: process.env.DB_HOST,
-      port: 5432,
-      username: process.env.DB_USERNAME,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_NAME,
+      host: DB_HOST,
+      port: DB_PORT,
+      username: DB_USERNAME,
+      password: DB_PASSWORD,
+      database: DB_NAME,
     },
     slaves,
   },
-  poolSize: parseInt(process.env.DB_CONNECTION_POOL_SIZE ?? '10', 10), // *2 because of the number of tasks
+  poolSize: DB_CONNECTION_POOL_SIZE, // *2 because of the number of tasks
   // log queries that take more than 2s to execute
   maxQueryExecutionTime: 2000,
   logging: ['migration', 'error'],

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -4,7 +4,16 @@ import { Transaction } from '@sentry/types';
 
 import { FastifyInstance } from 'fastify';
 
-import { APP_VERSION } from './utils/config';
+import {
+  APP_VERSION,
+  NODE_ENV,
+  SENTRY_DSN,
+  SENTRY_ENABLE_PERFORMANCE,
+  SENTRY_ENABLE_PROFILING,
+  SENTRY_ENV,
+  SENTRY_PROFILES_SAMPLE_RATE,
+  SENTRY_TRACES_SAMPLE_RATE,
+} from './utils/config';
 
 // todo: use graasp-sdk?
 declare module 'fastify' {
@@ -32,12 +41,12 @@ const IGNORED_TRANSACTIONS = {
 };
 
 export const SentryConfig = {
-  enable: Boolean(process.env.SENTRY_DSN),
-  dsn: process.env.SENTRY_DSN,
-  enablePerformance: (process.env.SENTRY_ENABLE_PERFORMANCE ?? 'true') === 'true', // env var must be literal string "true"
-  enableProfiling: (process.env.SENTRY_ENABLE_PROFILING ?? 'true') === 'true', // env var must be literal string "true"
-  profilesSampleRate: parseFloat(process.env.SENTRY_PROFILES_SAMPLE_RATE ?? '1.0'),
-  tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '1.0'),
+  enable: Boolean(SENTRY_DSN),
+  dsn: SENTRY_DSN,
+  enablePerformance: SENTRY_ENABLE_PERFORMANCE,
+  enableProfiling: SENTRY_ENABLE_PROFILING,
+  profilesSampleRate: SENTRY_PROFILES_SAMPLE_RATE,
+  tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
 };
 
 export function initSentry(instance: FastifyInstance): {
@@ -50,7 +59,7 @@ export function initSentry(instance: FastifyInstance): {
 
   Sentry.init({
     dsn: SentryConfig.dsn,
-    environment: process.env.SENTRY_ENV ?? process.env.NODE_ENV,
+    environment: SENTRY_ENV ?? NODE_ENV,
     release: APP_VERSION,
     integrations: [
       // TODO: re-enable when @sentry/profiling-node is more stable

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,21 +1,9 @@
-// sort-imports-ignore
-// ./utils/config needs to be the first import so environment variables are initialised before being used.
-// Prettier's sort imports is ignored so the order can be conserved.
-import {
-  APP_VERSION,
-  CORS_ORIGIN_REGEX,
-  DEV,
-  ENVIRONMENT,
-  HOSTNAME,
-  PORT,
-  PROD,
-} from './utils/config';
-
 import fastifyHelmet from '@fastify/helmet';
 import fastify from 'fastify';
 
 import registerAppPlugins from './app';
 import { initSentry } from './sentry';
+import { APP_VERSION, CORS_ORIGIN_REGEX, DEV, ENVIRONMENT, HOSTNAME, PORT, PROD } from './utils/config';
 // import fastifyCompress from 'fastify-compress';
 import { GREETING } from './utils/constants';
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,15 @@ import fastify from 'fastify';
 
 import registerAppPlugins from './app';
 import { initSentry } from './sentry';
-import { APP_VERSION, CORS_ORIGIN_REGEX, DEV, ENVIRONMENT, HOSTNAME, PORT, PROD } from './utils/config';
+import {
+  APP_VERSION,
+  CORS_ORIGIN_REGEX,
+  DEV,
+  ENVIRONMENT,
+  HOSTNAME,
+  PORT,
+  PROD,
+} from './utils/config';
 // import fastifyCompress from 'fastify-compress';
 import { GREETING } from './utils/constants';
 

--- a/src/services/websockets/service-api.ts
+++ b/src/services/websockets/service-api.ts
@@ -11,6 +11,7 @@ import { RedisOptions } from 'ioredis';
 import fws from '@fastify/websocket';
 import { FastifyBaseLogger, FastifyPluginAsync } from 'fastify';
 
+import { NODE_ENV } from '../../utils/config';
 import { AjvMessageSerializer } from './message-serializer';
 import { MultiInstanceChannelsBroker } from './multi-instance';
 import { WebSocketChannels } from './ws-channels';
@@ -80,7 +81,7 @@ const plugin: FastifyPluginAsync<WebsocketsPluginOptions> = async (fastify, opti
   fastify.decorate('websockets', wsService);
 
   // decorate with debug internals in test mode
-  if (process.env.NODE_ENV === 'test') {
+  if (NODE_ENV === 'test') {
     fastify.decorate('_debug_websocketsChannels', wsChannels);
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -24,8 +24,11 @@ enum Environment {
   test = 'test',
 }
 
+export const LOG_LEVEL: string | undefined = process.env.LOG_LEVEL;
+export const NODE_ENV: string | undefined = process.env.NODE_ENV;
+
 export const ENVIRONMENT: Environment = (() => {
-  switch (process.env.NODE_ENV) {
+  switch (NODE_ENV) {
     case Environment.production:
       dotenv.config({ path: '.env.production', override: true });
       return Environment.production;
@@ -321,9 +324,6 @@ export const REDIS_PORT = process.env.REDIS_PORT;
 export const REDIS_PASSWORD = process.env.REDIS_PASSWORD;
 export const REDIS_USERNAME = process.env.REDIS_USERNAME;
 
-// Database
-export const DB_PORT = process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432;
-
 // validation
 export const IMAGE_CLASSIFIER_API = process.env.IMAGE_CLASSIFIER_API;
 
@@ -398,3 +398,33 @@ export const ALLOWED_SEARCH_LANGS = {
 // Geolocation API Key
 export const GEOLOCATION_API_KEY = process.env.GEOLOCATION_API_KEY;
 export const GEOLOCATION_API_HOST = process.env.GEOLOCATION_API_HOST;
+
+////////////
+// Sentry //
+////////////
+export const SENTRY_ENV: string | undefined = process.env.SENTRY_ENV;
+export const SENTRY_DSN: string | undefined = process.env.SENTRY_DSN;
+export const SENTRY_ENABLE_PERFORMANCE: boolean =
+  (process.env.SENTRY_ENABLE_PERFORMANCE ?? 'true') === 'true'; // env var must be literal string "true"
+export const SENTRY_ENABLE_PROFILING: boolean =
+  (process.env.SENTRY_ENABLE_PROFILING ?? 'true') === 'true'; // env var must be literal string "true"
+export const SENTRY_PROFILES_SAMPLE_RATE: number = +process.env.SENTRY_PROFILES_SAMPLE_RATE! || 1.0;
+export const SENTRY_TRACES_SAMPLE_RATE: number = +process.env.SENTRY_TRACES_SAMPLE_RATE! || 1.0;
+
+//////////////////////////////////////
+// Database Environements Variables //
+//////////////////////////////////////
+// Can be undefined, so tests can run without setting it. In production, TypeORM will throw an exception if not defined.
+export const DB_HOST: string | undefined = process.env.DB_HOST;
+export const DB_PORT = +process.env.DB_PORT! || 5432;
+export const DB_USERNAME: string | undefined = process.env.DB_USERNAME;
+export const DB_PASSWORD: string | undefined = process.env.DB_PASSWORD;
+export const DB_NAME: string | undefined = process.env.DB_NAME;
+export const DB_CONNECTION_POOL_SIZE: number = +process.env.DB_CONNECTION_POOL_SIZE! || 10;
+export const DB_READ_REPLICA_HOSTS: string[] = process.env.DB_READ_REPLICA_HOSTS?.split(',') ?? [];
+
+/////////////////
+// CI and Test //
+/////////////////
+export const JEST_WORKER_ID: number = +process.env.JEST_WORKER_ID! || 1;
+export const CI: boolean = process.env.CI === 'true';

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,9 +1,11 @@
 import { ObjectLiteral, QueryBuilder } from 'typeorm';
 
+import { NODE_ENV } from './config';
+
 // Print a query with parameters already filled in, ready to be sent to the database
 // Only for debugging purposes. DO NOT USE in production. (injection risk)
 export const printFilledSQL = <T extends ObjectLiteral>(query: QueryBuilder<T>) => {
-  if (process.env.NODE_ENV === 'production') {
+  if (NODE_ENV === 'production') {
     throw new Error('Do not use debug functions in productionsÒ');
   }
 


### PR DESCRIPTION
The first implementation of #998 didn't solved the issue. Because environnement variables where still used before initialisation during test context.

I've moved every `process.env`declarations in `config.ts` file, so every time we need to fetch an environnement variable, we have to import the configuration file.