### PR TITLE
fix: remove leaked information and remove unused errors

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -152,7 +152,7 @@ services:
     container_name: graasp-localstack
     image: localstack/localstack
     volumes:
-      - ${TMPDIR}/localstack:/tmp/graasp-localstack
+      - ../tmp:/tmp/graasp-localstack
       - './localstack/init.sh:/etc/localstack/init/ready.d/init-aws.sh'
       - /var/run/docker.sock:/var/run/docker.sock
     environment:

--- a/src/services/auth/plugins/mobile/mobile.test.ts
+++ b/src/services/auth/plugins/mobile/mobile.test.ts
@@ -548,7 +548,7 @@ describe('Mobile Endpoints', () => {
         query: { token },
       });
       expect(response.headers).not.toHaveProperty('set-cookie');
-      expect(response.json()).toMatchObject(new MemberNotFound(memberId));
+      expect(response.json()).toMatchObject(new MemberNotFound({ id: memberId }));
     });
     it('Fail if token is invalid', async () => {
       const member = await saveMember();

--- a/src/services/auth/plugins/passport/strategies/emailChange.ts
+++ b/src/services/auth/plugins/passport/strategies/emailChange.ts
@@ -31,7 +31,7 @@ export default (
           } else {
             // Authentication refused
             return done(
-              options?.propagateError ? new MemberNotFound(uuid) : new UnauthorizedMember(),
+              options?.propagateError ? new MemberNotFound({ id: uuid }) : new UnauthorizedMember(),
               false,
             );
           }

--- a/src/services/auth/plugins/passport/strategies/jwt.ts
+++ b/src/services/auth/plugins/passport/strategies/jwt.ts
@@ -30,7 +30,7 @@ export default (
           } else {
             // Authentication refused
             return done(
-              options?.propagateError ? new MemberNotFound(sub) : new UnauthorizedMember(),
+              options?.propagateError ? new MemberNotFound({ id: sub }) : new UnauthorizedMember(),
               false,
             );
           }

--- a/src/services/auth/plugins/passport/strategies/jwtChallengeVerifier.ts
+++ b/src/services/auth/plugins/passport/strategies/jwtChallengeVerifier.ts
@@ -47,7 +47,7 @@ export default (
           } else {
             // Authentication refused
             return done(
-              spreadException ? new MemberNotFound(sub) : new UnauthorizedMember(),
+              spreadException ? new MemberNotFound({ id: sub }) : new UnauthorizedMember(),
               false,
             );
           }

--- a/src/services/auth/plugins/passport/strategies/magicLink.ts
+++ b/src/services/auth/plugins/passport/strategies/magicLink.ts
@@ -31,7 +31,7 @@ export default (
           } else {
             // Authentication refused
             return done(
-              options?.propagateError ? new MemberNotFound(sub) : new UnauthorizedMember(),
+              options?.propagateError ? new MemberNotFound({ id: sub }) : new UnauthorizedMember(),
               false,
             );
           }

--- a/src/services/auth/plugins/passport/strategies/passwordReset.ts
+++ b/src/services/auth/plugins/passport/strategies/passwordReset.ts
@@ -27,7 +27,7 @@ export default (
         } else {
           // Authentication refused
           return done(
-            options?.propagateError ? new MemberNotFound(uuid) : new UnauthorizedMember(),
+            options?.propagateError ? new MemberNotFound({ id: uuid }) : new UnauthorizedMember(),
             false,
           );
         }

--- a/src/services/auth/plugins/password/repository.ts
+++ b/src/services/auth/plugins/password/repository.ts
@@ -11,7 +11,7 @@ export const MemberPasswordRepository = AppDataSource.getRepository(MemberPasswo
     // additional check that id is not null
     // o/w empty parameter to findOneBy return the first entry
     if (!memberId) {
-      throw new MemberNotFound(memberId);
+      throw new MemberNotFound({ id: memberId });
     }
 
     const memberPassword = this.findOneBy({ member: { id: memberId } });

--- a/src/services/auth/plugins/password/service.ts
+++ b/src/services/auth/plugins/password/service.ts
@@ -193,7 +193,7 @@ export class MemberPasswordService {
     // Fetch the member's password
     const memberPassword = await memberPasswordRepository.getForMemberId(member.id);
     if (!memberPassword) {
-      throw new MemberWithoutPassword({ email });
+      throw new MemberWithoutPassword();
     }
     // Validate credentials to build token
     if (await comparePasswords(password, memberPassword.password)) {

--- a/src/services/chat/errors.ts
+++ b/src/services/chat/errors.ts
@@ -37,14 +37,14 @@ export class MemberCannotEditMessage extends GraaspChatboxError {
 }
 
 export class MemberCannotDeleteMessage extends GraaspChatboxError {
-  constructor(data?: unknown) {
+  constructor(data: { id: string }) {
     super(
       {
         code: 'GICERR005',
         statusCode: StatusCodes.UNAUTHORIZED,
         message: 'Member can only delete own messages',
       },
-      data,
+      data.id,
     );
   }
 }

--- a/src/services/chat/errors.ts
+++ b/src/services/chat/errors.ts
@@ -50,14 +50,14 @@ export class MemberCannotDeleteMessage extends GraaspChatboxError {
 }
 
 export class MemberCannotAccessMention extends GraaspChatboxError {
-  constructor(data?: unknown) {
+  constructor(data: { id: string }) {
     super(
       {
         code: 'GICERR004',
         statusCode: StatusCodes.UNAUTHORIZED,
         message: 'Member can only view own mentions',
       },
-      data,
+      data.id,
     );
   }
 }

--- a/src/services/chat/plugins/mentions/service.ts
+++ b/src/services/chat/plugins/mentions/service.ts
@@ -91,7 +91,7 @@ export class MentionService {
     const mentionContent = await mentionRepository.get(mentionId);
 
     if (mentionContent.member.id !== actor.id) {
-      throw new MemberCannotAccessMention(mentionId);
+      throw new MemberCannotAccessMention({ id: mentionId });
     }
 
     return mentionContent;

--- a/src/services/chat/service.ts
+++ b/src/services/chat/service.ts
@@ -96,7 +96,7 @@ export class ChatMessageService {
 
     const messageContent = await chatMessageRepository.get(messageId, { shouldExist: true });
     if (messageContent.creator?.id !== actor.id) {
-      throw new MemberCannotDeleteMessage(messageId);
+      throw new MemberCannotDeleteMessage({ id: messageId });
     }
 
     // TODO: get associated mentions to push the update in the websockets

--- a/src/services/chat/test/chatMention.test.ts
+++ b/src/services/chat/test/chatMention.test.ts
@@ -187,7 +187,7 @@ describe('Chat Mention tests', () => {
           payload,
         });
 
-        expect(response.json()).toMatchObject(new MemberCannotAccessMention(mention.id));
+        expect(response.json()).toMatchObject(new MemberCannotAccessMention(mention));
       });
     });
   });
@@ -255,7 +255,9 @@ describe('Chat Mention tests', () => {
           url: `${ITEMS_ROUTE_PREFIX}/mentions/${mention.id}`,
         });
 
-        expect(response.json()).toMatchObject(new MemberCannotAccessMention(expect.anything()));
+        expect(response.json()).toMatchObject(
+          new MemberCannotAccessMention({ id: expect.anything() }),
+        );
       });
     });
   });

--- a/src/services/chat/test/chatMessage.test.ts
+++ b/src/services/chat/test/chatMessage.test.ts
@@ -387,8 +387,8 @@ describe('Chat Message tests', () => {
           url: `${ITEMS_ROUTE_PREFIX}/${item.id}/chat/${chatMessage.id}`,
           payload,
         });
-
-        expect(response.json()).toMatchObject(new MemberCannotEditMessage(expect.anything()));
+        const res = await response.json();
+        expect(res).toMatchObject(new MemberCannotEditMessage(expect.anything()));
       });
     });
   });
@@ -492,8 +492,8 @@ describe('Chat Message tests', () => {
           method: HttpMethod.Delete,
           url: `${ITEMS_ROUTE_PREFIX}/${item.id}/chat/${chatMessage.id}`,
         });
-
-        expect(response.json()).toMatchObject(new MemberCannotDeleteMessage(expect.anything()));
+        const res = await response.json();
+        expect(res).toMatchObject(new MemberCannotDeleteMessage({ id: expect.anything() }));
       });
     });
   });

--- a/src/services/file/service.ts
+++ b/src/services/file/service.ts
@@ -7,7 +7,6 @@ import { FastifyReply } from 'fastify';
 
 import { FILE_REPOSITORY_DI_KEY } from '../../di/constants';
 import { BaseLogger } from '../../logger';
-import { UnauthorizedMember } from '../../utils/errors';
 import { Actor, Member } from '../member/entities/member';
 import { LocalFileConfiguration, S3FileConfiguration } from './interfaces/configuration';
 import { FileRepository } from './interfaces/fileRepository';
@@ -42,10 +41,6 @@ class FileService {
   }
 
   async upload(member: Member, data: { file: Readable; filepath: string; mimetype?: string }) {
-    if (!member) {
-      throw new UnauthorizedMember(member);
-    }
-
     const { file, filepath, mimetype } = data;
 
     if (!file || !filepath) {

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -113,6 +113,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
           user,
           query: { parentId },
         } = request;
+        const member = notUndefined(user?.member);
 
         // get the formData from the request
         const formData = await request.file();
@@ -124,7 +125,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
         return await db.transaction(async (manager) => {
           const repositories = buildRepositories(manager);
-          const item = await itemService.post(user?.member, repositories, {
+          const item = await itemService.post(member, repositories, {
             item: itemPayload,
             parentId,
             geolocation,
@@ -178,7 +179,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
   // get own
   fastify.get('/own', { schema: getOwn, preHandler: isAuthenticated }, async ({ user }) => {
-    return itemService.getOwn(user?.member, buildRepositories());
+    const member = notUndefined(user?.member);
+    return itemService.getOwn(member, buildRepositories());
   });
 
   // get shared with
@@ -189,7 +191,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       preHandler: isAuthenticated,
     },
     async ({ user, query }) => {
-      return itemService.getShared(user?.member, buildRepositories(), query.permission);
+      const member = notUndefined(user?.member);
+      return itemService.getShared(member, buildRepositories(), query.permission);
     },
   );
 
@@ -242,9 +245,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         params: { id },
         body,
       } = request;
+      const member = notUndefined(user?.member);
       return await db.transaction(async (manager) => {
         const repositories = buildRepositories(manager);
-        const item = await itemService.patch(user?.member, repositories, id, body);
+        const item = await itemService.patch(member, repositories, id, body);
         await actionItemService.postPatchAction(request, repositories, item);
         return item;
       });

--- a/src/services/item/plugins/action/requestExport/service.ts
+++ b/src/services/item/plugins/action/requestExport/service.ts
@@ -11,7 +11,6 @@ import {
 
 import { MAIL } from '../../../../../plugins/mailer/langs/constants';
 import { MailerService } from '../../../../../plugins/mailer/service';
-import { UnauthorizedMember } from '../../../../../utils/errors';
 import { Repositories } from '../../../../../utils/repositories';
 import { EXPORT_FILE_EXPIRATION, ZIP_MIMETYPE } from '../../../../action/constants/constants';
 import {
@@ -21,7 +20,7 @@ import {
 } from '../../../../action/utils/export';
 import { validatePermission } from '../../../../authorization';
 import FileService from '../../../../file/service';
-import { Actor, Member } from '../../../../member/entities/member';
+import { Member } from '../../../../member/entities/member';
 import { Item } from '../../../entities/Item';
 import { ItemService } from '../../../service';
 import { ActionItemService } from '../service';
@@ -47,15 +46,11 @@ export class ActionRequestExportService {
   }
 
   async request(
-    member: Actor,
+    member: Member,
     repositories: Repositories,
     itemId: UUID,
     format: ExportActionsFormatting,
   ) {
-    if (!member) {
-      throw new UnauthorizedMember(member);
-    }
-
     // check member has admin access to the item
     const item = await this.itemService.get(member, repositories, itemId);
     await validatePermission(repositories, PermissionLevel.Admin, member, item);

--- a/src/services/item/plugins/app/appSetting/service.ts
+++ b/src/services/item/plugins/app/appSetting/service.ts
@@ -136,7 +136,7 @@ export class AppSettingService {
 
   async copyForItem(actor: Actor, repositories: Repositories, original: Item, copy: Item) {
     if (!actor) {
-      throw new UnauthorizedMember(actor);
+      throw new UnauthorizedMember();
     }
     try {
       const appSettings = await this.getForItem(actor, repositories, original.id);

--- a/src/services/item/plugins/html/service.ts
+++ b/src/services/item/plugins/html/service.ts
@@ -14,7 +14,6 @@ import { FileItemType } from '@graasp/sdk';
 
 import { BaseLogger } from '../../../../logger';
 import { TMP_FOLDER } from '../../../../utils/config';
-import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import FileService, { FileServiceConfig } from '../../../file/service';
 import { fileRepositoryFactory } from '../../../file/utils/factory';
@@ -112,15 +111,11 @@ export abstract class HtmlService {
    * await in parallel (note: await in a map fn does not block the map iteration).
    */
   async upload(
-    member: Actor,
+    member: Member,
     folder: string,
     uploadPath: string,
     log?: FastifyBaseLogger,
   ): Promise<Array<string>> {
-    if (!member) {
-      throw new UnauthorizedMember(member);
-    }
-
     const children = await readdir(folder);
 
     // we will flatMap with promises: first map

--- a/src/services/item/plugins/invitation/index.ts
+++ b/src/services/item/plugins/invitation/index.ts
@@ -57,9 +57,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       preHandler: isAuthenticated,
     },
     async ({ user, body, params }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
         const res = await invitationService.postManyForItem(
-          user?.member,
+          member,
           buildRepositories(manager),
           params.id,
           body.invitations,
@@ -122,9 +123,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: IdParam }>(
     '/:id/invitations',
     { schema: getForItem, preHandler: isAuthenticated },
-    async ({ user, params }) => {
-      const { id: itemId } = params;
-      return invitationService.getForItem(user?.member, buildRepositories(), itemId);
+    async ({ user, params: { id: itemId } }) => {
+      const member = notUndefined(user?.member);
+      return invitationService.getForItem(member, buildRepositories(), itemId);
     },
   );
 
@@ -132,16 +133,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.patch<{ Params: { id: string; invitationId: string }; Body: Partial<Invitation> }>(
     '/:id/invitations/:invitationId',
     { schema: updateOne, preHandler: isAuthenticated },
-    async ({ user, params, body }) => {
-      const { invitationId } = params;
-
+    async ({ user, params: { invitationId }, body }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return invitationService.patch(
-          user?.member,
-          buildRepositories(manager),
-          invitationId,
-          body,
-        );
+        return invitationService.patch(member, buildRepositories(manager), invitationId, body);
       });
     },
   );
@@ -150,11 +145,10 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.delete<{ Params: { id: string; invitationId: string } }>(
     '/:id/invitations/:invitationId',
     { schema: deleteOne, preHandler: isAuthenticated },
-    async ({ user, params }) => {
-      const { invitationId } = params;
-
+    async ({ user, params: { invitationId } }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return invitationService.delete(user?.member, buildRepositories(manager), invitationId);
+        return invitationService.delete(member, buildRepositories(manager), invitationId);
       });
     },
   );
@@ -163,10 +157,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   fastify.post<{ Params: { id: string; invitationId: string } }>(
     '/:id/invitations/:invitationId/send',
     { schema: sendOne, preHandler: isAuthenticated },
-    async ({ user, params }, reply) => {
-      const { invitationId } = params;
-
-      await invitationService.resend(user?.member, buildRepositories(), invitationId);
+    async ({ user, params: { invitationId } }, reply) => {
+      const member = notUndefined(user?.member);
+      await invitationService.resend(member, buildRepositories(), invitationId);
       reply.status(StatusCodes.NO_CONTENT);
     },
   );

--- a/src/services/item/plugins/invitation/service.ts
+++ b/src/services/item/plugins/invitation/service.ts
@@ -9,7 +9,6 @@ import { BaseLogger } from '../../../../logger';
 import { MAIL } from '../../../../plugins/mailer/langs/constants';
 import { MailerService } from '../../../../plugins/mailer/service';
 import { GRAASP_LANDING_PAGE_ORIGIN } from '../../../../utils/constants';
-import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import { validatePermission } from '../../../authorization';
 import { Item, isItemType } from '../../../item/entities/Item';
@@ -53,10 +52,7 @@ export class InvitationService {
     this.itemMembershipService = itemMembershipService;
   }
 
-  async sendInvitationEmail({ actor, invitation }: { actor: Actor; invitation: Invitation }) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async sendInvitationEmail({ actor, invitation }: { actor: Member; invitation: Invitation }) {
     const { item, email } = invitation;
 
     // factor out
@@ -96,24 +92,18 @@ export class InvitationService {
     return repositories.invitationRepository.get(invitationId, actor);
   }
 
-  async getForItem(actor: Actor, repositories: Repositories, itemId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async getForItem(actor: Member, repositories: Repositories, itemId: string) {
     const { invitationRepository } = repositories;
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Admin);
     return invitationRepository.getForItem(item.path);
   }
 
   async postManyForItem(
-    actor: Actor,
+    actor: Member,
     repositories: Repositories,
     itemId: string,
     invitations: Partial<Invitation>[],
   ): Promise<Invitation[]> {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
     const { invitationRepository } = repositories;
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Admin);
 
@@ -129,14 +119,11 @@ export class InvitationService {
   }
 
   async patch(
-    actor: Actor,
+    actor: Member,
     repositories: Repositories,
     invitationId: string,
     body: Partial<Invitation>,
   ) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
     const { invitationRepository } = repositories;
     const invitation = await invitationRepository.get(invitationId);
     await validatePermission(repositories, PermissionLevel.Admin, actor, invitation.item);
@@ -144,10 +131,7 @@ export class InvitationService {
     return invitationRepository.patch(invitationId, body);
   }
 
-  async delete(actor: Actor, repositories: Repositories, invitationId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async delete(actor: Member, repositories: Repositories, invitationId: string) {
     const { invitationRepository } = repositories;
     const invitation = await invitationRepository.get(invitationId);
     await validatePermission(repositories, PermissionLevel.Admin, actor, invitation.item);
@@ -155,10 +139,7 @@ export class InvitationService {
     return invitationRepository.deleteOne(invitationId);
   }
 
-  async resend(actor: Actor, repositories: Repositories, invitationId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async resend(actor: Member, repositories: Repositories, invitationId: string) {
     const { invitationRepository } = repositories;
     const invitation = await invitationRepository.get(invitationId);
     await validatePermission(repositories, PermissionLevel.Admin, actor, invitation.item);

--- a/src/services/item/plugins/itemCategory/repositories/itemCategory.ts
+++ b/src/services/item/plugins/itemCategory/repositories/itemCategory.ts
@@ -48,7 +48,7 @@ export const ItemCategoryRepository = AppDataSource.getRepository(ItemCategory).
    */
   async getForMemberExport(memberId: string): Promise<ItemCategory[]> {
     if (!memberId) {
-      throw new MemberNotFound();
+      throw new MemberNotFound({ id: memberId });
     }
 
     return this.find({

--- a/src/services/item/plugins/itemFavorite/index.ts
+++ b/src/services/item/plugins/itemFavorite/index.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify';
 
 import { resolveDependency } from '../../../../di/utils';
+import { notUndefined } from '../../../../utils/assertions';
 import { buildRepositories } from '../../../../utils/repositories';
 import { isAuthenticated } from '../../../auth/plugins/passport';
 import common, { create, deleteOne, getFavorite } from './schemas';
@@ -18,7 +19,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/favorite',
     { schema: getFavorite, preHandler: isAuthenticated },
     async ({ user }) => {
-      return favoriteService.getOwn(user?.member, buildRepositories());
+      const member = notUndefined(user?.member);
+      return favoriteService.getOwn(member, buildRepositories());
     },
   );
 
@@ -27,8 +29,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/favorite/:itemId',
     { schema: create, preHandler: isAuthenticated },
     async ({ user, params: { itemId } }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return favoriteService.post(user?.member, buildRepositories(manager), itemId);
+        return favoriteService.post(member, buildRepositories(manager), itemId);
       });
     },
   );
@@ -38,8 +41,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/favorite/:itemId',
     { schema: deleteOne, preHandler: isAuthenticated },
     async ({ user, params: { itemId } }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return favoriteService.delete(user?.member, buildRepositories(manager), itemId);
+        return favoriteService.delete(member, buildRepositories(manager), itemId);
       });
     },
   );

--- a/src/services/item/plugins/itemFavorite/services/favorite.ts
+++ b/src/services/item/plugins/itemFavorite/services/favorite.ts
@@ -2,10 +2,9 @@ import { singleton } from 'tsyringe';
 
 import { PermissionLevel } from '@graasp/sdk';
 
-import { UnauthorizedMember } from '../../../../../utils/errors';
 import { Repositories } from '../../../../../utils/repositories';
 import { filterOutPackedItems } from '../../../../authorization';
-import { Actor } from '../../../../member/entities/member';
+import { Member } from '../../../../member/entities/member';
 import { ItemService } from '../../../service';
 import { PackedItemFavorite } from '../entities/ItemFavorite';
 
@@ -17,12 +16,8 @@ export class FavoriteService {
     this.itemService = itemService;
   }
 
-  async getOwn(actor: Actor, repositories: Repositories): Promise<PackedItemFavorite[]> {
+  async getOwn(actor: Member, repositories: Repositories): Promise<PackedItemFavorite[]> {
     const { itemFavoriteRepository } = repositories;
-
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
 
     const favorites = await itemFavoriteRepository.getFavoriteForMember(actor.id);
 
@@ -45,24 +40,16 @@ export class FavoriteService {
     });
   }
 
-  async post(actor: Actor, repositories: Repositories, itemId: string) {
+  async post(actor: Member, repositories: Repositories, itemId: string) {
     const { itemFavoriteRepository } = repositories;
-
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
 
     // get and check permissions
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Read);
     return itemFavoriteRepository.post(item.id, actor.id);
   }
 
-  async delete(actor: Actor, repositories: Repositories, itemId: string) {
+  async delete(actor: Member, repositories: Repositories, itemId: string) {
     const { itemFavoriteRepository } = repositories;
-
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
 
     return itemFavoriteRepository.deleteOne(itemId, actor.id);
   }

--- a/src/services/item/plugins/itemLike/index.ts
+++ b/src/services/item/plugins/itemLike/index.ts
@@ -25,7 +25,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     '/liked',
     { schema: getLikesForMember, preHandler: isAuthenticated },
     async ({ user }) => {
-      return itemLikeService.getForMember(user?.member, buildRepositories());
+      const member = notUndefined(user?.member);
+      return itemLikeService.getForMember(member, buildRepositories());
     },
   );
 

--- a/src/services/item/plugins/itemLike/service.ts
+++ b/src/services/item/plugins/itemLike/service.ts
@@ -1,8 +1,7 @@
-import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import { filterOutPackedItems } from '../../../authorization';
 import { ItemService } from '../../../item/service';
-import { Actor } from '../../../member/entities/member';
+import { Actor, Member } from '../../../member/entities/member';
 
 export class ItemLikeService {
   private itemService: ItemService;
@@ -11,10 +10,7 @@ export class ItemLikeService {
     this.itemService = itemService;
   }
 
-  async getForMember(actor: Actor, repositories: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async getForMember(actor: Member, repositories: Repositories) {
     const { itemLikeRepository } = repositories;
 
     // only own items
@@ -42,10 +38,7 @@ export class ItemLikeService {
     return itemLikeRepository.getForItem(itemId);
   }
 
-  async removeOne(actor: Actor, repositories: Repositories, itemId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async removeOne(actor: Member, repositories: Repositories, itemId: string) {
     const { itemLikeRepository } = repositories;
 
     // QUESTION: allow public to be liked?
@@ -54,10 +47,7 @@ export class ItemLikeService {
     return itemLikeRepository.deleteOne(actor, item);
   }
 
-  async post(actor: Actor, repositories: Repositories, itemId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async post(actor: Member, repositories: Repositories, itemId: string) {
     const { itemLikeRepository } = repositories;
 
     // QUESTION: allow public to be liked?

--- a/src/services/item/plugins/published/index.ts
+++ b/src/services/item/plugins/published/index.ts
@@ -98,8 +98,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       schema: unpublishItem,
     },
     async ({ params, user }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return itemPublishedService.delete(user?.member, buildRepositories(manager), params.itemId);
+        return itemPublishedService.delete(member, buildRepositories(manager), params.itemId);
       });
     },
   );

--- a/src/services/item/plugins/published/service.ts
+++ b/src/services/item/plugins/published/service.ts
@@ -7,7 +7,6 @@ import { BaseLogger } from '../../../../logger';
 import { MAIL } from '../../../../plugins/mailer/langs/constants';
 import { MailerService } from '../../../../plugins/mailer/service';
 import { resultOfToList } from '../../../../services/utils';
-import { UnauthorizedMember } from '../../../../utils/errors';
 import HookManager from '../../../../utils/hook';
 import { Repositories } from '../../../../utils/repositories';
 import { filterOutHiddenItems } from '../../../authorization';
@@ -169,10 +168,7 @@ export class ItemPublishedService {
     return published;
   }
 
-  async delete(actor: Actor, repositories: Repositories, itemId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async delete(actor: Member, repositories: Repositories, itemId: string) {
     const { itemPublishedRepository } = repositories;
 
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Admin);

--- a/src/services/item/plugins/recycled/index.ts
+++ b/src/services/item/plugins/recycled/index.ts
@@ -43,7 +43,8 @@ const plugin: FastifyPluginAsync<RecycledItemDataOptions> = async (fastify, opti
     '/recycled',
     { schema: getRecycledItemDatas, preHandler: isAuthenticated },
     async ({ user }) => {
-      const result = await recycleBinService.getAll(user?.member, buildRepositories());
+      const member = notUndefined(user?.member);
+      const result = await recycleBinService.getAll(member, buildRepositories());
       return result;
     },
   );

--- a/src/services/item/plugins/recycled/service.ts
+++ b/src/services/item/plugins/recycled/service.ts
@@ -1,10 +1,9 @@
 import { PermissionLevel } from '@graasp/sdk';
 
-import { UnauthorizedMember } from '../../../../utils/errors';
 import HookManager from '../../../../utils/hook';
 import { Repositories } from '../../../../utils/repositories';
 import { validatePermission } from '../../../authorization';
-import { Actor } from '../../../member/entities/member';
+import { Member } from '../../../member/entities/member';
 import { ItemWrapper } from '../../ItemWrapper';
 import { Item } from '../../entities/Item';
 
@@ -20,12 +19,8 @@ export class RecycledBinService {
     };
   }>();
 
-  async getAll(actor: Actor, repositories: Repositories) {
+  async getAll(actor: Member, repositories: Repositories) {
     const { recycledItemRepository } = repositories;
-    // check member is connected
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
 
     const recycled = await recycledItemRepository.getOwnRecycledItemDatas(actor);
     const packedItems = await ItemWrapper.createPackedItems(
@@ -47,10 +42,7 @@ export class RecycledBinService {
     });
   }
 
-  async recycleMany(actor: Actor, repositories: Repositories, itemIds: string[]) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async recycleMany(actor: Member, repositories: Repositories, itemIds: string[]) {
     const { itemRepository, recycledItemRepository } = repositories;
 
     const itemsResult = await itemRepository.getMany(itemIds, { throwOnError: true });
@@ -87,10 +79,7 @@ export class RecycledBinService {
     return itemsResult;
   }
 
-  async restoreMany(actor: Actor, repositories: Repositories, itemIds: string[]) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async restoreMany(actor: Member, repositories: Repositories, itemIds: string[]) {
     const { itemRepository, recycledItemRepository } = repositories;
 
     const result = await itemRepository.getMany(itemIds, {

--- a/src/services/item/plugins/shortLink/repository.ts
+++ b/src/services/item/plugins/shortLink/repository.ts
@@ -38,7 +38,9 @@ export const ShortLinkRepository = AppDataSource.getRepository(ShortLink).extend
   },
 
   async getItem(itemId: string): Promise<ShortLink[]> {
-    if (!itemId) throw new ItemNotFound();
+    if (!itemId) {
+      throw new ItemNotFound(itemId);
+    }
 
     const shortLinks = await this.find({
       where: {

--- a/src/services/item/repository.test.ts
+++ b/src/services/item/repository.test.ts
@@ -326,7 +326,7 @@ describe('ItemRepository', () => {
       });
 
       await expect(itemRepository.getChildren(notAFolder)).rejects.toMatchObject(
-        new ItemNotFolder(notAFolder.id),
+        new ItemNotFolder({ id: notAFolder.id }),
       );
     });
   });

--- a/src/services/item/repository.test.ts
+++ b/src/services/item/repository.test.ts
@@ -324,7 +324,10 @@ describe('ItemRepository', () => {
         item: { name: 'child1', type: ItemType.DOCUMENT },
         member,
       });
-      await expect(itemRepository.getChildren(notAFolder)).rejects.toThrow(ItemNotFolder);
+
+      await expect(itemRepository.getChildren(notAFolder)).rejects.toMatchObject(
+        new ItemNotFolder(notAFolder.id),
+      );
     });
   });
   describe('getDescendants', () => {

--- a/src/services/item/repository.test.ts
+++ b/src/services/item/repository.test.ts
@@ -316,6 +316,16 @@ describe('ItemRepository', () => {
         expect(() => expectItem(data[idx], notAFolder)).toThrow(Error);
       });
     });
+
+    it('returns error without leaking information', async () => {
+      const member = await saveMember();
+
+      const { item: notAFolder } = await testUtils.saveItemAndMembership({
+        item: { name: 'child1', type: ItemType.DOCUMENT },
+        member,
+      });
+      await expect(itemRepository.getChildren(notAFolder)).rejects.toThrow(ItemNotFolder);
+    });
   });
   describe('getDescendants', () => {
     it('Returns successfully', async () => {

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -103,7 +103,7 @@ export class ItemRepository {
     } = args;
 
     if (parent && !isItemType(parent, ItemType.FOLDER)) {
-      throw new ItemNotFolder(parent);
+      throw new ItemNotFolder(parent.id);
     }
 
     // TODO: extra
@@ -185,7 +185,7 @@ export class ItemRepository {
     options: { withOrder?: boolean } = {},
   ): Promise<Item[]> {
     if (!isItemType(parent, ItemType.FOLDER)) {
-      throw new ItemNotFolder(parent);
+      throw new ItemNotFolder(parent.id);
     }
 
     const query = this.repository

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -103,7 +103,7 @@ export class ItemRepository {
     } = args;
 
     if (parent && !isItemType(parent, ItemType.FOLDER)) {
-      throw new ItemNotFolder(parent.id);
+      throw new ItemNotFolder({ id: parent.id });
     }
 
     // TODO: extra
@@ -185,7 +185,7 @@ export class ItemRepository {
     options: { withOrder?: boolean } = {},
   ): Promise<Item[]> {
     if (!isItemType(parent, ItemType.FOLDER)) {
-      throw new ItemNotFolder(parent.id);
+      throw new ItemNotFolder({ id: parent.id });
     }
 
     const query = this.repository
@@ -358,7 +358,7 @@ export class ItemRepository {
 
       // cannot move inside non folder item
       if (!isItemType(parentItem, ItemType.FOLDER)) {
-        throw new ItemNotFolder(parentItemId);
+        throw new ItemNotFolder({ id: parentItemId });
       }
 
       // fail if
@@ -458,7 +458,7 @@ export class ItemRepository {
   ): Promise<{ copyRoot: Item; treeCopyMap: Map<string, { original: Item; copy: Item }> }> {
     // cannot copy inside non folder item
     if (parentItem && !isItemType(parentItem, ItemType.FOLDER)) {
-      throw new ItemNotFolder(parentItem.id);
+      throw new ItemNotFolder({ id: parentItem.id });
     }
 
     // copy (memberships from origin are not copied/kept)

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -121,7 +121,7 @@ export class ItemService {
 
       // quick check, necessary for ts
       if (!isItemType(parentItem, ItemType.FOLDER)) {
-        throw new ItemNotFolder(parentItem.id);
+        throw new ItemNotFolder(parentItem);
       }
 
       itemRepository.checkHierarchyDepth(parentItem);

--- a/src/services/item/test/index.test.ts
+++ b/src/services/item/test/index.test.ts
@@ -568,7 +568,7 @@ describe('Item routes tests', () => {
         });
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
-        expect(response.json()).toMatchObject(new ItemNotFolder(parent.id));
+        expect(response.json()).toMatchObject(new ItemNotFolder({ id: parent.id }));
       });
     });
   });

--- a/src/services/itemLogin/index.ts
+++ b/src/services/itemLogin/index.ts
@@ -3,6 +3,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { ItemLoginSchemaType } from '@graasp/sdk';
 
 import { resolveDependency } from '../../di/utils';
+import { notUndefined } from '../../utils/assertions';
 import { buildRepositories } from '../../utils/repositories';
 import { SESSION_KEY, isAuthenticated, optionalIsAuthenticated } from '../auth/plugins/passport';
 import { ItemService } from '../item/service';
@@ -85,8 +86,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       preHandler: isAuthenticated,
     },
     async ({ user, params: { id: itemId }, body: { type } }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return itemLoginService.put(user?.member, buildRepositories(manager), itemId, type);
+        return itemLoginService.put(member, buildRepositories(manager), itemId, type);
       });
     },
   );
@@ -101,7 +103,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
     },
     async ({ user, params: { id: itemId } }) => {
       return db.transaction(async (manager) => {
-        return itemLoginService.delete(user?.member, buildRepositories(manager), itemId);
+        const member = notUndefined(user?.member);
+        return itemLoginService.delete(member, buildRepositories(manager), itemId);
       });
     },
   );

--- a/src/services/itemLogin/service.ts
+++ b/src/services/itemLogin/service.ts
@@ -2,7 +2,6 @@ import { FastifyInstance } from 'fastify';
 
 import { ItemLoginSchemaType, PermissionLevel, UUID } from '@graasp/sdk';
 
-import { UnauthorizedMember } from '../../utils/errors';
 import { Repositories } from '../../utils/repositories';
 import { ItemService } from '../item/service';
 import { Actor, Member } from '../member/entities/member';
@@ -119,10 +118,7 @@ export class ItemLoginService {
     return bondMember;
   }
 
-  async put(actor: Actor, repositories: Repositories, itemId: string, type?: ItemLoginSchemaType) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async put(actor: Member, repositories: Repositories, itemId: string, type?: ItemLoginSchemaType) {
     const { itemLoginSchemaRepository } = repositories;
 
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Admin);
@@ -130,10 +126,7 @@ export class ItemLoginService {
     return itemLoginSchemaRepository.put(item, type);
   }
 
-  async delete(actor: Actor, repositories: Repositories, itemId: string) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async delete(actor: Member, repositories: Repositories, itemId: string) {
     const { itemLoginSchemaRepository } = repositories;
 
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Admin);

--- a/src/services/itemMembership/index.ts
+++ b/src/services/itemMembership/index.ts
@@ -7,6 +7,7 @@ import { PermissionLevel } from '@graasp/sdk';
 
 import { resolveDependency } from '../../di/utils';
 import { IdParam } from '../../types';
+import { notUndefined } from '../../utils/assertions';
 import { buildRepositories } from '../../utils/repositories';
 import { isAuthenticated, optionalIsAuthenticated } from '../auth/plugins/passport';
 import { PurgeBelowParam } from './interfaces/requests';
@@ -52,8 +53,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         '/',
         { schema: create, preHandler: isAuthenticated },
         async ({ user, query: { itemId }, body }) => {
+          const member = notUndefined(user?.member);
           return db.transaction((manager) => {
-            return itemMembershipService.post(user?.member, buildRepositories(manager), {
+            return itemMembershipService.post(member, buildRepositories(manager), {
               permission: body.permission,
               itemId,
               memberId: body.memberId,
@@ -70,12 +72,13 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         '/:itemId',
         { schema: createMany, preHandler: isAuthenticated },
         async ({ user, params: { itemId }, body }) => {
+          const member = notUndefined(user?.member);
           // BUG: because we use this call to save csv member
           // we have to return immediately
           // solution: it's probably simpler to upload a csv and handle it in the back
           return db.transaction((manager) => {
             return itemMembershipService.postMany(
-              user?.member,
+              member,
               buildRepositories(manager),
               body.memberships,
               itemId,
@@ -95,8 +98,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
           preHandler: isAuthenticated,
         },
         async ({ user, params: { id }, body }) => {
+          const member = notUndefined(user?.member);
           return db.transaction((manager) => {
-            return itemMembershipService.patch(user?.member, buildRepositories(manager), id, body);
+            return itemMembershipService.patch(member, buildRepositories(manager), id, body);
           });
         },
       );
@@ -106,8 +110,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         '/:id',
         { schema: deleteOne, preHandler: isAuthenticated },
         async ({ user, params: { id }, query: { purgeBelow } }) => {
+          const member = notUndefined(user?.member);
           return db.transaction((manager) => {
-            return itemMembershipService.deleteOne(user?.member, buildRepositories(manager), id, {
+            return itemMembershipService.deleteOne(member, buildRepositories(manager), id, {
               purgeBelow,
             });
           });

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -14,7 +14,7 @@ import {
   InvalidMembership,
   InvalidPermissionLevel,
   ItemMembershipNotFound,
-  ModifyExisting,
+  ModifyExistingMembership,
 } from '../../utils/errors';
 import { ITEMS_PAGE_SIZE, ITEMS_PAGE_SIZE_MAX } from '../item/constants';
 import { Item } from '../item/entities/Item';
@@ -75,7 +75,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
     });
 
     if (!item) {
-      throw new ItemMembershipNotFound(id);
+      throw new ItemMembershipNotFound({ id });
     }
 
     return item;
@@ -257,7 +257,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
     const mapByPath = mapById({
       keys: items.map(({ path }) => path),
       findElement: (path) => memberships.filter(({ item }) => path.includes(item.path)),
-      buildError: (path) => new ItemMembershipNotFound(path),
+      buildError: (path) => new ItemMembershipNotFound({ path }),
     });
 
     // use id as key
@@ -310,7 +310,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
     const result = mapById({
       keys: ids,
       findElement: (id) => itemIdToMemberships.get(id),
-      buildError: (id) => new ItemMembershipNotFound(id),
+      buildError: (id) => new ItemMembershipNotFound({ id }),
     });
 
     return result;
@@ -367,7 +367,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
     const result = mapById({
       keys: ids,
       findElement: (id) => itemMemberships.find(({ id: thisId }) => id === thisId),
-      buildError: (id) => new ItemMembershipNotFound(id),
+      buildError: (id) => new ItemMembershipNotFound({ id }),
     });
 
     if (args.throwOnError && result.errors.length) {
@@ -478,7 +478,7 @@ export const ItemMembershipRepository = AppDataSource.getRepository(ItemMembersh
       const { item: itemFromPermission, permission: inheritedPermission, id } = inheritedMembership;
       // fail if trying to add a new membership for the same member and item
       if (itemFromPermission.id === item.id) {
-        throw new ModifyExisting(id);
+        throw new ModifyExistingMembership({ id });
       }
 
       if (PermissionLevelCompare.lte(permission, inheritedPermission)) {

--- a/src/services/itemMembership/service.ts
+++ b/src/services/itemMembership/service.ts
@@ -203,7 +203,7 @@ export class ItemMembershipService {
       (m) => m.id !== itemMembershipId && m.permission === PermissionLevel.Admin,
     );
     if (otherAdminMemberships.length === 0) {
-      throw new CannotDeleteOnlyAdmin(item.id);
+      throw new CannotDeleteOnlyAdmin({ id: item.id });
     }
 
     await this.hooks.runPreHooks('delete', actor, repositories, membership);

--- a/src/services/itemMembership/test/index.test.ts
+++ b/src/services/itemMembership/test/index.test.ts
@@ -898,8 +898,8 @@ describe('Membership routes tests', () => {
           url: `/item-memberships/${itemMembership.id}`,
         });
         expect(response.statusCode).toEqual(StatusCodes.FORBIDDEN);
-
-        expect(response.json()).toMatchObject(new CannotDeleteOnlyAdmin(expect.anything()));
+        const res = await response.json();
+        expect(res).toMatchObject(new CannotDeleteOnlyAdmin({ id: expect.anything() }));
       });
     });
   });

--- a/src/services/itemMembership/test/index.test.ts
+++ b/src/services/itemMembership/test/index.test.ts
@@ -16,7 +16,7 @@ import {
   ItemNotFound,
   MemberCannotAccess,
   MemberCannotAdminItem,
-  ModifyExisting,
+  ModifyExistingMembership,
 } from '../../../utils/errors';
 import { setItemPublic } from '../../item/plugins/itemTag/test/fixtures';
 import { ItemTestUtils } from '../../item/test/fixtures/items';
@@ -367,7 +367,7 @@ describe('Membership routes tests', () => {
         });
 
         // check item membership repository contains one membership
-        expect(response.json()).toEqual(new ModifyExisting(membership.id));
+        expect(response.json()).toEqual(new ModifyExistingMembership({ id: membership.id }));
         const newCount = await ItemMembershipRepository.count();
         expect(newCount).toEqual(initialCount);
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
@@ -694,7 +694,7 @@ describe('Membership routes tests', () => {
         // membership below does not exist
         expect(await ItemMembershipRepository.count()).toEqual(initialCount - 1);
         ItemMembershipRepository.get(membership.id).catch((e) =>
-          expect(e).toEqual(new ItemMembershipNotFound(membership.id)),
+          expect(e).toEqual(new ItemMembershipNotFound({ id: membership.id })),
         );
       });
       it('Bad request if payload is invalid', async () => {
@@ -844,7 +844,7 @@ describe('Membership routes tests', () => {
         });
 
         expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
-        expect(response.json()).toEqual(new ItemMembershipNotFound(id));
+        expect(response.json()).toEqual(new ItemMembershipNotFound({ id }));
         expect(await ItemMembershipRepository.count()).toEqual(initialCount);
       });
 

--- a/src/services/member/controller.ts
+++ b/src/services/member/controller.ts
@@ -96,7 +96,7 @@ const controller: FastifyPluginAsync = async (fastify) => {
       // handle partial change
       // question: you can never remove a key?
       if (member.id !== id) {
-        throw new CannotModifyOtherMembers(id);
+        throw new CannotModifyOtherMembers({ id });
       }
 
       return db.transaction(async (manager) => {

--- a/src/services/member/plugins/action/index.ts
+++ b/src/services/member/plugins/action/index.ts
@@ -4,6 +4,7 @@ import { FileItemType } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../di/utils';
 import { IdParam } from '../../../../types';
+import { notUndefined } from '../../../../utils/assertions';
 import { buildRepositories } from '../../../../utils/repositories';
 import { isAuthenticated } from '../../../auth/plugins/passport';
 import {
@@ -28,7 +29,8 @@ const plugin: FastifyPluginAsync<GraaspActionsOptions> = async (fastify) => {
     '/actions',
     { schema: getMemberFilteredActions, preHandler: isAuthenticated },
     async ({ user, query }) => {
-      return actionMemberService.getFilteredActions(user?.member, buildRepositories(), query);
+      const member = notUndefined(user?.member);
+      return actionMemberService.getFilteredActions(member, buildRepositories(), query);
     },
   );
   // todo: delete self data
@@ -37,8 +39,9 @@ const plugin: FastifyPluginAsync<GraaspActionsOptions> = async (fastify) => {
     '/members/:id/delete',
     { schema: deleteAllById, preHandler: isAuthenticated },
     async ({ user, params: { id } }) => {
+      const member = notUndefined(user?.member);
       return db.transaction(async (manager) => {
-        return actionMemberService.deleteAllForMember(user?.member, buildRepositories(manager), id);
+        return actionMemberService.deleteAllForMember(member, buildRepositories(manager), id);
       });
     },
   );

--- a/src/services/member/plugins/action/service.ts
+++ b/src/services/member/plugins/action/service.ts
@@ -80,7 +80,7 @@ export class ActionMemberService {
     const { actionRepository } = repositories;
 
     if (actor?.id !== memberId) {
-      throw new CannotModifyOtherMembers(memberId);
+      throw new CannotModifyOtherMembers({ id: memberId });
     }
 
     await actionRepository.deleteAllForMember(memberId);

--- a/src/services/member/plugins/action/service.ts
+++ b/src/services/member/plugins/action/service.ts
@@ -3,12 +3,12 @@ import { singleton } from 'tsyringe';
 
 import { ActionTriggers, PermissionLevel } from '@graasp/sdk';
 
-import { CannotModifyOtherMembers, UnauthorizedMember } from '../../../../utils/errors';
+import { CannotModifyOtherMembers } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import { ActionService } from '../../../action/services/action';
 import { validatePermissionMany } from '../../../authorization';
 import { Item, ItemExtraMap } from '../../../item/entities/Item';
-import { Actor } from '../../entities/member';
+import { Member } from '../../entities/member';
 
 export const getPreviousMonthFromNow = () => {
   const date = new Date(); // Today's date
@@ -35,14 +35,10 @@ export class ActionMemberService {
   }
 
   async getFilteredActions(
-    actor: Actor,
+    actor: Member,
     repositories: Repositories,
     filters: { startDate?: string; endDate?: string },
   ) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
     const { actionRepository } = repositories;
 
     const { startDate, endDate } = filters;
@@ -77,7 +73,7 @@ export class ActionMemberService {
   }
 
   async deleteAllForMember(
-    actor: Actor,
+    actor: Member,
     repositories: Repositories,
     memberId: string,
   ): Promise<void> {

--- a/src/services/member/plugins/action/test/service.test.ts
+++ b/src/services/member/plugins/action/test/service.test.ts
@@ -38,16 +38,6 @@ describe('Action member service', () => {
   });
 
   describe('Test getFilteredActions', () => {
-    // FIX this test is now obsolete, as the endpoint checks the member authentication
-    // the type should remove the need to check
-    // it('throw for signed out user', async () => {
-    //   ({ app } = await build({ member: null }));
-
-    //   await expect(
-    //     getActionMemberService().getFilteredActions(actor, buildRepositories(), {}),
-    //   ).rejects.toBeInstanceOf(UnauthorizedMember);
-    // });
-
     it('get filtered actions by start and end date for auth member ', async () => {
       ({ app, actor } = await build());
       const member = notUndefined(actor);

--- a/src/services/member/plugins/export-data/controller.ts
+++ b/src/services/member/plugins/export-data/controller.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { FastifyPluginAsync } from 'fastify';
 
 import { resolveDependency } from '../../../../di/utils';
+import { notUndefined } from '../../../../utils/assertions';
 import { buildRepositories } from '../../../../utils/repositories';
 import { isAuthenticated } from '../../../auth/plugins/passport';
 import { exportMemberData } from './schemas/schemas';
@@ -20,11 +21,12 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       preHandler: isAuthenticated,
     },
     async ({ user }, reply) => {
+      const member = notUndefined(user?.member);
       db.transaction(async (manager) => {
         const repositories = buildRepositories(manager);
 
         await exportMemberDataService.requestDataExport({
-          actor: user?.member,
+          actor: member,
           repositories,
         });
       });

--- a/src/services/member/plugins/export-data/service.ts
+++ b/src/services/member/plugins/export-data/service.ts
@@ -1,9 +1,8 @@
 import { singleton } from 'tsyringe';
 
-import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import { Item } from '../../../item/entities/Item';
-import { Actor } from '../../entities/member';
+import { Member } from '../../entities/member';
 import {
   actionArraySchema,
   appActionArraySchema,
@@ -32,21 +31,13 @@ export class ExportMemberDataService {
     this.requestDataExportService = requestDataExportService;
   }
 
-  async requestDataExport({ actor, repositories }: { actor: Actor; repositories: Repositories }) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async requestDataExport({ actor, repositories }: { actor: Member; repositories: Repositories }) {
     // get the data to export
     const dataRetriever = async () => await this.getAllData(actor, repositories);
     await this.requestDataExportService.requestExport(actor, actor.id, dataRetriever);
   }
 
-  async getAllData(actor: Actor, repositories: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getAllData(actor: Member, repositories: Repositories) {
     // TODO: export more data
     const actions = await this.getActions(actor, repositories);
     const appActions = await this.getAppActions(actor, repositories);
@@ -76,67 +67,39 @@ export class ExportMemberDataService {
     };
   }
 
-  async getActions(actor: Actor, { actionRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getActions(actor: Member, { actionRepository }: Repositories) {
     const results = await actionRepository.getForMemberExport(actor.id);
     return getFilteredData(results, actionArraySchema);
   }
 
-  async getAppActions(actor: Actor, { appActionRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getAppActions(actor: Member, { appActionRepository }: Repositories) {
     const results = await appActionRepository.getForMemberExport(actor.id);
     return getFilteredData(results, appActionArraySchema);
   }
 
-  async getAppData(actor: Actor, { appDataRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getAppData(actor: Member, { appDataRepository }: Repositories) {
     const appData = await appDataRepository.getForMemberExport(actor.id);
     return getFilteredData(appData, appDataArraySchema);
   }
 
-  async getAppSettings(actor: Actor, { appSettingRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getAppSettings(actor: Member, { appSettingRepository }: Repositories) {
     const results = await appSettingRepository.getForMemberExport(actor.id);
     return getFilteredData(results, appSettingArraySchema);
   }
 
-  async getChatMentions(actor: Actor, { mentionRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getChatMentions(actor: Member, { mentionRepository }: Repositories) {
     const results = await mentionRepository.getForMemberExport(actor.id);
     const anonymized = anonymizeMentionsMessage({ results, exportingActorId: actor.id });
     return getFilteredData(anonymized, messageMentionArraySchema);
   }
 
-  async getChatMessages(actor: Actor, { chatMessageRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getChatMessages(actor: Member, { chatMessageRepository }: Repositories) {
     const results = await chatMessageRepository.getForMemberExport(actor.id);
     const anonymized = anonymizeMessages({ results, exportingActorId: actor.id });
     return getFilteredData(anonymized, messageArraySchema);
   }
 
-  async getItemsMemberShips(actor: Actor, { itemMembershipRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getItemsMemberShips(actor: Member, { itemMembershipRepository }: Repositories) {
     const itemMemberShips = await itemMembershipRepository.getForMemberExport(actor.id);
     return getFilteredData(itemMemberShips, itemMembershipArraySchema);
   }
@@ -145,36 +108,22 @@ export class ExportMemberDataService {
     return memberItemsOwner.map((item) => item.id);
   }
 
-  async getItems(actor: Actor, { itemRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async getItems(actor: Member, { itemRepository }: Repositories) {
     const results = await itemRepository.getForMemberExport(actor.id);
     return getFilteredData(results, itemArraySchema);
   }
 
-  async getItemCategories(actor: Actor, { itemCategoryRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
+  async getItemCategories(actor: Member, { itemCategoryRepository }: Repositories) {
     const results = await itemCategoryRepository.getForMemberExport(actor.id);
     return getFilteredData(results, itemCategoryArraySchema);
   }
 
-  async getItemFavorites(actor: Actor, { itemFavoriteRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getItemFavorites(actor: Member, { itemFavoriteRepository }: Repositories) {
     const results = await itemFavoriteRepository.getForMemberExport(actor.id);
     return getFilteredData(results, itemFavoriteArraySchema);
   }
 
-  async getItemLikes(actor: Actor, { itemLikeRepository }: Repositories) {
-    if (!actor) {
-      throw new UnauthorizedMember(actor);
-    }
-
+  async getItemLikes(actor: Member, { itemLikeRepository }: Repositories) {
     // TODO: check if we should also export the likes created by another actor on its items
     // In this case, don't forget to anonymize the id of the other actor ?
     // Or should we put the username of the other actor who liked the item ?

--- a/src/services/member/plugins/profile/repository.ts
+++ b/src/services/member/plugins/profile/repository.ts
@@ -38,7 +38,7 @@ class MemberProfileRepository extends AbstractRepository<MemberProfile> {
     },
   ): Promise<MemberProfile | null> {
     if (!memberId) {
-      throw new MemberNotFound();
+      throw new MemberNotFound({ id: memberId });
     }
     const memberProfile = await this.repository.findOne({
       where: { member: { id: memberId }, visibility: filter?.visibility },

--- a/src/services/member/repository.ts
+++ b/src/services/member/repository.ts
@@ -20,11 +20,11 @@ export class MemberRepository extends AbstractRepository<Member> {
     // additional check that id is not null
     // o/w empty parameter to findOneBy return the first entry
     if (!id) {
-      throw new MemberNotFound(id);
+      throw new MemberNotFound({ id });
     }
     const m = await this.repository.findOneBy({ id });
     if (!m) {
-      throw new MemberNotFound(id);
+      throw new MemberNotFound({ id });
     }
     return m;
   }
@@ -34,7 +34,7 @@ export class MemberRepository extends AbstractRepository<Member> {
     return mapById({
       keys: ids,
       findElement: (id) => members.find(({ id: thisId }) => thisId === id),
-      buildError: (id) => new MemberNotFound(id),
+      buildError: (id) => new MemberNotFound({ id }),
     });
   }
 
@@ -55,7 +55,7 @@ export class MemberRepository extends AbstractRepository<Member> {
     return mapById({
       keys: emails,
       findElement: (email) => members.find(({ email: thisEmail }) => thisEmail === email),
-      buildError: (email) => new MemberNotFound(email),
+      buildError: (email) => new MemberNotFound({ email }),
     });
   }
 

--- a/src/services/member/service.ts
+++ b/src/services/member/service.ts
@@ -101,7 +101,7 @@ export class MemberService {
 
   async deleteOne(actor: Actor, { memberRepository }: Repositories, id: UUID) {
     if (!actor || actor.id !== id) {
-      throw new CannotModifyOtherMembers(id);
+      throw new CannotModifyOtherMembers({ id });
     }
 
     return memberRepository.deleteOne(id);

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -232,7 +232,7 @@ describe('Member routes tests', () => {
           url: `/members/${memberId}`,
         });
         expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
-        expect(response.json()).toEqual(new MemberNotFound(memberId));
+        expect(response.json()).toEqual(new MemberNotFound({ id: memberId }));
       });
     });
   });
@@ -350,7 +350,7 @@ describe('Member routes tests', () => {
         });
 
         // TODO: currently we do not return empty values
-        expect(response.json().errors[0]).toEqual(new MemberNotFound(memberId));
+        expect(response.json().errors[0]).toEqual(new MemberNotFound({ id: memberId }));
         expect(response.statusCode).toBe(StatusCodes.OK);
       });
     });
@@ -423,7 +423,7 @@ describe('Member routes tests', () => {
         });
 
         expect(response.statusCode).toBe(StatusCodes.OK);
-        expect(response.json().errors[0]).toEqual(new MemberNotFound(email));
+        expect(response.json().errors[0]).toEqual(new MemberNotFound({ email }));
       });
 
       /**

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -585,7 +585,7 @@ describe('Member routes tests', () => {
         expect(m?.name).not.toEqual(newName);
 
         expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
-        expect(response.json()).toEqual(new CannotModifyOtherMembers(member.id));
+        expect(response.json()).toEqual(new CannotModifyOtherMembers({ id: member.id }));
       });
     });
   });
@@ -630,7 +630,7 @@ describe('Member routes tests', () => {
         expect(m).toBeTruthy();
 
         expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
-        expect(response.json()).toEqual(new CannotModifyOtherMembers(member.id));
+        expect(response.json()).toEqual(new CannotModifyOtherMembers({ id: member.id }));
       });
     });
   });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -15,55 +15,55 @@ export class ExpectedEnvVariable extends Error {
 export const CoreError = ErrorFactory('core');
 
 export class ItemNotFound extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR001',
         statusCode: StatusCodes.NOT_FOUND,
         message: FAILURE_MESSAGES.ITEM_NOT_FOUND,
       },
-      data,
+      itemId,
     );
   }
 }
 export class MemberCannotReadItem extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR002',
         statusCode: StatusCodes.FORBIDDEN,
         message: FAILURE_MESSAGES.USER_CANNOT_READ_ITEM,
       },
-      data,
+      itemId,
     );
   }
 }
 export class MemberCannotWriteItem extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR003',
         statusCode: StatusCodes.FORBIDDEN,
         message: FAILURE_MESSAGES.USER_CANNOT_WRITE_ITEM,
       },
-      data,
+      itemId,
     );
   }
 }
 export class MemberCannotAdminItem extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR004',
         statusCode: StatusCodes.FORBIDDEN,
         message: FAILURE_MESSAGES.USER_CANNOT_ADMIN_ITEM,
       },
-      data,
+      itemId,
     );
   }
 }
 export class InvalidMembership extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data?: { itemId: string; memberId: string; permission: string }) {
     super(
       {
         code: 'GERR005',
@@ -75,7 +75,7 @@ export class InvalidMembership extends CoreError {
   }
 }
 export class ItemMembershipNotFound extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data?: { id?: string; path?: string }) {
     super(
       {
         code: 'GERR006',
@@ -86,8 +86,8 @@ export class ItemMembershipNotFound extends CoreError {
     );
   }
 }
-export class ModifyExisting extends CoreError {
-  constructor(data?: unknown) {
+export class ModifyExistingMembership extends CoreError {
+  constructor(data?: { id: string }) {
     super(
       {
         code: 'GERR007',
@@ -99,7 +99,7 @@ export class ModifyExisting extends CoreError {
   }
 }
 export class InvalidPermissionLevel extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data?: string) {
     super(
       {
         code: 'GERR008',
@@ -111,31 +111,25 @@ export class InvalidPermissionLevel extends CoreError {
   }
 }
 export class HierarchyTooDeep extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR009',
-        statusCode: StatusCodes.FORBIDDEN,
-        message: FAILURE_MESSAGES.HIERARCHY_TOO_DEEP,
-      },
-      data,
-    );
+  constructor() {
+    super({
+      code: 'GERR009',
+      statusCode: StatusCodes.FORBIDDEN,
+      message: FAILURE_MESSAGES.HIERARCHY_TOO_DEEP,
+    });
   }
 }
 export class TooManyChildren extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR010',
-        statusCode: StatusCodes.FORBIDDEN,
-        message: FAILURE_MESSAGES.TOO_MANY_CHILDREN,
-      },
-      data,
-    );
+  constructor() {
+    super({
+      code: 'GERR010',
+      statusCode: StatusCodes.FORBIDDEN,
+      message: FAILURE_MESSAGES.TOO_MANY_CHILDREN,
+    });
   }
 }
 export class TooManyDescendants extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data?: string) {
     super(
       {
         code: 'GERR011',
@@ -147,7 +141,7 @@ export class TooManyDescendants extends CoreError {
   }
 }
 export class InvalidMoveTarget extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data?: string) {
     super(
       {
         code: 'GERR012',
@@ -159,7 +153,7 @@ export class InvalidMoveTarget extends CoreError {
   }
 }
 export class MemberNotFound extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data?: { email?: string; id?: string }) {
     super(
       {
         code: 'GERR013',
@@ -171,44 +165,33 @@ export class MemberNotFound extends CoreError {
   }
 }
 export class CannotModifyOtherMembers extends CoreError {
-  constructor(data?: unknown) {
+  constructor(memberId: string) {
     super(
       {
         code: 'GERR014',
         statusCode: StatusCodes.FORBIDDEN,
         message: FAILURE_MESSAGES.CANNOT_MODIFY_OTHER_MEMBERS,
       },
-      data,
+      memberId,
     );
   }
 }
-export class TooManyMemberships extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR015',
-        statusCode: StatusCodes.FORBIDDEN,
-        message: FAILURE_MESSAGES.TOO_MANY_MEMBERSHIP,
-      },
-      data,
-    );
-  }
-}
+
 export class MemberCannotAccess extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR016',
         statusCode: StatusCodes.FORBIDDEN,
         message: FAILURE_MESSAGES.MEMBER_CANNOT_ACCESS,
       },
-      data,
+      itemId,
     );
   }
 }
 
 export class MemberAlreadySignedUp extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data: { email: string }) {
     super(
       {
         code: 'GERR017',
@@ -221,7 +204,7 @@ export class MemberAlreadySignedUp extends CoreError {
 }
 
 export class MemberNotSignedUp extends CoreError {
-  constructor(data?: unknown) {
+  constructor(data: { email: string }) {
     super(
       {
         code: 'GERR018',
@@ -234,35 +217,12 @@ export class MemberNotSignedUp extends CoreError {
 }
 
 export class MemberWithoutPassword extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR019',
-        statusCode: StatusCodes.NOT_ACCEPTABLE,
-        message: FAILURE_MESSAGES.MEMBER_WITHOUT_PASSWORD,
-      },
-      data,
-    );
-  }
-}
-
-export class IncorrectPassword extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR020',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: FAILURE_MESSAGES.INCORRECT_PASSWORD,
-      },
-      data,
-    );
-  }
-}
-
-export class TokenExpired extends CoreError {
-  constructor(data?: unknown) {
-    // this status code is custom for the browser to know it needs to refresh its token
-    super({ code: 'GERR021', statusCode: 439, message: FAILURE_MESSAGES.TOKEN_EXPIRED }, data);
+  constructor() {
+    super({
+      code: 'GERR019',
+      statusCode: StatusCodes.NOT_ACCEPTABLE,
+      message: FAILURE_MESSAGES.MEMBER_WITHOUT_PASSWORD,
+    });
   }
 }
 
@@ -276,78 +236,30 @@ export class ChallengeFailed extends CoreError {
   }
 }
 
-export class InvalidToken extends CoreError {
-  constructor(data?: unknown) {
-    // this status code is custom for the browser to know it needs to refresh its token
-    super(
-      {
-        code: 'GERR022',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: FAILURE_MESSAGES.INVALID_TOKEN,
-      },
-      data,
-    );
-  }
-}
-
-export class InvalidSession extends CoreError {
-  constructor(data?: unknown) {
-    // this status code is custom for the browser to know it needs to refresh its token
-    super(
-      {
-        code: 'GERR023',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: FAILURE_MESSAGES.INVALID_SESSION,
-      },
-      data,
-    );
-  }
-}
-
-export class OrphanSession extends CoreError {
-  constructor(data?: unknown) {
-    // this status code is custom for the browser to know it needs to refresh its token
-    super(
-      {
-        code: 'GERR024',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: FAILURE_MESSAGES.ORPHAN_SESSION,
-      },
-      data,
-    );
-  }
-}
-
 export class InvalidPassword extends CoreError {
-  constructor(data?: unknown) {
+  constructor() {
     // this status code is custom for the browser to know it needs to refresh its token
-    super(
-      {
-        code: 'GERR025',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: FAILURE_MESSAGES.INVALID_PASSWORD,
-      },
-      data,
-    );
+    super({
+      code: 'GERR025',
+      statusCode: StatusCodes.UNAUTHORIZED,
+      message: FAILURE_MESSAGES.INVALID_PASSWORD,
+    });
   }
 }
 
 export class EmptyCurrentPassword extends CoreError {
-  constructor(data?: unknown) {
+  constructor() {
     // this status code is custom for the browser to know it needs to refresh its token
-    super(
-      {
-        code: 'GERR026',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: FAILURE_MESSAGES.EMPTY_CURRENT_PASSWORD,
-      },
-      data,
-    );
+    super({
+      code: 'GERR026',
+      statusCode: StatusCodes.UNAUTHORIZED,
+      message: FAILURE_MESSAGES.EMPTY_CURRENT_PASSWORD,
+    });
   }
 }
 
 export class UnauthorizedMember extends CoreError {
-  constructor(_data?: unknown) {
+  constructor() {
     // this status code is custom for the browser to know it needs to refresh its token
     super({
       code: 'GERR027',
@@ -357,54 +269,38 @@ export class UnauthorizedMember extends CoreError {
   }
 }
 
-export class EmailNotAllowed extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR027',
-        statusCode: StatusCodes.FORBIDDEN,
-        message: 'Your email is not allowed to sign up',
-      },
-      data,
-    );
-  }
-}
-
 export class AuthenticationError extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR028',
-        statusCode: StatusCodes.UNAUTHORIZED,
-        message: 'The authentication failed',
-      },
-      data,
-    );
+  constructor() {
+    super({
+      code: 'GERR028',
+      statusCode: StatusCodes.UNAUTHORIZED,
+      message: 'The authentication failed',
+    });
   }
 }
 
 export class ItemNotFolder extends CoreError {
-  constructor(data?: unknown) {
+  constructor(parentId: string) {
     super(
       {
         code: 'GERR029',
         statusCode: StatusCodes.BAD_REQUEST,
         message: 'Item is not a folder',
       },
-      data,
+      parentId,
     );
   }
 }
 
 export class CannotDeleteOnlyAdmin extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR030',
         statusCode: StatusCodes.FORBIDDEN,
         message: 'Cannot delete the only admin on item',
       },
-      data,
+      itemId,
     );
   }
 }
@@ -416,19 +312,6 @@ export class MissingNameOrTypeForItemError extends CoreError {
         code: 'GERR031',
         statusCode: StatusCodes.BAD_REQUEST,
         message: 'Name and type should be defined',
-      },
-      data,
-    );
-  }
-}
-
-export class InvalidItemError extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR032',
-        statusCode: StatusCodes.BAD_REQUEST,
-        message: 'path should be defined',
       },
       data,
     );
@@ -449,27 +332,14 @@ export class NoFileProvided extends CoreError {
 }
 
 export class CannotReorderRootItem extends CoreError {
-  constructor(data?: unknown) {
+  constructor(itemId: string) {
     super(
       {
         code: 'GERR034',
         statusCode: StatusCodes.BAD_REQUEST,
         message: 'Cannot reorder items at root',
       },
-      data,
-    );
-  }
-}
-
-export class DatabaseError extends CoreError {
-  constructor(data?: unknown) {
-    super(
-      {
-        code: 'GERR998',
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-        message: FAILURE_MESSAGES.DATABASE_ERROR,
-      },
-      data,
+      itemId,
     );
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -165,14 +165,14 @@ export class MemberNotFound extends CoreError {
   }
 }
 export class CannotModifyOtherMembers extends CoreError {
-  constructor(memberId: string) {
+  constructor(member: { id: string }) {
     super(
       {
         code: 'GERR014',
         statusCode: StatusCodes.FORBIDDEN,
         message: FAILURE_MESSAGES.CANNOT_MODIFY_OTHER_MEMBERS,
       },
-      memberId,
+      member.id,
     );
   }
 }
@@ -280,27 +280,27 @@ export class AuthenticationError extends CoreError {
 }
 
 export class ItemNotFolder extends CoreError {
-  constructor(parentId: string) {
+  constructor(parent: { id: string }) {
     super(
       {
         code: 'GERR029',
         statusCode: StatusCodes.BAD_REQUEST,
         message: 'Item is not a folder',
       },
-      parentId,
+      parent.id,
     );
   }
 }
 
 export class CannotDeleteOnlyAdmin extends CoreError {
-  constructor(itemId: string) {
+  constructor(item: { id: string }) {
     super(
       {
         code: 'GERR030',
         statusCode: StatusCodes.FORBIDDEN,
         message: 'Cannot delete the only admin on item',
       },
-      itemId,
+      item.id,
     );
   }
 }


### PR DESCRIPTION
In this PR:
- remove leaked information from errors
- specify data type expected by the errors instead of using `unknown`
- remove unused errors
- make heavier use of the actor type in services that are used inside authenticated controllers, so we do not need to throw if the member does not exist as it will always be defined.
