### PR TITLE
fix: deprecate patch member use current member instead

### DIFF
--- a/src/services/member/controller.ts
+++ b/src/services/member/controller.ts
@@ -26,7 +26,6 @@ import { EmailAlreadyTaken } from './error';
 import { StorageService } from './plugins/storage/service';
 import {
   deleteCurrent,
-  deleteOne,
   getCurrent,
   getMany,
   getManyBy,
@@ -157,33 +156,6 @@ const controller: FastifyPluginAsync = async (fastify) => {
 
       return db.transaction(async (manager) => {
         return memberService.patch(buildRepositories(manager), member.id, body);
-      });
-    },
-  );
-
-  // delete member
-  /**
-   * @deprecated use the delete member function without the id param
-   */
-  fastify.delete<{ Params: IdParam }>(
-    '/:id',
-    { schema: deleteOne, preHandler: isAuthenticated },
-    async (request, reply) => {
-      const {
-        user,
-        params: { id },
-      } = request;
-      if (!user?.account || user.account.id !== id) {
-        throw new CannotModifyOtherMembers({ id });
-      }
-
-      return db.transaction(async (manager) => {
-        await memberService.deleteOne(buildRepositories(manager), id);
-        // logout member
-        request.logOut();
-        // remove session from browser
-        request.session.delete();
-        reply.status(StatusCodes.NO_CONTENT);
       });
     },
   );

--- a/src/services/member/controller.ts
+++ b/src/services/member/controller.ts
@@ -35,6 +35,7 @@ import {
   getStorageFiles,
   patchChangeEmail,
   postChangeEmail,
+  updateCurrent,
   updateOne,
 } from './schemas';
 import { MemberService } from './service';
@@ -126,6 +127,9 @@ const controller: FastifyPluginAsync = async (fastify) => {
     },
   );
 
+  /**
+   * @deprecated use PATCH /members/current instead
+   */
   // update member
   fastify.patch<{ Params: IdParam; Body: Partial<Member> }>(
     '/:id',
@@ -140,6 +144,19 @@ const controller: FastifyPluginAsync = async (fastify) => {
 
       return db.transaction(async (manager) => {
         return memberService.patch(buildRepositories(manager), id, body);
+      });
+    },
+  );
+
+  // update current member
+  fastify.patch<{ Body: Partial<Member> }>(
+    '/current',
+    { schema: updateCurrent, preHandler: isAuthenticated },
+    async ({ user, body }) => {
+      const member = asDefined(user?.account);
+
+      return db.transaction(async (manager) => {
+        return memberService.patch(buildRepositories(manager), member.id, body);
       });
     },
   );

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -260,6 +260,7 @@ export const getManyBy: FastifySchema = {
 
 // schema for updating a member
 export const updateOne: FastifySchema = {
+  deprecated: true,
   params: { $ref: 'https://graasp.org/#/definitions/idParam' },
   body: { $ref: 'https://graasp.org/members/#/definitions/partialMemberRequireOne' },
   response: {

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -258,9 +258,18 @@ export const getManyBy: FastifySchema = {
   },
 };
 
-// schema for updating own member
+// schema for updating a member
 export const updateOne: FastifySchema = {
   params: { $ref: 'https://graasp.org/#/definitions/idParam' },
+  body: { $ref: 'https://graasp.org/members/#/definitions/partialMemberRequireOne' },
+  response: {
+    [StatusCodes.OK]: { $ref: 'https://graasp.org/members/#/definitions/currentMember' },
+    [StatusCodes.FORBIDDEN]: error,
+  },
+};
+
+// schema for updating the current member
+export const updateCurrent: FastifySchema = {
   body: { $ref: 'https://graasp.org/members/#/definitions/partialMemberRequireOne' },
   response: {
     [StatusCodes.OK]: { $ref: 'https://graasp.org/members/#/definitions/currentMember' },


### PR DESCRIPTION
In this PR: 
- add stricter route for updating the current member under `PATCH /members/current` 
- deprecate the old route
- [x] update the tests

ref #1397 