### PR TITLE
fix: copy suffix can't increment past 3

### DIFF
--- a/src/services/item/repository.test.ts
+++ b/src/services/item/repository.test.ts
@@ -669,6 +669,22 @@ describe('ItemRepository', () => {
       expect(result.treeCopyMap.get(item.id)!.copy.id).toEqual(copy.id);
       expect(result.treeCopyMap.get(item.id)!.original.id).toEqual(item.id);
     });
+    it('copy multiple times', async () => {
+      // regession test for issue with statefull regular expression
+      const item = await testUtils.saveItem({ actor });
+      const result = await itemRepository.copy(item, actor);
+      const copy = result.copyRoot;
+      expect(copy.name).toEqual(`${item.name} (2)`);
+      expect(copy.id).not.toEqual(item.id);
+      expect(result.treeCopyMap.get(item.id)!.copy.id).toEqual(copy.id);
+      expect(result.treeCopyMap.get(item.id)!.original.id).toEqual(item.id);
+      const secondResult = await itemRepository.copy(copy, actor);
+      const secondCopy = secondResult.copyRoot;
+      expect(secondCopy.name).toEqual(`${item.name} (3)`);
+      const thirdResult = await itemRepository.copy(secondCopy, actor);
+      const thirdCopy = thirdResult.copyRoot;
+      expect(thirdCopy.name).toEqual(`${item.name} (4)`);
+    });
     it('cannot copy in non-folder', async () => {
       const parentItem = await testUtils.saveItem({ actor, item: { type: 'app' } });
       const item = await testUtils.saveItem({ actor });

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -33,7 +33,7 @@ import { ItemChildrenParams } from './types';
 import { _fixChildrenOrder, sortChildrenForTreeWith, sortChildrenWith } from './utils';
 
 const DEFAULT_COPY_SUFFIX = ' (2)';
-const IS_COPY_REGEX = /\s\(\d+\)$/g;
+const IS_COPY_REGEX = /\s\(\d+\)$/;
 
 const DEFAULT_THUMBNAIL_SETTING: ItemSettings = {
   hasThumbnail: false,


### PR DESCRIPTION
Using the `global` flag on a regex makes it stateful, which is not what we want in our case. 

I added a test and fixed the issue by removing the global flag.