### PR TITLE
fix: set jest extension to run on-demand instead of watch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
   "appService.zipIgnorePattern": [
     ".vscode{,/**}"
   ],
-  "appService.deploySubpath": ""
+  "appService.deploySubpath": "",
+  "jest.runMode": "on-demand",
 }


### PR DESCRIPTION
@Defferrard I think this fixes the issue where the tests are run as soon as you start the container. 

I had this configuration set in my personnal settings, I put it in the shared settings so it can be applied to everyone using it.