### PR TITLE
fix: log group in dev should be `ecs/graasp`

### DIFF
--- a/.aws/graasp-dev.json
+++ b/.aws/graasp-dev.json
@@ -9,7 +9,7 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-          "awslogs-group": "/ecs/graasp-development",
+          "awslogs-group": "/ecs/graasp",
           "awslogs-region": "eu-central-1",
           "awslogs-stream-prefix": "ecs"
         }
@@ -178,7 +178,9 @@
   "family": "graasp",
   "requiresAttributes": [],
   "pidMode": null,
-  "requiresCompatibilities": ["FARGATE"],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
   "networkMode": "awsvpc",
   "runtimePlatform": {
     "operatingSystemFamily": "LINUX",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -190,7 +190,7 @@ services:
   nudenet:
     container_name: graasp-nudenet
     image: notaitech/nudenet:classifier
-    # sxposing these ports is not necessary
+    # exposing these ports is not necessary
     # ports:
     #   - 8080:8080
 


### PR DESCRIPTION
The log group for dev is not the same as the one defined by the the infrastructure. I correct this in this PR.

fixes #1248 