### PR TITLE
feat: implement fastify swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@fastify/passport": "2.5.0",
     "@fastify/secure-session": "7.5.1",
     "@fastify/static": "7.0.4",
+    "@fastify/swagger": "8.14.0",
+    "@fastify/swagger-ui": "4.0.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
     "@graasp/sdk": "4.22.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import fp from 'fastify-plugin';
 import { registerDependencies } from './di/container';
 import databasePlugin from './plugins/database';
 import metaPlugin from './plugins/meta';
+import swaggerPlugin from './plugins/swagger';
 import shared from './schemas/fluent-schema';
 import authPlugin from './services/auth';
 import { plugin as passportPlugin } from './services/auth/plugins/passport';
@@ -24,6 +25,8 @@ import {
 } from './utils/config';
 
 export default async function (instance: FastifyInstance): Promise<void> {
+  await instance.register(fp(swaggerPlugin));
+
   // load some shared schema definitions
   instance.addSchema(shared);
 

--- a/src/plugins/swagger.ts
+++ b/src/plugins/swagger.ts
@@ -1,0 +1,25 @@
+import swaggerPlugin from '@fastify/swagger';
+import swaggerUiPlugin from '@fastify/swagger-ui';
+import { FastifyInstance } from 'fastify';
+
+import { APP_VERSION } from '../utils/config';
+
+export default async function (instance: FastifyInstance): Promise<void> {
+  await instance.register(swaggerPlugin, {
+    openapi: {
+      openapi: '3.0.0',
+      info: {
+        title: 'Graasp Backend API',
+        version: APP_VERSION ?? ' ',
+        description: 'Graasp Backend API used to serve data to frontend applications',
+      },
+    },
+  });
+
+  await instance.register(swaggerUiPlugin, {
+    routePrefix: '/docs',
+    transformSpecification: (swaggerObject, _request, _reply) => {
+      return swaggerObject;
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,7 +1991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/static@npm:7.0.4":
+"@fastify/static@npm:7.0.4, @fastify/static@npm:^7.0.0":
   version: 7.0.4
   resolution: "@fastify/static@npm:7.0.4"
   dependencies:
@@ -2002,6 +2002,32 @@ __metadata:
     fastq: "npm:^1.17.0"
     glob: "npm:^10.3.4"
   checksum: 10/9471ff60dffffd155aaf748f121700f01981bce597494a8f87b8b13ef1b41214d372cd5edc40f6d06242e65f2f9785c67671cc67728a64168361d1b372b68f4b
+  languageName: node
+  linkType: hard
+
+"@fastify/swagger-ui@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@fastify/swagger-ui@npm:4.0.0"
+  dependencies:
+    "@fastify/static": "npm:^7.0.0"
+    fastify-plugin: "npm:^4.0.0"
+    openapi-types: "npm:^12.0.2"
+    rfdc: "npm:^1.3.0"
+    yaml: "npm:^2.2.2"
+  checksum: 10/72dc37684b11b3143d11b78872908fb8d93943a82f8ce16ff9ded5c0206faf9a6730e2589090b5462ee7fbf7401859666df2e64d718bb0725903e6fb5bf93572
+  languageName: node
+  linkType: hard
+
+"@fastify/swagger@npm:8.14.0":
+  version: 8.14.0
+  resolution: "@fastify/swagger@npm:8.14.0"
+  dependencies:
+    fastify-plugin: "npm:^4.0.0"
+    json-schema-resolver: "npm:^2.0.0"
+    openapi-types: "npm:^12.0.0"
+    rfdc: "npm:^1.3.0"
+    yaml: "npm:^2.2.2"
+  checksum: 10/e63f1ecb7c4915ec950d52766ffc99f46efa9c13a7572b3395c12342ee3dcaa7d0ab54f8aae08db1f949f2f17dd2e3be1e7f79818139e1799fbfcfada933fd76
   languageName: node
   linkType: hard
 
@@ -7489,6 +7515,8 @@ __metadata:
     "@fastify/passport": "npm:2.5.0"
     "@fastify/secure-session": "npm:7.5.1"
     "@fastify/static": "npm:7.0.4"
+    "@fastify/swagger": "npm:8.14.0"
+    "@fastify/swagger-ui": "npm:4.0.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
     "@graasp/sdk": "npm:4.22.0"
@@ -9000,6 +9028,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema-resolver@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "json-schema-resolver@npm:2.0.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    rfdc: "npm:^1.1.4"
+    uri-js: "npm:^4.2.2"
+  checksum: 10/829b951001d5ca605598aaa137b4fa7ef675f4ae11d7f156fee0616353c6e64d5278b405e8fb4823f15dd826cafd1727ed005ff52291975c408b7fcd14b7709b
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -10306,6 +10345,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openapi-types@npm:^12.0.0, openapi-types@npm:^12.0.2":
+  version: 12.1.3
+  resolution: "openapi-types@npm:12.1.3"
+  checksum: 10/9d1d7ed848622b63d0a4c3f881689161b99427133054e46b8e3241e137f1c78bb0031c5d80b420ee79ac2e91d2e727ffd6fc13c553d1b0488ddc8ad389dcbef8
+  languageName: node
+  linkType: hard
+
 "optimist@npm:~0.3.5":
   version: 0.3.7
   resolution: "optimist@npm:0.3.7"
@@ -11368,6 +11414,13 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: 10/14222c9e1d3f9ae01480c50d96057228a8524706db79cdeb5a2ce5bb7070dd9f409a6f84a02cbef8cdc80d39aef86f2dd03d155188a1300c599b05437dcd2ffb
+  languageName: node
+  linkType: hard
+
+"rfdc@npm:^1.1.4":
+  version: 1.4.1
+  resolution: "rfdc@npm:1.4.1"
+  checksum: 10/2f3d11d3d8929b4bfeefc9acb03aae90f971401de0add5ae6c5e38fec14f0405e6a4aad8fdb76344bfdd20c5193110e3750cbbd28ba86d73729d222b6cf4a729
   languageName: node
   linkType: hard
 
@@ -13238,6 +13291,15 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 10/4cb02b42b8a93b5cf50caf5d8e9beb409400a8a4d85e83bb0685c1457e9ac0b7a00819e9f5991ac25ffabb56a78e2f017c1acc010b3a1babfe6de690ba531abd
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.2.2":
+  version: 2.4.5
+  resolution: "yaml@npm:2.4.5"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/b09bf5a615a65276d433d76b8e34ad6b4c0320b85eb3f1a39da132c61ae6e2ff34eff4624e6458d96d49566c93cf43408ba5e568218293a8c6541a2006883f64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The documentation is accessible on `/docs`

We should be able to seperate our route by service with titles
Apparently for some reason models at the end of the page are buggy.