### PR TITLE
fix: logout member on delete

### DIFF
--- a/API Collections/Auth/Mobile/Register.bru
+++ b/API Collections/Auth/Mobile/Register.bru
@@ -12,9 +12,9 @@ post {
 
 body:json {
   {
-    "name": "kim",
-    "email": "kim1@gmail.com",
+    "name": "{{user_name}}",
+    "email": "{{user_email}}",
     "captcha": "mock",
-    "challenge":"2dd00bd77e0222ced882665481a9c1d9f907309d16e05ed007a1ea63928477a9"
+    "challenge":"{{challenge}}"
   }
 }

--- a/API Collections/Member/Delete Current Member.bru
+++ b/API Collections/Member/Delete Current Member.bru
@@ -1,15 +1,11 @@
 meta {
-  name: Current Member
+  name: Delete Current Member
   type: http
-  seq: 1
+  seq: 2
 }
 
-get {
+delete {
   url: {{host}}/members/current
   body: none
   auth: inherit
-}
-
-vars:post-response {
-  member_id: res("id")
 }

--- a/API Collections/Member/Patch Current Member.bru
+++ b/API Collections/Member/Patch Current Member.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Patch Current Member
+  type: http
+  seq: 3
+}
+
+patch {
+  url: {{host}}/members/{{member_id}}
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "New Name"
+  }
+}

--- a/API Collections/environments/Graasp Local.bru
+++ b/API Collections/environments/Graasp Local.bru
@@ -4,4 +4,5 @@ vars {
   verifier: 1234
   challenge: 03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4
   temp_magic_token: ''
+  user_name: Alice
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
     "@graasp/sdk": "4.16.0",
-    "@graasp/translations": "1.30.3",
+    "@graasp/translations": "1.31.2",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.118.0",
     "@sentry/tracing": "7.114.0",

--- a/src/plugins/datasource.ts
+++ b/src/plugins/datasource.ts
@@ -63,7 +63,7 @@ export const AppDataSource = new DataSource({
   poolSize: DB_CONNECTION_POOL_SIZE, // *2 because of the number of tasks
   // log queries that take more than 2s to execute
   maxQueryExecutionTime: 2000,
-  logging: ['migration', 'error', 'query'],
+  logging: ['migration', 'error'],
   migrationsRun: true,
 
   entities: [

--- a/src/plugins/datasource.ts
+++ b/src/plugins/datasource.ts
@@ -63,7 +63,7 @@ export const AppDataSource = new DataSource({
   poolSize: DB_CONNECTION_POOL_SIZE, // *2 because of the number of tasks
   // log queries that take more than 2s to execute
   maxQueryExecutionTime: 2000,
-  logging: ['migration', 'error'],
+  logging: ['migration', 'error', 'query'],
   migrationsRun: true,
 
   entities: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,6 @@ const start = async () => {
         // This allow routes that take array to correctly interpret single values as an array
         // https://github.com/fastify/fastify/blob/main/docs/Validation-and-Serialization.md
         coerceTypes: 'array',
-        allowUnionTypes: true,
       },
       plugins: [ajvFormats],
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ const start = async () => {
         // This allow routes that take array to correctly interpret single values as an array
         // https://github.com/fastify/fastify/blob/main/docs/Validation-and-Serialization.md
         coerceTypes: 'array',
+        allowUnionTypes: true,
       },
       plugins: [ajvFormats],
     },

--- a/src/services/auth/plugins/magicLink/index.ts
+++ b/src/services/auth/plugins/magicLink/index.ts
@@ -135,7 +135,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
   // logout
   fastify.get('/logout', async (request, reply) => {
-    request.logOut();
+    // logout user, so subsequent calls can not make use of the current user.
+    request.logout();
+    // remove session so the cookie is removed by the browser
+    request.session.delete();
     reply.status(StatusCodes.NO_CONTENT);
   });
 };

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -132,7 +132,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       preHandler: optionalIsAuthenticated,
     },
     async ({ user, params: { id } }) => {
-      return itemService.getPacked(user?.member, buildRepositories(), id);
+      const item = await itemService.getPacked(user?.member, buildRepositories(), id);
+      console.log(item);
+      return item;
     },
   );
 

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -133,7 +133,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
     async ({ user, params: { id } }) => {
       const item = await itemService.getPacked(user?.member, buildRepositories(), id);
-      console.log(item);
       return item;
     },
   );

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -49,6 +49,7 @@ export const settings = S.object()
   .prop('alignment', S.enum(Object.values(Alignment)));
 
 export const partialMember = S.object()
+  .additionalProperties(false)
   .prop('id', uuid)
   .prop('name', S.string())
   .prop('email', S.string().format('email'));

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -66,7 +66,7 @@ export const item = S.object()
   .prop('settings', settings)
   .prop('lang', S.string())
   // creator could have been deleted
-  .prop('creator', S.ifThenElse(S.null(), S.null(), partialMember))
+  .prop('creator', S.ifThenElse(S.not(S.null()), partialMember, S.null()))
   /**
    * for some reason setting these date fields as "type: 'string'"
    * makes the serialization fail using the anyOf.

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -55,6 +55,7 @@ export const partialMember = S.object()
   .prop('email', S.string().format('email'));
 
 export const item = S.object()
+  .additionalProperties(false)
   .prop('id', uuid)
   .prop('name', S.string())
   .prop('displayName', S.string())
@@ -65,7 +66,7 @@ export const item = S.object()
   .prop('settings', settings)
   .prop('lang', S.string())
   // creator could have been deleted
-  .prop('creator', S.object().ifThenElse(S.null(), S.null(), partialMember))
+  .prop('creator', S.ifThenElse(S.null(), S.null(), partialMember))
   /**
    * for some reason setting these date fields as "type: 'string'"
    * makes the serialization fail using the anyOf.

--- a/src/services/item/fluent-schema.ts
+++ b/src/services/item/fluent-schema.ts
@@ -49,13 +49,11 @@ export const settings = S.object()
   .prop('alignment', S.enum(Object.values(Alignment)));
 
 export const partialMember = S.object()
-  .additionalProperties(false)
   .prop('id', uuid)
   .prop('name', S.string())
   .prop('email', S.string().format('email'));
 
 export const item = S.object()
-  .additionalProperties(false)
   .prop('id', uuid)
   .prop('name', S.string())
   .prop('displayName', S.string())
@@ -66,7 +64,7 @@ export const item = S.object()
   .prop('settings', settings)
   .prop('lang', S.string())
   // creator could have been deleted
-  .prop('creator', S.ifThenElse(S.not(S.null()), partialMember, S.null()))
+  .prop('creator', S.object().ifThenElse(S.null(), S.null(), partialMember))
   /**
    * for some reason setting these date fields as "type: 'string'"
    * makes the serialization fail using the anyOf.
@@ -176,12 +174,12 @@ export const create =
     };
   };
 
-export const getOne = {
+export const getOne: FastifySchema = {
   params: idParam,
   response: { 200: packedItem, '4xx': error },
 };
 
-export const getAccessible = {
+export const getAccessible: FastifySchema = {
   querystring: S.object()
     .prop('page', S.number().default(1))
     .prop('name', S.string())
@@ -200,7 +198,7 @@ export const getAccessible = {
   },
 };
 
-export const getMany = {
+export const getMany: FastifySchema = {
   querystring: S.object()
     .prop('id', S.array().minItems(1).maxItems(MAX_TARGETS_FOR_READ_REQUEST))
     .extend(idsQuery),

--- a/src/services/item/plugins/html/h5p/validation/h5p-validator.ts
+++ b/src/services/item/plugins/html/h5p/validation/h5p-validator.ts
@@ -9,7 +9,7 @@ import { H5PInvalidManifestError } from '../errors';
 import { h5pManifestSchema } from '../schemas';
 import { H5P } from './h5p';
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allowUnionTypes: true });
 
 /**
  * Utility class containing the logic to validate a .h5p package

--- a/src/services/item/test/index.test.ts
+++ b/src/services/item/test/index.test.ts
@@ -182,7 +182,6 @@ describe('Item routes tests', () => {
         // a membership is created for this item
         const membership = await ItemMembershipRepository.findOneBy({ item: { id: newItem.id } });
         expect(membership?.permission).toEqual(PermissionLevel.Admin);
-
         // check some creator properties are not leaked
         expect(newItem.creator.id).toBeTruthy();
         expect(newItem.creator.createdAt).toBeFalsy();

--- a/src/services/member/controller.ts
+++ b/src/services/member/controller.ts
@@ -107,10 +107,7 @@ const controller: FastifyPluginAsync = async (fastify) => {
 
   // delete member
   /**
-   * @deprecated
-   * TODO: Fix this endpoint as it should not need the member ID.
-   * We only want to delete the currently authenticated member
-   * and this information is already provided by the session
+   * @deprecated use the delete member function without the id param
    */
   fastify.delete<{ Params: IdParam }>(
     '/:id',
@@ -139,7 +136,7 @@ const controller: FastifyPluginAsync = async (fastify) => {
       const { user } = request;
       const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        await memberService.deleteCurrent(member, buildRepositories(manager));
+        await memberService.deleteCurrent(member.id, buildRepositories(manager));
         // logout member
         request.logOut();
         // remove session from browser

--- a/src/services/member/plugins/profile/controller.ts
+++ b/src/services/member/plugins/profile/controller.ts
@@ -35,7 +35,6 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     { schema: getProfileForMember, preHandler: optionalIsAuthenticated },
     async ({ user, params: { memberId } }, reply) => {
       const profile = await memberProfileService.get(user?.member, buildRepositories(), memberId);
-      console.log(profile);
       if (!profile) {
         reply.status(StatusCodes.NO_CONTENT);
         return;

--- a/src/services/member/plugins/profile/controller.ts
+++ b/src/services/member/plugins/profile/controller.ts
@@ -33,8 +33,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: { memberId: string } }>(
     '/:memberId',
     { schema: getProfileForMember, preHandler: optionalIsAuthenticated },
-    async ({ user, params: { memberId } }, reply) => {
-      const profile = await memberProfileService.get(user?.member, buildRepositories(), memberId);
+    async ({ params: { memberId } }, reply) => {
+      const profile = await memberProfileService.get(buildRepositories(), memberId);
       if (!profile) {
         reply.status(StatusCodes.NO_CONTENT);
         return;

--- a/src/services/member/plugins/profile/controller.ts
+++ b/src/services/member/plugins/profile/controller.ts
@@ -12,9 +12,9 @@ import { MemberProfileService } from './service';
 import { IMemberProfile } from './types';
 
 const plugin: FastifyPluginAsync = async (fastify) => {
-  const { db, log } = fastify;
+  const { db } = fastify;
 
-  const memberProfileService = new MemberProfileService(log);
+  const memberProfileService = new MemberProfileService();
 
   fastify.get<{ Params: { memberId: string } }>(
     '/own',

--- a/src/services/member/plugins/profile/errors.ts
+++ b/src/services/member/plugins/profile/errors.ts
@@ -1,6 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 
 import { ErrorFactory } from '@graasp/sdk';
+import { FAILURE_MESSAGES } from '@graasp/translations';
 
 export const GraaspMemberProfileError = ErrorFactory('graasp-member-profile');
 
@@ -10,7 +11,7 @@ export class MemberProfileNotFound extends GraaspMemberProfileError {
       {
         code: 'GMPERR001',
         statusCode: StatusCodes.NOT_FOUND,
-        message: 'Member Profile not found',
+        message: FAILURE_MESSAGES.MEMBER_PROFILE_NOT_FOUND,
       },
       data,
     );

--- a/src/services/member/plugins/profile/errors.ts
+++ b/src/services/member/plugins/profile/errors.ts
@@ -1,0 +1,18 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { ErrorFactory } from '@graasp/sdk';
+
+export const GraaspMemberProfileError = ErrorFactory('graasp-member-profile');
+
+export class MemberProfileNotFound extends GraaspMemberProfileError {
+  constructor(data?: unknown) {
+    super(
+      {
+        code: 'GMPERR001',
+        statusCode: StatusCodes.NOT_FOUND,
+        message: 'Member Profile not found',
+      },
+      data,
+    );
+  }
+}

--- a/src/services/member/plugins/profile/repository.ts
+++ b/src/services/member/plugins/profile/repository.ts
@@ -1,3 +1,4 @@
+import { EntityManager, Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
 import { Member } from '@graasp/sdk';
@@ -7,7 +8,17 @@ import { MemberNotFound } from '../../../../utils/errors';
 import { MemberProfile } from './entities/profile';
 import { IMemberProfile } from './types';
 
-const MemberProfileRepository = AppDataSource.getRepository(MemberProfile).extend({
+class MemberProfileRepository {
+  private repository: Repository<MemberProfile>;
+
+  constructor(manager?: EntityManager) {
+    if (manager) {
+      this.repository = manager.getRepository(MemberProfile);
+    } else {
+      this.repository = AppDataSource.getRepository(MemberProfile);
+    }
+  }
+
   async createOne(
     args: IMemberProfile & {
       member: Member;
@@ -17,7 +28,7 @@ const MemberProfileRepository = AppDataSource.getRepository(MemberProfile).exten
 
     const id = v4();
 
-    const memberProfile = await this.create({
+    const memberProfile = await this.repository.create({
       id,
       bio,
       visibility,
@@ -26,9 +37,9 @@ const MemberProfileRepository = AppDataSource.getRepository(MemberProfile).exten
       twitterID,
       member,
     });
-    await this.insert(memberProfile);
+    await this.repository.insert(memberProfile);
     return memberProfile;
-  },
+  }
 
   async getByMemberId(
     memberId: string,
@@ -39,17 +50,32 @@ const MemberProfileRepository = AppDataSource.getRepository(MemberProfile).exten
     if (!memberId) {
       throw new MemberNotFound();
     }
-    const memberProfile = await this.findOne({
+    const memberProfile = await this.repository.findOne({
       where: { member: { id: memberId }, visibility: filter?.visibility },
       relations: ['member'],
     });
 
     return memberProfile;
-  },
+  }
 
-  async patch(memberId: string, data: Partial<IMemberProfile>): Promise<void> {
-    await this.update({ member: { id: memberId } }, data);
-  },
-});
+  async patch(memberId: string, data: Partial<IMemberProfile>): Promise<MemberProfile | null> {
+    const {
+      raw: [profile],
+    } = await this.repository
+      .createQueryBuilder()
+      .update(MemberProfile)
+      .set(data)
+      .where('member.id = :memberId', { memberId })
+      .returning('*')
+      .execute();
+
+    console.log(profile);
+    return profile;
+    // await this.repository.update({ member: { id: memberId } }, data);
+    // const profile = await this.repository.findOneBy({ member: { id: memberId } });
+    // return profile;
+    // return null;
+  }
+}
 
 export default MemberProfileRepository;

--- a/src/services/member/plugins/profile/repository.ts
+++ b/src/services/member/plugins/profile/repository.ts
@@ -59,6 +59,14 @@ class MemberProfileRepository {
   }
 
   async patch(memberId: string, data: Partial<IMemberProfile>): Promise<MemberProfile | null> {
+    /**
+     * this function is a test to try to make the queries more efficient while still
+     * getting the return values in one go.
+     * but this is really type unsafe, sinc ewe have to use the raw sql output provided by typeorm
+     * the normal `update` method from typeorm results in 3 Sql queries (because it needs to fetch the relation beforehand) and does not even allow us to get the resulting data.
+     *
+     * Not using the ORM means that the datetime columns are not updated from snake_case to camelCase, so they are not present at validation
+     */
     const {
       raw: [profile],
     } = await this.repository
@@ -70,10 +78,6 @@ class MemberProfileRepository {
       .execute();
 
     return profile;
-    // await this.repository.update({ member: { id: memberId } }, data);
-    // const profile = await this.repository.findOneBy({ member: { id: memberId } });
-    // return profile;
-    // return null;
   }
 }
 

--- a/src/services/member/plugins/profile/repository.ts
+++ b/src/services/member/plugins/profile/repository.ts
@@ -62,7 +62,7 @@ class MemberProfileRepository {
     /**
      * this function is a test to try to make the queries more efficient while still
      * getting the return values in one go.
-     * but this is really type unsafe, sinc ewe have to use the raw sql output provided by typeorm
+     * but this is really type unsafe, since we have to use the raw sql output provided by typeorm
      * the normal `update` method from typeorm results in 3 Sql queries (because it needs to fetch the relation beforehand) and does not even allow us to get the resulting data.
      *
      * Not using the ORM means that the datetime columns are not updated from snake_case to camelCase, so they are not present at validation

--- a/src/services/member/plugins/profile/repository.ts
+++ b/src/services/member/plugins/profile/repository.ts
@@ -1,34 +1,24 @@
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
 
 import { Member } from '@graasp/sdk';
 
-import { AppDataSource } from '../../../../plugins/datasource';
+import { AbstractRepository } from '../../../../repository';
 import { MemberNotFound } from '../../../../utils/errors';
 import { MemberProfile } from './entities/profile';
 import { IMemberProfile } from './types';
 
-class MemberProfileRepository {
-  private repository: Repository<MemberProfile>;
-
+class MemberProfileRepository extends AbstractRepository<MemberProfile> {
   constructor(manager?: EntityManager) {
-    if (manager) {
-      this.repository = manager.getRepository(MemberProfile);
-    } else {
-      this.repository = AppDataSource.getRepository(MemberProfile);
-    }
+    super(MemberProfile, manager);
   }
 
-  async createOne(
-    args: IMemberProfile & {
-      member: Member;
-    },
-  ): Promise<MemberProfile> {
-    const { bio, visibility = false, facebookID, linkedinID, twitterID, member } = args;
+  async createOne(member: Member, payload: IMemberProfile): Promise<MemberProfile> {
+    const { bio, visibility = false, facebookID, linkedinID, twitterID } = payload;
 
     const id = v4();
 
-    const memberProfile = await this.repository.create({
+    const memberProfile = this.repository.create({
       id,
       bio,
       visibility,
@@ -59,23 +49,8 @@ class MemberProfileRepository {
   }
 
   async patch(memberId: string, data: Partial<IMemberProfile>): Promise<MemberProfile | null> {
-    /**
-     * this function is a test to try to make the queries more efficient while still
-     * getting the return values in one go.
-     * but this is really type unsafe, since we have to use the raw sql output provided by typeorm
-     * the normal `update` method from typeorm results in 3 Sql queries (because it needs to fetch the relation beforehand) and does not even allow us to get the resulting data.
-     *
-     * Not using the ORM means that the datetime columns are not updated from snake_case to camelCase, so they are not present at validation
-     */
-    const {
-      raw: [profile],
-    } = await this.repository
-      .createQueryBuilder()
-      .update(MemberProfile)
-      .set(data)
-      .where('member.id = :memberId', { memberId })
-      .returning('*')
-      .execute();
+    await this.repository.update({ member: { id: memberId } }, data);
+    const profile = await this.repository.findOneByOrFail({ member: { id: memberId } });
 
     return profile;
   }

--- a/src/services/member/plugins/profile/repository.ts
+++ b/src/services/member/plugins/profile/repository.ts
@@ -69,7 +69,6 @@ class MemberProfileRepository {
       .returning('*')
       .execute();
 
-    console.log(profile);
     return profile;
     // await this.repository.update({ member: { id: memberId } }, data);
     // const profile = await this.repository.findOneBy({ member: { id: memberId } });

--- a/src/services/member/plugins/profile/schemas.ts
+++ b/src/services/member/plugins/profile/schemas.ts
@@ -1,15 +1,13 @@
 import { S } from 'fluent-json-schema';
+import { StatusCodes } from 'http-status-codes';
+
+import { FastifySchema } from 'fastify';
 
 import { error, uuid } from '../../../../schemas/fluent-schema';
 import { partialMember } from '../../../item/fluent-schema';
 
-const sharedProporities = {
-  bio: { type: 'string' },
-  facebookID: { type: 'string' },
-  linkedinID: { type: 'string' },
-  twitterID: { type: 'string' },
-};
 const memberSharedSchema = S.object()
+  .additionalProperties(false)
   .prop('bio', S.string())
   .prop('facebookID', S.anyOf([S.string(), S.null()]))
   .prop('linkedinID', S.anyOf([S.string(), S.null()]))
@@ -17,66 +15,52 @@ const memberSharedSchema = S.object()
 
 export const profileMember = S.object()
   .prop('id', uuid)
+  .prop('bio', S.string())
   .prop('visibility', S.boolean())
-  .prop('member', partialMember)
+  .prop('facebookID', S.string())
+  .prop('linkedinID', S.string())
+  .prop('twitterID', S.string())
   .prop('createdAt', S.string().format('date-time'))
   .prop('updatedAt', S.string().format('date-time'))
-  .extend(memberSharedSchema);
+  .prop('member', partialMember);
 
 export const createProfile = {
+  body: S.object()
+    .additionalProperties(false)
+    .prop('visibility', S.boolean())
+    // QUESTION: why is the always required ? Can't we only update a social link ?
+    .required(['bio'])
+    .extend(memberSharedSchema),
   response: {
-    201: profileMember,
-    '4xx': error,
-  },
-  body: S.object().prop('visibility', S.boolean()).required(['bio']).extend(memberSharedSchema),
-};
-
-export const getProfileForMember = {
-  params: {
-    type: 'object',
-    properties: {
-      memberId: { $ref: 'https://graasp.org/#/definitions/uuid' },
-    },
-    additionalProperties: false,
-  },
-  response: {
-    200: {
-      type: 'object',
-      nullable: true,
-      properties: {
-        id: { type: 'string' },
-        ...sharedProporities,
-        member: { $ref: 'https://graasp.org/members/#/definitions/member' },
-        createdAt: { type: 'string' },
-        updatedAt: { type: 'string' },
-      },
-    },
-    '4xx': error,
+    [StatusCodes.CREATED]: profileMember,
+    [StatusCodes.UNAUTHORIZED]: error,
   },
 };
 
-export const getOwnProfile = {
+export const getProfileForMember: FastifySchema = {
+  params: S.object().additionalProperties(false).prop('memberId', uuid),
   response: {
-    200: {
-      type: 'object',
-      nullable: true,
-      properties: {
-        id: { type: 'string' },
-        ...sharedProporities,
-        member: { $ref: 'https://graasp.org/members/#/definitions/member' },
-        createdAt: { type: 'string' },
-        updatedAt: { type: 'string' },
-        visibility: { type: 'boolean' },
-      },
-    },
-    '4xx': error,
+    [StatusCodes.OK]: profileMember,
+    [StatusCodes.NO_CONTENT]: S.null(),
+    [StatusCodes.UNAUTHORIZED]: error,
+  },
+};
+
+export const getOwnProfile: FastifySchema = {
+  response: {
+    [StatusCodes.OK]: profileMember,
+    [StatusCodes.NO_CONTENT]: S.null(),
+    [StatusCodes.UNAUTHORIZED]: error,
   },
 };
 
 export const updateMemberProfile = {
+  body: S.object()
+    .additionalProperties(false)
+    .prop('visibility', S.boolean())
+    .extend(memberSharedSchema),
   response: {
-    200: profileMember,
-    '4xx': error,
+    [StatusCodes.OK]: profileMember,
+    [StatusCodes.UNAUTHORIZED]: error,
   },
-  body: S.object().prop('visibility', S.boolean()).extend(memberSharedSchema),
 };

--- a/src/services/member/plugins/profile/schemas.ts
+++ b/src/services/member/plugins/profile/schemas.ts
@@ -16,12 +16,11 @@ const memberSharedSchema = S.object()
   .prop('twitterID', S.anyOf([S.string(), S.null()]));
 
 export const profileMember = S.object()
-  .additionalProperties(false)
   .prop('id', uuid)
   .prop('visibility', S.boolean())
   .prop('member', partialMember)
-  .prop('createdAt', S.raw({}))
-  .prop('updatedAt', S.raw({}))
+  .prop('createdAt', S.string().format('date-time'))
+  .prop('updatedAt', S.string().format('date-time'))
   .extend(memberSharedSchema);
 
 export const createProfile = {
@@ -29,11 +28,7 @@ export const createProfile = {
     201: profileMember,
     '4xx': error,
   },
-  body: S.object()
-    .prop('visibility', S.boolean())
-    .additionalProperties(false)
-    .required(['bio'])
-    .extend(memberSharedSchema),
+  body: S.object().prop('visibility', S.boolean()).required(['bio']).extend(memberSharedSchema),
 };
 
 export const getProfileForMember = {
@@ -83,8 +78,5 @@ export const updateMemberProfile = {
     200: profileMember,
     '4xx': error,
   },
-  body: S.object()
-    .additionalProperties(false)
-    .prop('visibility', S.boolean())
-    .extend(memberSharedSchema),
+  body: S.object().prop('visibility', S.boolean()).extend(memberSharedSchema),
 };

--- a/src/services/member/plugins/profile/schemas.ts
+++ b/src/services/member/plugins/profile/schemas.ts
@@ -28,7 +28,7 @@ export const createProfile = {
   body: S.object()
     .additionalProperties(false)
     .prop('visibility', S.boolean())
-    // QUESTION: why is the always required ? Can't we only update a social link ?
+    // QUESTION: why is the bio always required ? Can't we only update a social link ?
     .required(['bio'])
     .extend(memberSharedSchema),
   response: {

--- a/src/services/member/plugins/profile/service.ts
+++ b/src/services/member/plugins/profile/service.ts
@@ -1,28 +1,24 @@
 import { FastifyBaseLogger } from 'fastify';
 
-import { UnauthorizedMember } from '../../../../utils/errors';
+import { UUID } from '@graasp/sdk';
+
 import { Repositories } from '../../../../utils/repositories';
-import { Actor } from '../../../member/entities/member';
+import { Actor, Member } from '../../../member/entities/member';
 import { IMemberProfile } from './types';
 
 export class MemberProfileService {
-  log: FastifyBaseLogger;
+  private log: FastifyBaseLogger;
 
   constructor(log: FastifyBaseLogger) {
     this.log = log;
   }
 
-  async post(member: Actor, repositories: Repositories, data: IMemberProfile) {
-    const { memberProfileRepository } = repositories;
-    if (!member?.id) {
-      throw new UnauthorizedMember();
-    }
+  async post(member: Member, { memberProfileRepository }: Repositories, data: IMemberProfile) {
     const profile = await memberProfileRepository.createOne({ ...data, member });
     return profile;
   }
 
-  async get(memberId: string, repositories: Repositories) {
-    const { memberProfileRepository } = repositories;
+  async get(_actor: Actor, { memberProfileRepository }: Repositories, memberId: UUID) {
     const memberProfile = await memberProfileRepository.getByMemberId(memberId, {
       visibility: true,
     });
@@ -33,22 +29,16 @@ export class MemberProfileService {
     return memberProfile;
   }
 
-  async getOwn(member: Actor, repositories: Repositories) {
-    const { memberProfileRepository } = repositories;
-    if (!member?.id) {
-      throw new UnauthorizedMember();
-    }
+  async getOwn(member: Member, { memberProfileRepository }: Repositories) {
     const memberProfile = await memberProfileRepository.getByMemberId(member.id);
     return memberProfile;
   }
 
-  async patch(member: Actor, repositories: Repositories, data: Partial<IMemberProfile>) {
-    const { memberProfileRepository } = repositories;
-
-    if (!member?.id) {
-      throw new UnauthorizedMember();
-    }
-
+  async patch(
+    member: Member,
+    { memberProfileRepository }: Repositories,
+    data: Partial<IMemberProfile>,
+  ) {
     return memberProfileRepository.patch(member.id, data);
   }
 }

--- a/src/services/member/plugins/profile/service.ts
+++ b/src/services/member/plugins/profile/service.ts
@@ -3,7 +3,7 @@ import { FastifyBaseLogger } from 'fastify';
 import { UUID } from '@graasp/sdk';
 
 import { Repositories } from '../../../../utils/repositories';
-import { Actor, Member } from '../../../member/entities/member';
+import { Member } from '../../../member/entities/member';
 import { IMemberProfile } from './types';
 
 export class MemberProfileService {
@@ -18,7 +18,7 @@ export class MemberProfileService {
     return profile;
   }
 
-  async get(_actor: Actor, { memberProfileRepository }: Repositories, memberId: UUID) {
+  async get({ memberProfileRepository }: Repositories, memberId: UUID) {
     const memberProfile = await memberProfileRepository.getByMemberId(memberId, {
       visibility: true,
     });

--- a/src/services/member/plugins/profile/service.ts
+++ b/src/services/member/plugins/profile/service.ts
@@ -1,5 +1,3 @@
-import { FastifyBaseLogger } from 'fastify';
-
 import { UUID } from '@graasp/sdk';
 
 import { Repositories } from '../../../../utils/repositories';
@@ -7,14 +5,8 @@ import { Member } from '../../../member/entities/member';
 import { IMemberProfile } from './types';
 
 export class MemberProfileService {
-  private log: FastifyBaseLogger;
-
-  constructor(log: FastifyBaseLogger) {
-    this.log = log;
-  }
-
   async post(member: Member, { memberProfileRepository }: Repositories, data: IMemberProfile) {
-    const profile = await memberProfileRepository.createOne({ ...data, member });
+    const profile = await memberProfileRepository.createOne(member, data);
     return profile;
   }
 

--- a/src/services/member/plugins/profile/test/fixtures/profile.ts
+++ b/src/services/member/plugins/profile/test/fixtures/profile.ts
@@ -45,14 +45,15 @@ export const getMemberProfile = async (id: string) => {
   return profile;
 };
 
-export const ANNA_PROFILE = {
+export const ANNA_PROFILE: IMemberProfile = {
   bio: "Hi, I'm Anna, an english teacher",
   facebookID: 'anna',
   twitterID: '',
   linkedinID: 'anna',
+  visibility: false,
 };
 
-export const BOB_PROFILE = {
+export const BOB_PROFILE: IMemberProfile = {
   bio: "Hi, I'm Bob, a science teacher",
   facebookID: 'bob',
   twitterID: '',

--- a/src/services/member/plugins/profile/test/fixtures/profile.ts
+++ b/src/services/member/plugins/profile/test/fixtures/profile.ts
@@ -32,13 +32,17 @@ export const getDummyProfile = (options: Partial<MemberProfile>): Partial<Member
 export const saveMemberProfile = async (m: CompleteMember, profile: IMemberProfile) => {
   const member = await saveMember(m);
   const memberProfile = MemberProfile.create({ ...profile, member });
-  const savedMember = await MemberProfile.save(memberProfile);
+  const savedMemberProfile = await MemberProfile.save(memberProfile);
 
-  return savedMember;
+  return savedMemberProfile;
 };
 
 export const getMemberProfile = async (id: string) => {
-  return MemberProfile.findOneBy({ id });
+  const profile = await MemberProfile.findOneBy({ id });
+  if (!profile) {
+    throw new Error('Unable to find profile, but it should exist');
+  }
+  return profile;
 };
 
 export const ANNA_PROFILE = {

--- a/src/services/member/plugins/profile/types.ts
+++ b/src/services/member/plugins/profile/types.ts
@@ -1,7 +1,7 @@
-export interface IMemberProfile {
+export type IMemberProfile = {
   bio: string;
-  visibility?: boolean;
-  facebookID?: string;
-  linkedinID?: string;
-  twitterID?: string;
-}
+  visibility: boolean;
+  facebookID: string;
+  linkedinID: string;
+  twitterID: string;
+};

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -93,14 +93,14 @@ export default {
 };
 
 // schema for getting current member
-export const getCurrent = {
+export const getCurrent: FastifySchema = {
   response: {
     200: { $ref: 'https://graasp.org/members/#/definitions/currentMember' },
   },
 };
 
 // schema for getting current member's storage limits
-export const getStorage = {
+export const getStorage: FastifySchema = {
   response: {
     200: {
       type: 'object',
@@ -119,7 +119,7 @@ export const getStorage = {
 };
 
 // schema for getting a member
-export const getOne = {
+export const getOne: FastifySchema = {
   params: { $ref: 'https://graasp.org/#/definitions/idParam' },
   response: {
     200: { $ref: 'https://graasp.org/members/#/definitions/member' },
@@ -127,7 +127,7 @@ export const getOne = {
 };
 
 // schema for getting >1 members
-export const getMany = {
+export const getMany: FastifySchema = {
   querystring: {
     allOf: [
       { $ref: 'https://graasp.org/#/definitions/idsQuery' },
@@ -166,7 +166,7 @@ export const getMany = {
 };
 
 // schema for getting members by
-export const getManyBy = {
+export const getManyBy: FastifySchema = {
   querystring: {
     type: 'object',
     properties: {
@@ -207,19 +207,27 @@ export const getManyBy = {
 };
 
 // schema for updating own member
-export const updateOne = {
+export const updateOne: FastifySchema = {
   params: { $ref: 'https://graasp.org/#/definitions/idParam' },
   body: { $ref: 'https://graasp.org/members/#/definitions/partialMemberRequireOne' },
   response: {
-    200: { $ref: 'https://graasp.org/members/#/definitions/currentMember' },
+    [StatusCodes.OK]: { $ref: 'https://graasp.org/members/#/definitions/currentMember' },
+    [StatusCodes.FORBIDDEN]: {},
   },
 };
 
-// schema for getting a member
-export const deleteOne = {
+// schema for deleting a member
+export const deleteOne: FastifySchema = {
   params: { $ref: 'https://graasp.org/#/definitions/idParam' },
   response: {
-    200: { $ref: 'https://graasp.org/members/#/definitions/member' },
+    [StatusCodes.NO_CONTENT]: {},
+  },
+};
+
+// schema for deleting the current member
+export const deleteCurrent: FastifySchema = {
+  response: {
+    [StatusCodes.NO_CONTENT]: {},
   },
 };
 

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -8,6 +8,7 @@ import {
   MIN_USERNAME_LENGTH,
 } from '@graasp/sdk';
 
+import { error } from '../../schemas/fluent-schema';
 import { NAME_REGEX, UUID_REGEX } from '../../schemas/global';
 
 /**
@@ -212,7 +213,7 @@ export const updateOne: FastifySchema = {
   body: { $ref: 'https://graasp.org/members/#/definitions/partialMemberRequireOne' },
   response: {
     [StatusCodes.OK]: { $ref: 'https://graasp.org/members/#/definitions/currentMember' },
-    [StatusCodes.FORBIDDEN]: {},
+    [StatusCodes.FORBIDDEN]: error,
   },
 };
 

--- a/src/services/member/service.ts
+++ b/src/services/member/service.ts
@@ -95,6 +95,10 @@ export class MemberService {
     });
   }
 
+  async deleteCurrent(member: Member, { memberRepository }: Repositories) {
+    return memberRepository.deleteOne(member.id);
+  }
+
   async deleteOne(actor: Actor, { memberRepository }: Repositories, id: UUID) {
     if (!actor || actor.id !== id) {
       throw new CannotModifyOtherMembers(id);

--- a/src/services/member/service.ts
+++ b/src/services/member/service.ts
@@ -95,8 +95,8 @@ export class MemberService {
     });
   }
 
-  async deleteCurrent(member: Member, { memberRepository }: Repositories) {
-    return memberRepository.deleteOne(member.id);
+  async deleteCurrent(memberId: string, { memberRepository }: Repositories) {
+    return memberRepository.deleteOne(memberId);
   }
 
   async deleteOne(actor: Actor, { memberRepository }: Repositories, id: UUID) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -149,14 +149,25 @@ export class TooManyDescendants extends CoreError {
 export class InvalidMoveTarget extends CoreError {
   constructor(data?: unknown) {
     super(
-      { code: 'GERR012', statusCode: 400, message: FAILURE_MESSAGES.INVALID_MOVE_TARGET },
+      {
+        code: 'GERR012',
+        statusCode: StatusCodes.BAD_REQUEST,
+        message: FAILURE_MESSAGES.INVALID_MOVE_TARGET,
+      },
       data,
     );
   }
 }
 export class MemberNotFound extends CoreError {
   constructor(data?: unknown) {
-    super({ code: 'GERR013', statusCode: 404, message: FAILURE_MESSAGES.MEMBER_NOT_FOUND }, data);
+    super(
+      {
+        code: 'GERR013',
+        statusCode: StatusCodes.NOT_FOUND,
+        message: FAILURE_MESSAGES.MEMBER_NOT_FOUND,
+      },
+      data,
+    );
   }
 }
 export class CannotModifyOtherMembers extends CoreError {
@@ -349,7 +360,11 @@ export class UnauthorizedMember extends CoreError {
 export class EmailNotAllowed extends CoreError {
   constructor(data?: unknown) {
     super(
-      { code: 'GERR027', statusCode: 403, message: 'Your email is not allowed to sign up' },
+      {
+        code: 'GERR027',
+        statusCode: StatusCodes.FORBIDDEN,
+        message: 'Your email is not allowed to sign up',
+      },
       data,
     );
   }
@@ -435,13 +450,27 @@ export class NoFileProvided extends CoreError {
 
 export class DatabaseError extends CoreError {
   constructor(data?: unknown) {
-    super({ code: 'GERR998', statusCode: 500, message: FAILURE_MESSAGES.DATABASE_ERROR }, data);
+    super(
+      {
+        code: 'GERR998',
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: FAILURE_MESSAGES.DATABASE_ERROR,
+      },
+      data,
+    );
   }
 }
 
 export class UnexpectedError extends CoreError {
   constructor(data?: unknown) {
-    super({ code: 'GERR999', statusCode: 500, message: FAILURE_MESSAGES.UNEXPECTED_ERROR }, data);
+    super(
+      {
+        code: 'GERR999',
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: FAILURE_MESSAGES.UNEXPECTED_ERROR,
+      },
+      data,
+    );
     this.origin = 'unknown';
   }
 }
@@ -456,7 +485,7 @@ export class OpenAIBaseError extends CoreError {
   constructor({
     message = 'An unknown error occured',
     code = 'GERR1000',
-    statusCode = 500,
+    statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
   }: OpenAIParamsError = {}) {
     super({ code: code, statusCode: statusCode, message: message });
     this.origin = 'OpenAI';
@@ -487,14 +516,14 @@ export class OpenAITimeOutError extends OpenAIBaseError {
 export class OpenAIQuotaError extends OpenAIBaseError {
   constructor() {
     const message = 'This token exceeded current quota, please check plan and billing details.';
-    super({ code: 'GERR1004', message: message, statusCode: 429 });
+    super({ code: 'GERR1004', message: message, statusCode: StatusCodes.TOO_MANY_REQUESTS });
   }
 }
 
 export class OpenAIBadVersion extends OpenAIBaseError {
   constructor(gptVersion: string, validVersions: string) {
     const message = `The gpt-version '${gptVersion}' is not a valid version. Try one of these instead: "${validVersions}".`;
-    super({ code: 'GERR1005', message: message, statusCode: 400 });
+    super({ code: 'GERR1005', message: message, statusCode: StatusCodes.BAD_REQUEST });
   }
 }
 

--- a/src/utils/repositories.ts
+++ b/src/utils/repositories.ts
@@ -59,7 +59,7 @@ export type Repositories = {
   mentionRepository: ChatMentionRepository;
   publisherRepository: typeof PublisherRepository;
   recycledItemRepository: typeof RecycledItemDataRepository;
-  memberProfileRepository: typeof MemberProfileRepository;
+  memberProfileRepository: MemberProfileRepository;
   shortLinkRepository: typeof ShortLinkRepository;
   itemGeolocationRepository: ItemGeolocationRepository;
 };
@@ -119,9 +119,7 @@ export const buildRepositories = (manager?: EntityManager): Repositories => ({
   actionRequestExportRepository: manager
     ? manager.withRepository(ActionRequestExportRepository)
     : ActionRequestExportRepository,
-  memberProfileRepository: manager
-    ? manager.withRepository(MemberProfileRepository)
-    : MemberProfileRepository,
+  memberProfileRepository: new MemberProfileRepository(manager),
   shortLinkRepository: manager ? manager.withRepository(ShortLinkRepository) : ShortLinkRepository,
   itemGeolocationRepository: new ItemGeolocationRepository(manager),
 });

--- a/test/app.ts
+++ b/test/app.ts
@@ -57,6 +57,7 @@ const build = async ({ member }: { member?: CompleteMember | null } = {}) => {
     ajv: {
       customOptions: {
         coerceTypes: 'array',
+        allowUnionTypes: true,
       },
       plugins: [ajvFormats],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,12 +2067,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/translations@npm:1.30.3":
-  version: 1.30.3
-  resolution: "@graasp/translations@npm:1.30.3"
+"@graasp/translations@npm:1.31.2":
+  version: 1.31.2
+  resolution: "@graasp/translations@npm:1.31.2"
   peerDependencies:
     i18next: ^23.8.1
-  checksum: 10/4b1dce4a5dba01994607337698c9dd57d1c1d2bb82a8bb14b5bc8dc184376255e764891457310d3f030b8ac15fec1cda48cbbb427ba247f8c3fc1f30a96436da
+  checksum: 10/8f7d8065ffdb017a374d00e86156f06213cc720a8d85c4ac362cc08a1419bf185b1e23d0d916f02f3f37763e7d78313dae44658d5871a65ea5492ea3dfa8ee5c
   languageName: node
   linkType: hard
 
@@ -7509,7 +7509,7 @@ __metadata:
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
     "@graasp/sdk": "npm:4.16.0"
-    "@graasp/translations": "npm:1.30.3"
+    "@graasp/translations": "npm:1.31.2"
     "@jest/globals": "npm:29.7.0"
     "@rapideditor/country-coder": "npm:5.2.2"
     "@sentry/node": "npm:7.118.0"


### PR DESCRIPTION
fix #1157 

In this PR:
- add `request.session.delete()` on /logout to ensure cookie is removed from the browser
- add types on schemas
- fix an AJV warning in the h5p schema by adding `allowUnionTypes: true` to the options
- deprecate `DELETE /members/:id` and add a new `DELETE `/members/current` instead 
- add the logout directly on these delete routes
- refactor the members profile plugin and routes to make the responses more consistent
  - NO_CONTENT when there is nothing
  - OK when there is data
  - UNAUTHORIZED when not logged in
- move the memberProfile repository to a custom repository class
- experiment with the querybuilder for efficient queries, but these are not type-safe and lack transformations ... sad
