### PR TITLE
fix: email regex for `.swiss` emails

### DIFF
--- a/src/services/item/plugins/embeddedLink/schemas.ts
+++ b/src/services/item/plugins/embeddedLink/schemas.ts
@@ -8,7 +8,7 @@ import { error } from '../../../../schemas/fluent-schema';
 // all other extra properties are filled by the backend.
 const strictUrlProperty = S.object()
   .additionalProperties(false)
-  .prop('url', S.string().format('url'))
+  .prop('url', S.string().format('uri-reference'))
   .required(['url']);
 
 // schema defining the properties that can be supplied on the "extra" for the link item on creation
@@ -30,7 +30,9 @@ export const updateExtraSchema = S.object()
   .required([ItemType.LINK]);
 
 export const getLinkMetadata = {
-  querystring: S.object().additionalProperties(false).prop('link', S.string().format('url')),
+  querystring: S.object()
+    .additionalProperties(false)
+    .prop('link', S.string().format('uri-reference')),
   response: {
     '2xx': S.object()
       .additionalProperties(false)

--- a/src/services/member/schema.test.ts
+++ b/src/services/member/schema.test.ts
@@ -1,0 +1,25 @@
+import { EMAIL_REGEX } from './schemas';
+
+describe('Email regex', () => {
+  it('Allows basic CH emails', () => {
+    expect(new RegExp(EMAIL_REGEX).test('bob@tech.ch')).toBeTruthy();
+    // with a dash in the name
+    expect(new RegExp(EMAIL_REGEX).test('bob-helper@tech.ch')).toBeTruthy();
+    // with a dot in the name
+    expect(new RegExp(EMAIL_REGEX).test('bob.helper@tech.ch')).toBeTruthy();
+    // with nested domains
+    expect(new RegExp(EMAIL_REGEX).test('bob.helper@tech-team.ch')).toBeTruthy();
+    // with dashes in the domain
+    expect(new RegExp(EMAIL_REGEX).test('bob.helper@tech.team.ch')).toBeTruthy();
+  });
+
+  it('Allows longer domain names', () => {
+    expect(new RegExp(EMAIL_REGEX).test('contact@paris.museum')).toBeTruthy();
+    expect(new RegExp(EMAIL_REGEX).test('test@team.swiss')).toBeTruthy();
+    expect(new RegExp(EMAIL_REGEX).test('test@team.swiss-hello')).toBeTruthy();
+  });
+
+  it('Does not allow non-emails', () => {
+    expect(new RegExp(EMAIL_REGEX).test('bob')).toBeFalsy();
+  });
+});

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -6,7 +6,25 @@ import {
 
 import { NAME_REGEX, UUID_REGEX } from '../../schemas/global';
 
-const EMAIL_REGEX = '^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$';
+/**
+ * This allows email adresses that are structured as follows:
+ * - at least one of
+ *   - word character
+ *   - dash
+ *   - dot
+ * - the @ symbol
+ * - multiple times
+ *   - at least one of
+ *     - word cahracter
+ *     - dash
+ *   - a dot
+ * - a tld extension that is between 2 and 63 chars long
+ *
+ * The maximum length of the TLD is defined by https://www.rfc-editor.org/rfc/rfc1034
+ * and is 63 octets (chars)
+ *
+ */
+export const EMAIL_REGEX = '^[.-\\w]+@[.-\\w]+.[-\\w]{2,63}$';
 
 export default {
   $id: 'https://graasp.org/members/',


### PR DESCRIPTION
fix #1128 

- Increase the tolerance for TLD names up to 63 chars long (according to https://www.rfc-editor.org/rfc/rfc1034)
- Add unit test for the email regex
- App regression test for the `/members/search` endpoint with offending `.swiss` email