### PR TITLE
fix: allow to update link url and disallow editing html

### DIFF
--- a/API Collections/Auth/Mobile/Sign In.bru
+++ b/API Collections/Auth/Mobile/Sign In.bru
@@ -14,6 +14,6 @@ body:json {
   {
     "email": "{{user_email}}",
     "captcha":"mock",
-    "challenge": "2dd00bd77e0222ced882665481a9c1d9f907309d16e05ed007a1ea63928477a9"
+    "challenge": "{{challenge}}"
   }
 }

--- a/API Collections/Item/Create Link Item.bru
+++ b/API Collections/Item/Create Link Item.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Create Link Item
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{host}}/items
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "New Link item",
+    "type": "embeddedLink",
+    "description": "My custom description",
+    "extra": {
+      "embeddedLink": {
+        "url": "https://graasp.org"
+      }
+    },
+    "settings": {
+      "showButton": true
+    }
+  }
+}

--- a/API Collections/Item/Update Link Item.bru
+++ b/API Collections/Item/Update Link Item.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Update Link Item
+  type: http
+  seq: 4
+}
+
+patch {
+  url: {{host}}/items/{{itemId}}
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "type": "embeddedLink",
+    "extra": {
+      "embeddedLink": {
+        "url": "https://google.com"
+      }
+    }
+  }
+}

--- a/API Collections/environments/Graasp Local.bru
+++ b/API Collections/environments/Graasp Local.bru
@@ -1,4 +1,7 @@
 vars {
   host: http://localhost:3000
   user_email: alice@graasp.org
+  verifier: 1234
+  challenge: 03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4
+  temp_magic_token: ''
 }

--- a/src/services/item/plugins/embeddedLink/index.ts
+++ b/src/services/item/plugins/embeddedLink/index.ts
@@ -6,7 +6,7 @@ import { Repositories } from '../../../../utils/repositories';
 import { Actor } from '../../../member/entities/member';
 import { Item } from '../../entities/Item';
 import { LinkQueryParameterIsRequired } from './errors';
-import { createSchema } from './schemas';
+import { createSchema, getLinkMetadata, updateExtraSchema } from './schemas';
 import { EmbeddedLinkService } from './service';
 import { ensureProtocol } from './utils';
 
@@ -19,7 +19,7 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
   const { iframelyHrefOrigin } = options;
   const {
     log,
-    items: { extendCreateSchema, service: itemService },
+    items: { extendCreateSchema, extendExtrasUpdateSchema, service: itemService },
   } = fastify;
   const embeddedLinkService = new EmbeddedLinkService();
 
@@ -28,20 +28,19 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
   }
   // "install" custom schema for validating embedded link items creation
   extendCreateSchema(createSchema);
+  // add link extra update schema that allows to update url
+  extendExtrasUpdateSchema(updateExtraSchema);
 
   fastify.get<{ Querystring: { link: string } }>(
     '/metadata',
-    { preHandler: fastify.verifyAuthentication },
+    { preHandler: fastify.verifyAuthentication, schema: getLinkMetadata },
     async ({ query: { link } }) => {
       if (!link) {
         throw new LinkQueryParameterIsRequired();
       }
 
       const url = ensureProtocol(link);
-      const { html: _html, ...metadata } = await embeddedLinkService.getLinkMetadata(
-        iframelyHrefOrigin,
-        url,
-      );
+      const metadata = await embeddedLinkService.getLinkMetadata(iframelyHrefOrigin, url);
       const isEmbeddingAllowed = await embeddedLinkService.checkEmbeddingAllowed(url, log);
 
       return {
@@ -68,11 +67,12 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
       await embeddedLinkService.getLinkMetadata(iframelyHrefOrigin, url);
 
     // TODO: maybe all the code below should be moved to another place if it gets more complex
-    if (title) {
+    if (!item.name && title) {
+      // only override item name if it is an empty string (should not happen)
       item.name = title;
     }
     if (description) {
-      item.description = description;
+      embeddedLink.description = description;
     }
     if (html) {
       embeddedLink.html = html;
@@ -90,6 +90,7 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
   };
 
   itemService.hooks.setPreHook('create', hook);
+  itemService.hooks.setPreHook('update', hook);
 };
 
 export default plugin;

--- a/src/services/item/plugins/embeddedLink/index.ts
+++ b/src/services/item/plugins/embeddedLink/index.ts
@@ -68,7 +68,6 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
 
     // TODO: maybe all the code below should be moved to another place if it gets more complex
     if (title) {
-      // only override item name if it is an empty string (should not happen)
       item.name = title;
     }
     if (description) {

--- a/src/services/item/plugins/embeddedLink/index.ts
+++ b/src/services/item/plugins/embeddedLink/index.ts
@@ -67,7 +67,7 @@ const plugin: FastifyPluginAsync<GraaspEmbeddedLinkItemOptions> = async (fastify
       await embeddedLinkService.getLinkMetadata(iframelyHrefOrigin, url);
 
     // TODO: maybe all the code below should be moved to another place if it gets more complex
-    if (!item.name && title) {
+    if (title) {
       // only override item name if it is an empty string (should not happen)
       item.name = title;
     }

--- a/src/services/item/plugins/embeddedLink/schemas.ts
+++ b/src/services/item/plugins/embeddedLink/schemas.ts
@@ -2,10 +2,13 @@ import S from 'fluent-json-schema';
 
 import { ItemType } from '@graasp/sdk';
 
+import { error } from '../../../../schemas/fluent-schema';
+
 const embeddedLinkItemExtraCreate = S.object()
   .additionalProperties(false)
   .prop(
     ItemType.LINK,
+    // only allow to set url in extra on create
     S.object().additionalProperties(false).prop('url', S.string().format('url')).required(['url']),
   )
   .required([ItemType.LINK]);
@@ -15,25 +18,27 @@ export const createSchema = S.object()
   .prop('extra', embeddedLinkItemExtraCreate)
   .required(['type', 'extra']);
 
-// equivalent in a static JSON Schema
-// {
-//   type: 'object',
-//   properties: {
-//     type: { const: 'embeddedLink' },
-//     extra: {
-//       type: 'object',
-//       additionalProperties: false,
-//       properties: {
-//         embeddedLink: {
-//           type: 'object',
-//           additionalProperties: false,
-//           properties: {
-//             url: { type: 'string', format: 'url' }
-//           },
-//           required: ['url']
-//         }
-//       },
-//       required: ['embeddedLink']
-//     }
-//   }
-// }
+// schema defining the allowed properties for the link item
+export const updateExtraSchema = S.object()
+  .additionalProperties(false)
+  .prop(
+    ItemType.LINK,
+    // only allow to set url in extra on create
+    S.object().additionalProperties(false).prop('url', S.string().format('url')).required(['url']),
+  )
+  .required([ItemType.LINK]);
+
+export const getLinkMetadata = {
+  querystring: S.object().additionalProperties(false).prop('link', S.string().format('url')),
+  response: {
+    '2xx': S.object()
+      .additionalProperties(false)
+      .prop('title', S.string())
+      .prop('description', S.string())
+      .prop('html', S.string())
+      .prop('isEmbeddingAllowed', S.boolean())
+      .prop('icons', S.array().items(S.string()))
+      .prop('thumbnails', S.array().items(S.string())),
+    '4xx': error,
+  },
+};

--- a/src/services/item/plugins/embeddedLink/schemas.ts
+++ b/src/services/item/plugins/embeddedLink/schemas.ts
@@ -4,28 +4,29 @@ import { ItemType } from '@graasp/sdk';
 
 import { error } from '../../../../schemas/fluent-schema';
 
+// on link creation or update, the only allowed property in extra is the "url" property.
+// all other extra properties are filled by the backend.
+const strictUrlProperty = S.object()
+  .additionalProperties(false)
+  .prop('url', S.string().format('url'))
+  .required(['url']);
+
+// schema defining the properties that can be supplied on the "extra" for the link item on creation
 const embeddedLinkItemExtraCreate = S.object()
   .additionalProperties(false)
-  .prop(
-    ItemType.LINK,
-    // only allow to set url in extra on create
-    S.object().additionalProperties(false).prop('url', S.string().format('url')).required(['url']),
-  )
+  .prop(ItemType.LINK, strictUrlProperty)
   .required([ItemType.LINK]);
 
+// schema upgrading the general item creation schema, specifying the link properties allowed on creation
 export const createSchema = S.object()
   .prop('type', S.const(ItemType.LINK))
   .prop('extra', embeddedLinkItemExtraCreate)
   .required(['type', 'extra']);
 
-// schema defining the allowed properties for the link item
+// schema defining the properties that can be supplied on the "extra" for the link item on update
 export const updateExtraSchema = S.object()
   .additionalProperties(false)
-  .prop(
-    ItemType.LINK,
-    // only allow to set url in extra on create
-    S.object().additionalProperties(false).prop('url', S.string().format('url')).required(['url']),
-  )
+  .prop(ItemType.LINK, strictUrlProperty)
   .required([ItemType.LINK]);
 
 export const getLinkMetadata = {

--- a/src/services/item/plugins/embeddedLink/test/embeddedLink.test.ts
+++ b/src/services/item/plugins/embeddedLink/test/embeddedLink.test.ts
@@ -189,7 +189,7 @@ describe('Link Item tests', () => {
         ({ app, actor } = await build());
       });
 
-      it('Bad Request for link', async () => {
+      it('Allow to edit link url', async () => {
         const { item } = await testUtils.saveItemAndMembership({
           item: {
             name: 'link item',
@@ -206,6 +206,34 @@ describe('Link Item tests', () => {
           },
           settings: {
             someSetting: 'value',
+          },
+        };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusMessage).toEqual(ReasonPhrases.OK);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        // TODO: check that the title and description have been updated for the new link
+      });
+
+      it('Disallow editing html in extra', async () => {
+        const { item } = await testUtils.saveItemAndMembership({
+          item: {
+            name: 'link item',
+            type: ItemType.LINK,
+          },
+          member: actor,
+        });
+        const payload = {
+          name: 'new name',
+          extra: {
+            [ItemType.LINK]: {
+              html: '<script>alert("Hello !")</script>',
+            },
           },
         };
 

--- a/src/services/item/plugins/embeddedLink/test/embeddedLink.test.ts
+++ b/src/services/item/plugins/embeddedLink/test/embeddedLink.test.ts
@@ -88,9 +88,10 @@ describe('Link Item tests', () => {
               html: 'html',
               icons: [],
               thumbnails: [],
+              description: iframelyMeta.description,
             },
           },
-          description: iframelyMeta.description,
+          description: payload.description,
           settings: {
             showLinkIframe: false,
             showLinkButton: true,
@@ -302,8 +303,9 @@ describe('Link Item tests', () => {
           payload,
         });
 
-        expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
-        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(response.statusMessage).toEqual(ReasonPhrases.ACCEPTED);
+        expect(response.statusCode).toBe(StatusCodes.ACCEPTED);
+        // TODO: test that the link info has been updated
       });
     });
   });

--- a/src/services/item/plugins/importExport/test/fixtures/archive.ts
+++ b/src/services/item/plugins/importExport/test/fixtures/archive.ts
@@ -16,8 +16,8 @@ export const childContent = {
 export const link = {
   name: 'Graasp',
   type: ItemType.LINK,
-  description: 'Graasp description',
-  extra: { embeddedLink: { url: 'https://graasp.org' } },
+  description: 'link.url\n',
+  extra: { embeddedLink: { url: 'https://graasp.org', description: 'Graasp description' } },
 };
 
 export const archive = [

--- a/src/services/item/plugins/importExport/test/index.test.ts
+++ b/src/services/item/plugins/importExport/test/index.test.ts
@@ -61,7 +61,7 @@ jest.mock('@aws-sdk/lib-storage', () => {
 
 const iframelyMeta = {
   title: ARCHIVE_CONTENT.link.name,
-  description: ARCHIVE_CONTENT.link.description,
+  description: ARCHIVE_CONTENT.link.extra.embeddedLink.description,
 };
 
 const iframelyResult = {

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -434,6 +434,8 @@ export class ItemService {
     const item = await itemRepository.get(itemId);
     await validatePermission(repositories, PermissionLevel.Write, actor, item);
 
+    // TODO: if updating a link item, fetch the new informations
+
     await this.hooks.runPreHooks('update', actor, repositories, { item: item });
 
     const updated = await itemRepository.patch(itemId, body);

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,13 +663,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.577.0, @aws-sdk/types@npm:^3.222.0":
+"@aws-sdk/types@npm:3.577.0":
   version: 3.577.0
   resolution: "@aws-sdk/types@npm:3.577.0"
   dependencies:
     "@smithy/types": "npm:^3.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10/a384ea32fcd0ae02a8058aa1f0d370de4c54f38a5e88bf649090e85bde09ef36efca49351f88669152626826441a7de8a3b1dfd0d6886553eeb2234d5205a196
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
+  version: 3.535.0
+  resolution: "@aws-sdk/types@npm:3.535.0"
+  dependencies:
+    "@smithy/types": "npm:^2.12.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/29c2def0ef0a10c0cc44d45b18e149ed6884a6417ddef7a23a58d50ad83f71cf0b00dd774fcc57fcdf85e1e21a8849d9e25999943435a1487ee8ac127a668c6d
   languageName: node
   linkType: hard
 
@@ -3303,6 +3313,15 @@ __metadata:
     "@smithy/util-stream": "npm:^3.0.1"
     tslib: "npm:^2.6.2"
   checksum: 10/c9813aa7de2b11d4eb93482b42a52467d1b1fa94e18678ed343ecdb9929880c7526722c22e68993b9f238763cf43e21f266e7c51d3041a93ebaba1112e27ac0f
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@smithy/types@npm:2.12.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/2fb459b10d0c51d10da92e9d4b1551c1312dfb2a4739c4aeaeab703e8b35260a87ebc0c1cbb8a1deba669369ae7addab4eb81d99c70d0021b13cd26050a8c9b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR:
- move automatic link description to the `extra.description` field
- allow to update a link `url`
- do not allow to update more that the `extra.url` field in updates to prevent injecting into the unsafe `extra.html` prop

fix #1057 