### PR TITLE
fix: app actions structure is wrong for export

### DIFF
--- a/src/services/action/utils/export-utils.test.ts
+++ b/src/services/action/utils/export-utils.test.ts
@@ -6,6 +6,9 @@ import { writeFileForFormat } from './export';
 
 const writeFileSyncMock = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
 describe('writeFileForFormat', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
   describe('CSV format', () => {
     it('Empty array should not write anything', () => {
       writeFileForFormat('./test.csv', ExportActionsFormatting.CSV, []);

--- a/src/services/action/utils/export-utils.test.ts
+++ b/src/services/action/utils/export-utils.test.ts
@@ -12,7 +12,7 @@ describe('writeFileForFormat', () => {
       expect(writeFileSyncMock).not.toHaveBeenCalled();
     });
 
-    it('Object should not write anything', () => {
+    it('Empty object should not write anything', () => {
       writeFileForFormat('./test.csv', ExportActionsFormatting.CSV, {});
       expect(writeFileSyncMock).not.toHaveBeenCalled();
     });
@@ -43,7 +43,7 @@ describe('writeFileForFormat', () => {
       expect(writeFileSyncMock).not.toHaveBeenCalled();
     });
 
-    it('Object should not write anything', () => {
+    it('Empty object should not write anything', () => {
       writeFileForFormat('./test.json', ExportActionsFormatting.JSON, {});
       expect(writeFileSyncMock).not.toHaveBeenCalled();
     });

--- a/src/services/action/utils/export-utils.test.ts
+++ b/src/services/action/utils/export-utils.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+
+import { ExportActionsFormatting } from '@graasp/sdk';
+
+import { writeFileForFormat } from './export';
+
+const writeFileSyncMock = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+describe('writeFileForFormat', () => {
+  describe('CSV format', () => {
+    it('Empty array should not write anything', () => {
+      writeFileForFormat('./test.csv', ExportActionsFormatting.CSV, []);
+      expect(writeFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('Object should not write anything', () => {
+      writeFileForFormat('./test.csv', ExportActionsFormatting.CSV, {});
+      expect(writeFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('Array should be written', () => {
+      writeFileForFormat('./test.csv', ExportActionsFormatting.CSV, [
+        { name: 'hello' },
+        { name: 'test' },
+      ]);
+      expect(writeFileSyncMock).toHaveBeenCalledWith('./test.csv', 'name\r\nhello\r\ntest');
+    });
+
+    it('Nested properties will be flattened', () => {
+      writeFileForFormat('./test.csv', ExportActionsFormatting.CSV, [
+        { name: 'hello', nest: { prop: 'value' } },
+        { name: 'test', nest: { prop: 'other value' } },
+      ]);
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        './test.csv',
+        'name,nest.prop\r\nhello,value\r\ntest,other value',
+      );
+    });
+  });
+
+  describe('JSON format', () => {
+    it('Empty array should not write anything', () => {
+      writeFileForFormat('./test.json', ExportActionsFormatting.JSON, []);
+      expect(writeFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('Object should not write anything', () => {
+      writeFileForFormat('./test.json', ExportActionsFormatting.JSON, {});
+      expect(writeFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('Array should be written', () => {
+      const data = [
+        { name: 'hello', nest: { prop: 'value' } },
+        { name: 'test', nest: { prop: 'other value' } },
+      ];
+      writeFileForFormat('./test.json', ExportActionsFormatting.JSON, data);
+      expect(writeFileSyncMock).toHaveBeenCalledWith('./test.json', JSON.stringify(data));
+    });
+
+    it('Object should be written', () => {
+      const data = { name: 'hello', nest: { prop: 'value' } };
+      writeFileForFormat('./test.json', ExportActionsFormatting.JSON, data);
+      expect(writeFileSyncMock).toHaveBeenCalledWith('./test.json', JSON.stringify(data));
+    });
+  });
+});

--- a/src/services/action/utils/export.ts
+++ b/src/services/action/utils/export.ts
@@ -43,11 +43,10 @@ const flattenObject = (obj: RecursiveObject, prefix: string = ''): ReturnObject 
   }, {});
 };
 
-export const writeFileForFormat = (
+export const writeFileForFormat = <T extends object>(
   path: string,
   format: ExportActionsFormatting,
-  // TODO: Replace 'object' with specific type(s) when defining schema for data to export
-  data: object[] | object,
+  data: T[] | T,
 ): void => {
   switch (format) {
     case ExportActionsFormatting.CSV: {
@@ -167,7 +166,7 @@ export const exportActionsInArchive = async (args: {
         writeFileForFormat(appsPath, format, { appActions, appData, appSettings });
         break;
       }
-      // For CSV format there will be one file for actions, one fofr data and one for settings
+      // For CSV format there will be one file for actions, one for data and one for settings
       // with all the apps together.
       case ExportActionsFormatting.CSV: {
         // create files for the apps

--- a/src/services/auth/plugins/password/index.ts
+++ b/src/services/auth/plugins/password/index.ts
@@ -135,7 +135,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
       // We can already return to avoid leaking timing information.
       reply.status(StatusCodes.NO_CONTENT);
-      reply.send();
+      // need to await this
+      await reply.send();
 
       const repositories = buildRepositories();
 

--- a/src/services/item/plugins/action/index.ts
+++ b/src/services/item/plugins/action/index.ts
@@ -11,7 +11,6 @@ import {
   CountGroupBy,
   ExportActionsFormatting,
   FileItemType,
-  HttpMethod,
 } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../di/utils';
@@ -115,12 +114,13 @@ const plugin: FastifyPluginAsync<GraaspActionsOptions> = async (fastify) => {
     },
   );
 
-  fastify.route<{ Params: IdParam; Body: { type: string; extra?: { [key: string]: unknown } } }>({
-    method: HttpMethod.Post,
-    url: '/:id/actions',
-    schema: postAction,
-    preHandler: optionalIsAuthenticated,
-    handler: async (request) => {
+  fastify.post<{ Params: IdParam; Body: { type: string; extra?: { [key: string]: unknown } } }>(
+    '/:id/actions',
+    {
+      schema: postAction,
+      preHandler: optionalIsAuthenticated,
+    },
+    async (request) => {
       const {
         user,
         params: { id: itemId },
@@ -148,15 +148,13 @@ const plugin: FastifyPluginAsync<GraaspActionsOptions> = async (fastify) => {
         ]);
       });
     },
-  });
+  );
 
   // export actions matching the given `id`
-  fastify.route<{ Params: IdParam; Querystring: { format?: ExportActionsFormatting } }>({
-    method: 'POST',
-    url: '/:id/actions/export',
-    schema: exportAction,
-    preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
-    handler: async (request, reply) => {
+  fastify.post<{ Params: IdParam; Querystring: { format?: ExportActionsFormatting } }>(
+    '/:id/actions/export',
+    { schema: exportAction, preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)] },
+    async (request, reply) => {
       const {
         user,
         params: { id: itemId },
@@ -187,7 +185,7 @@ const plugin: FastifyPluginAsync<GraaspActionsOptions> = async (fastify) => {
       // reply no content and let the server create the archive and send the mail
       reply.status(StatusCodes.NO_CONTENT);
     },
-  });
+  );
 };
 
 export default fp(plugin);

--- a/src/services/item/plugins/action/schemas.ts
+++ b/src/services/item/plugins/action/schemas.ts
@@ -1,6 +1,8 @@
 import { S } from 'fluent-json-schema';
 import { StatusCodes } from 'http-status-codes';
 
+import { FastifySchema } from 'fastify';
+
 import {
   AggregateBy,
   AggregateFunction,
@@ -128,7 +130,7 @@ export const getAggregateActions = {
   },
 };
 
-export const exportAction = {
+export const exportAction: FastifySchema = {
   params: idParam,
   querystring: S.object().prop('format', S.enum(Object.values(ExportActionsFormatting))),
   response: {

--- a/src/services/item/plugins/action/service.ts
+++ b/src/services/item/plugins/action/service.ts
@@ -207,12 +207,12 @@ export class ActionItemService {
         actions: AppAction[];
       };
     } = {};
-    for (const { id: appId } of [item, ...descendants].filter(
-      ({ type }) => type === ItemType.APP,
-    )) {
+    const appItems = [item, ...descendants].filter(({ type }) => type === ItemType.APP);
+    for (const { id: appId } of appItems) {
       const appData = await repositories.appDataRepository.getForItem(
         appId,
         {},
+        // needs investigating: does this mean a reader could export the actions of an item and see all users responses ?
         PermissionLevel.Admin,
       );
       // TODO member id?

--- a/src/services/member/controller.test.ts
+++ b/src/services/member/controller.test.ts
@@ -19,7 +19,7 @@ import {
   FILE_METADATA_MIN_PAGE,
   FILE_METADATA_MIN_PAGE_SIZE,
 } from './constants';
-import { Actor, Member } from './entities/member';
+import { Member } from './entities/member';
 import { saveMember } from './test/fixtures/members';
 
 jest.mock('node-fetch');
@@ -55,7 +55,7 @@ describe('Member Controller', () => {
   });
   beforeEach(async () => {
     member = await saveMember();
-    mockAuthenticate(member as Actor);
+    mockAuthenticate(member);
     mockSendEmail = jest.spyOn(resolveDependency(MailerService), 'sendEmail');
   });
   afterEach(async () => {

--- a/src/services/member/controller.ts
+++ b/src/services/member/controller.ts
@@ -72,8 +72,7 @@ const controller: FastifyPluginAsync = async (fastify) => {
         pageSize < FILE_METADATA_MIN_PAGE_SIZE ||
         pageSize > FILE_METADATA_MAX_PAGE_SIZE
       ) {
-        reply.status(StatusCodes.BAD_REQUEST).send();
-        return;
+        return reply.status(StatusCodes.BAD_REQUEST).send();
       }
       const member = asDefined(user?.account);
       assertIsMember(member);
@@ -216,13 +215,16 @@ const controller: FastifyPluginAsync = async (fastify) => {
         await memberService.patch(repositories, member.id, {
           email: emailModification.newEmail,
         });
+
+        // we send the email asynchronously without awaiting
         memberService.mailConfirmEmailChangeRequest(
           member.email,
           emailModification.newEmail,
           member.lang,
         );
-        return reply.status(StatusCodes.NO_CONTENT).send();
       });
+      // this needs to be outside the transaction
+      return reply.status(StatusCodes.NO_CONTENT).send();
     },
   );
 };

--- a/src/services/member/plugins/thumbnail/index.ts
+++ b/src/services/member/plugins/thumbnail/index.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { fastifyMultipart } from '@fastify/multipart';
 import { FastifyPluginAsync } from 'fastify';
 
-import { ThumbnailSizeType } from '@graasp/sdk';
+import { MAX_THUMBNAIL_SIZE, ThumbnailSizeType } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../di/utils';
 import { IdParam } from '../../../../types';
@@ -12,7 +12,6 @@ import { buildRepositories } from '../../../../utils/repositories';
 import { isAuthenticated, optionalIsAuthenticated } from '../../../auth/plugins/passport';
 import { matchOne } from '../../../authorization';
 import FileService from '../../../file/service';
-import { DEFAULT_MAX_FILE_SIZE } from '../../../file/utils/constants';
 import { UploadEmptyFileError, UploadFileUnexpectedError } from '../../../file/utils/errors';
 import { assertIsMember } from '../../entities/member';
 import { validatedMemberAccountRole } from '../../strategies/validatedMemberAccountRole';
@@ -26,7 +25,7 @@ type GraaspThumbnailsOptions = {
 };
 
 const plugin: FastifyPluginAsync<GraaspThumbnailsOptions> = async (fastify, options) => {
-  const { maxFileSize = DEFAULT_MAX_FILE_SIZE } = options;
+  const { maxFileSize = MAX_THUMBNAIL_SIZE } = options;
   const { db } = fastify;
   const fileService = resolveDependency(FileService);
   const thumbnailService = resolveDependency(MemberThumbnailService);


### PR DESCRIPTION
In this PR: I fix the structure of the apps file in the exported zip.

Now the structure is as follows:
 - In JSON, there will be a single file `apps.json` that will contain:
    ```json
    {
      "actions": [ array of actions ],
      "data": [ array of data ],
      "settings": [ array of data ],
    }
    ```
- In CSV, there will be 3 files, `app_actions.csv`, `app_data.csv` and `app_settings.csv` which will contain tabular data from all items.
