### PR TITLE
chore: add missing env var error, for better DX

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,7 @@ import {
   S3FileConfiguration,
 } from '../services/file/interfaces/configuration';
 import { notUndefined } from './assertions';
+import { ExpectedEnvVariable } from './errors';
 
 enum Environment {
   production = 'production',
@@ -204,7 +205,10 @@ export const PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES: number =
   Number(process.env.PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES) || 1440;
 
 /** Email change token Secret */
-export const EMAIL_CHANGE_JWT_SECRET: string = notUndefined(process.env.EMAIL_CHANGE_JWT_SECRET);
+export const EMAIL_CHANGE_JWT_SECRET: string = notUndefined(
+  process.env.EMAIL_CHANGE_JWT_SECRET,
+  new ExpectedEnvVariable('EMAIL_CHANGE_JWT_SECRET'),
+);
 
 /** Email change token expiration, in minutes */
 export const EMAIL_CHANGE_JWT_EXPIRATION_IN_MINUTES: number =

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,6 +3,15 @@ import { StatusCodes } from 'http-status-codes';
 import { ErrorFactory } from '@graasp/sdk';
 import { FAILURE_MESSAGES } from '@graasp/translations';
 
+export const ConfigurationError = ErrorFactory('config');
+
+export class ExpectedEnvVariable extends Error {
+  constructor(envVarName: string) {
+    super(`Expected to find env variable "${envVarName}" but it was undefined.`);
+    this.name = 'MissingEnvVar';
+  }
+}
+
 export const CoreError = ErrorFactory('core');
 
 export class ItemNotFound extends CoreError {


### PR DESCRIPTION
In this PR I propose to send a more meaningful error when and env var is missing. 

I spent a good amount of time figuring out the origin of the issue. 
The server would not start, because a new env variable was missing, but the error made it look like there was an error somewhere else. 

I try to create a new error that gives more information and indicates that the issue comes from a missing env variable. 