### PR TITLE
fix: sort descendants as number

### DIFF
--- a/src/services/item/utils.ts
+++ b/src/services/item/utils.ts
@@ -10,7 +10,9 @@ import { NoFileProvided } from '../../utils/errors';
 import { FolderItem, Item, isItemType } from './entities/Item';
 import { validateGeolocation, validateSettings } from './validation';
 
-const itemOrderFn = (a, b) => (a.order > b.order ? 1 : -1);
+const itemOrderFn = (a: Item, b: Item) => {
+  return (a.order ?? 0) - (b.order ?? 0);
+};
 // cannot use sdk sort because of createdAt type
 export const sortChildrenForTreeWith = (descendants: Item[], parentItem: FolderItem): Item[] => {
   const directChildren = descendants.filter((child) => isChildOf(child.path, parentItem.path));


### PR DESCRIPTION
Descendants does not return the correct order. In real context, typeorm actually returns strings, and they are not sorted correctly when representing numbers (1001 < 20).