### PR TITLE
feat: change last migration to set legacy data validation to true

### DIFF
--- a/src/migrations/1718693920666-add-isvalidated-lastauthenticated.ts
+++ b/src/migrations/1718693920666-add-isvalidated-lastauthenticated.ts
@@ -1,13 +1,15 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migrations1718693920666 implements MigrationInterface {
-  name = 'Migrations1718693920666';
+  name = 'is-validated-1718693920666';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "member" ADD "last_authenticated_at" TIMESTAMP`);
     await queryRunner.query(
-      `ALTER TABLE "member" ADD "is_validated" boolean NOT NULL DEFAULT false`,
+      `ALTER TABLE "member" ADD "is_validated" boolean NOT NULL DEFAULT true`,
     );
+    // pseudonized members will also be validated, but this will disappear in next migrations
+    await queryRunner.query(`ALTER TABLE "member" ALTER COLUMN "is_validated" SET DEFAULT false`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
set legacy members as validated members. New members will be not validated.

WARNING: we need to redo the migration in dev