### PR TITLE
refactor: remove item hooks - in progress

### DIFF
--- a/src/services/item/classcontroller.ts
+++ b/src/services/item/classcontroller.ts
@@ -1,0 +1,46 @@
+import { StatusCodes } from 'http-status-codes';
+import { DataSource } from 'typeorm';
+
+import { buildRepositories } from '../../utils/repositories';
+import { ItemServiceManager } from './itemServiceManager';
+import { AppService } from './plugins/app/service';
+import { H5PService } from './plugins/html/h5p/service';
+
+export class ItemController {
+  // get from injection
+  private db: DataSource;
+  private h5pService: H5PService;
+  private appService: AppService;
+
+  async copy(request, reply) {
+    const {
+      member,
+      query: { id: ids },
+      body: { parentId },
+    } = request;
+
+    // todo: replace with authenticate
+    if (!member) {
+      throw 'not authenticated';
+    }
+
+    this.db.transaction(async (manager) => {
+      const repositories = buildRepositories(manager);
+
+      const results = await Promise.all(
+        ids.map(async (id) => {
+          const service = await ItemServiceManager.getServiceForTypeFromId(repositories, id);
+
+          // TODO: check permission here
+
+          return service.copy(member, repositories, id, { parentId });
+        }),
+      );
+      return { items: results.map(({ item }) => item), copies: results.map(({ copy }) => copy) };
+    });
+    // TODO: set back websocket
+
+    reply.status(StatusCodes.ACCEPTED);
+    return ids;
+  }
+}

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -9,6 +9,7 @@ import { IdParam, IdsParams, PaginationParams } from '../../types';
 import { UnauthorizedMember } from '../../utils/errors';
 import { buildRepositories } from '../../utils/repositories';
 import { resultOfToList } from '../utils';
+import { ItemController } from './classcontroller';
 import { Item } from './entities/Item';
 import {
   copyMany,
@@ -379,12 +380,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         body: { parentId },
         log,
       } = request;
-      db.transaction(async (manager) => {
-        const repositories = buildRepositories(manager);
-        return await itemService.copyMany(member, repositories, ids, {
-          parentId,
-        });
-      })
+      new ItemController()
+        .copy(request, reply)
+        // TODO: move websockets as observer?
         .then(({ items, copies }) => {
           if (member) {
             websockets.publish(

--- a/src/services/item/folderService.ts
+++ b/src/services/item/folderService.ts
@@ -1,0 +1,32 @@
+import { UUID } from '@graasp/sdk';
+
+import { Repositories } from '../../utils/repositories';
+import { Actor } from '../member/entities/member';
+import { FolderItem } from './entities/Item';
+import { ItemServiceManager } from './itemServiceManager';
+import { ItemService } from './service';
+
+export class FolderService extends ItemService {
+  async copy(actor: Actor, repositories: Repositories, itemId: UUID, args: { parentId?: UUID }) {
+    const item = (await this.get(actor, repositories, itemId)) as FolderItem;
+
+    const descendants = await repositories.itemRepository.getDescendants(item);
+    const items = [...descendants, item];
+
+    const res = await super.copy(actor, repositories, itemId, args);
+
+    // TODO: handle children order
+
+    // recursive given item type
+    for (const i of items) {
+      const service = await ItemServiceManager.getServiceForTypeFromId(repositories, i.id);
+      await service.copy(actor, repositories, itemId, args);
+    }
+
+    return res;
+  }
+
+  async delete() {
+    // delete self + descendants using tree, without using super
+  }
+}

--- a/src/services/item/itemServiceManager.ts
+++ b/src/services/item/itemServiceManager.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+
+import { ItemType } from '@graasp/sdk';
+
+import { FolderService } from './folderService';
+import { AppService } from './plugins/app/service';
+import { H5PService } from './plugins/html/h5p/service';
+import { ItemService } from './service';
+
+export class ItemServiceManager {
+  // get from injection
+  private db: DataSource;
+  private h5pService: H5PService;
+  private appService: AppService;
+  private folderService: FolderService;
+
+  static async getServiceForTypeFromId(repositories, id: string): Promise<ItemService> {
+    // TODO: check permission
+
+    // not really cool
+    const item = await repositories.itemRepository.get(id);
+
+    // question: would be best to get the service given the item
+    // like item.getService() but not sure it's feasible
+    switch (item.type) {
+      case ItemType.FOLDER:
+        return this.folderService;
+      case ItemType.APP:
+        return this.appService;
+      case ItemType.H5P:
+      default:
+        return this.h5pService;
+    }
+  }
+}

--- a/src/services/item/plugins/app/appSetting/index.ts
+++ b/src/services/item/plugins/app/appSetting/index.ts
@@ -26,18 +26,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
   fastify.register(appSettingsWsHooks, { appSettingService });
 
-  // copy app settings and related files on item copy
-  const hook = async (
-    actor: Actor,
-    repositories: Repositories,
-    { original, copy }: { original: Item; copy: Item },
-  ) => {
-    if (original.type !== ItemType.APP || copy.type !== ItemType.APP) return;
-
-    await appSettingService.copyForItem(actor, repositories, original, copy);
-  };
-  itemService.hooks.setPostHook('copy', hook);
-
   // endpoints accessible to third parties with Bearer token
   fastify.register(async function (fastify) {
     fastify.addHook('preHandler', fastify.verifyBearerAuth as preHandlerHookHandler);

--- a/src/services/item/plugins/app/service.ts
+++ b/src/services/item/plugins/app/service.ts
@@ -7,20 +7,21 @@ import { validatePermission } from '../../../authorization';
 import { Actor, Member } from '../../../member/entities/member';
 import { Item, isItemType } from '../../entities/Item';
 import { ItemService } from '../../service';
+import { AppSettingService } from './appSetting/service';
 import { checkTargetItemAndTokenItemMatch } from './utils';
 
-export class AppService {
-  itemService: ItemService;
+export class AppService extends ItemService {
   jwtExpiration: number;
   promisifiedJwtSign: (
     arg1: { sub: AuthTokenSubject },
     arg2: { expiresIn: string },
   ) => Promise<string>;
+  private appSettingService: AppSettingService;
 
-  constructor(itemService, jwtExpiration, promisifiedJwtSign) {
-    this.itemService = itemService;
+  constructor(jwtExpiration, promisifiedJwtSign) {
+    // TODO
+    super(0 as any, 0 as any);
     this.jwtExpiration = jwtExpiration;
-    // this.promisifiedJwtVerify = promisifiedJwtVerify;
     this.promisifiedJwtSign = promisifiedJwtSign;
   }
 
@@ -104,5 +105,13 @@ export class AppService {
       memberships.data[item.id].map(({ member }) => member),
       ({ id }) => id,
     );
+  }
+
+  async copy(actor, repositories, id, args) {
+    const { item: original, copy } = await super.copy(actor, repositories, id, args);
+
+    await this.appSettingService.copyForItem(actor, repositories, original, copy);
+
+    return { item: original, copy };
   }
 }

--- a/src/services/item/plugins/html/h5p/index.ts
+++ b/src/services/item/plugins/html/h5p/index.ts
@@ -13,7 +13,7 @@ import { UnauthorizedMember } from '../../../../../utils/errors';
 import { buildRepositories } from '../../../../../utils/repositories';
 import { validatePermission } from '../../../../authorization';
 import { Member } from '../../../../member/entities/member';
-import { Item, isItemType } from '../../../entities/Item';
+import { Item } from '../../../entities/Item';
 import { FastifyStaticReply } from '../types';
 import {
   DEFAULT_H5P_ASSETS_ROUTE,
@@ -157,38 +157,6 @@ const plugin: FastifyPluginAsync<H5PPluginOptions> = async (fastify) => {
         });
       },
     );
-  });
-
-  /**
-   * Delete H5P assets on item delete
-   */
-  itemService.hooks.setPostHook('delete', async (actor, repositories, { item }) => {
-    if (!isItemType(item, ItemType.H5P)) {
-      return;
-    }
-    if (!actor) {
-      return;
-    }
-    const { extra } = item;
-    await h5pService.deletePackage(actor, extra.h5p.contentId);
-  });
-
-  /**
-   * Copy H5P assets on item copy
-   */
-  itemService.hooks.setPostHook('copy', async (actor, repositories, { original: item, copy }) => {
-    // only execute this handler for H5P item types
-    if (!isItemType(item, ItemType.H5P) || !isItemType(copy, ItemType.H5P)) {
-      return;
-    }
-    if (!actor) {
-      return;
-    }
-
-    await h5pService.copy(actor, repositories, {
-      original: item,
-      copy: copy,
-    });
   });
 };
 

--- a/src/services/item/plugins/html/service.ts
+++ b/src/services/item/plugins/html/service.ts
@@ -17,7 +17,9 @@ import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import FileService, { FileServiceConfig } from '../../../file/service';
 import { Actor, Member } from '../../../member/entities/member';
+import { ThumbnailService } from '../../../thumbnail/service';
 import { Item } from '../../entities/Item';
+import { ItemService } from '../../service';
 import { GraaspHtmlError, HtmlImportError } from './errors';
 import { DEFAULT_MIME_TYPE } from './h5p/constants';
 import { HtmlValidator } from './validator';
@@ -25,7 +27,7 @@ import { HtmlValidator } from './validator';
 /**
  * Implementation for the Html service
  */
-export abstract class HtmlService {
+export abstract class HtmlService extends ItemService {
   public readonly fileService: FileService;
   protected readonly validator: HtmlValidator;
   protected readonly mimetype: string;
@@ -49,6 +51,10 @@ export abstract class HtmlService {
     validator: HtmlValidator,
     log: FastifyBaseLogger,
   ) {
+    // TODO: get thumbnailservice from injection
+    // TODO: get logger
+    super({} as unknown as ThumbnailService, (() => {}) as unknown as FastifyBaseLogger);
+
     if (pathPrefix && pathPrefix.startsWith('/')) {
       throw new Error('path prefix should not start with a "/"!');
     }


### PR DESCRIPTION
> [!WARNING]  
> This PR is here to show an idea, but won't be merged, because it's missing the dependencies injection.


Here is my idea to remove hooks related to items:
- structure the item services so that they extends a generic `itemService`. 
- then we can use an common implemented function depending on the item type (eg. copy)
- I haven't tried really hard for now, but how I did the switching of services given the type is to have a `ItemServiceManager`. Perhaps there's some way to link a string to a service. The other problem here is also that we often don't have the item immediately.  

Notes:
- this does not apply for websockets, or related entities such as tags, geolocation, etc.
- the current code does not compile, it is a proof of concept that a common function can be used. The functions themselves are not 100% correct.

```mermaid
classDiagram
    ItemService : copy()
    ItemService --|>  HTMLService
    ItemService --|>  FolderService
    FolderService : copy()
    ItemService --|>  AppService
    AppService : copy()
    HTMLService  --|>  H5PService
    H5PService : copy()
    
    ItemController : copy(req, reply) { \n service = getServiceForItemType() \n service.copy() \n  }
    ItemController --> ItemService
    class ItemServiceManager {
        static getServiceForItemType()
    }

    ItemServiceManager o-- H5PService
    ItemServiceManager o-- AppService
    ItemServiceManager o-- FolderService
    
```