### PR TITLE
fix(MutableRepository): use getOne in updateOne

### DIFF
--- a/src/repositories/MutableRepository.ts
+++ b/src/repositories/MutableRepository.ts
@@ -50,9 +50,9 @@ export abstract class MutableRepository<
         entity as QueryDeepPartialEntity<T>,
       );
 
-      const updatedEntity = await this.findOne(pkValue);
+      const updatedEntity = await this.getOne(pkValue);
 
-      // Should never happen, if an error occurs, it should throw during the update.
+      // Could happen if the given pk doesn't exist, because update does not check if entity exists.
       if (!updatedEntity) {
         throw new EntryNotFoundAfterUpdateException(this.entity);
       }


### PR DESCRIPTION
Update the `updateOne` method to use `getOne` instead of `findOne` to ensure to return the updated entity with the same relations as in the `getOne`.