### PR TITLE
chore: allow gpg signing inside container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,9 @@ RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
+# install GNUPG to allow signing commits with GPG signature
+RUN apt-get update && apt-get install gnupg2 -y
+
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"


### PR DESCRIPTION
In this PR I add the gnupg2 package inside the dev-container image to allow signing commit with GPG keys inside the container.

fix #1038 
