### PR TITLE
fix: remove dependency to fix deploy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG NODE_VERSION=20
 ARG ALPINE_VERSION=3.19
 
 # Variable passed as a build arg. Represents the tag or git sha used for the build
-ARG APP_VERSION 
+ARG APP_VERSION
 
 ##############################
 ### Build Application Step ###

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "http-status-codes": "2.3.0",
     "i18next": "23.15.2",
     "ioredis": "5.4.1",
-    "is-url-http": "2.3.8",
     "jsonwebtoken": "9.0.2",
     "lodash.groupby": "4.6.0",
     "lodash.partition": "4.6.0",
@@ -118,6 +117,7 @@
     "tmp-promise": "3.0.3",
     "tsyringe": "4.8.0",
     "typeorm": "0.3.19",
+    "url-http": "1.2.2",
     "uuid": "10.0.0",
     "ws": "8.18.0",
     "yazl": "2.5.1"
@@ -171,7 +171,7 @@
     "wait-for-expect": "3.0.2"
   },
   "resolutions": {
-    "sodium-native": "4.1.1"
+    "sodium-native": "4.2.0"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/src/services/item/plugins/embeddedLink/utils.ts
+++ b/src/services/item/plugins/embeddedLink/utils.ts
@@ -1,7 +1,7 @@
-import isUrlHttp from 'is-url-http';
+import urlHttp from 'url-http';
 
-export const isValidUrl = (url: string) => {
-  return isUrlHttp(ensureProtocol(url));
+export const isValidUrl = (url: string): boolean => {
+  return !!urlHttp(ensureProtocol(url));
 };
 
 export const ensureProtocol = (url: string) => {

--- a/src/services/item/plugins/embeddedLink/utils.ts
+++ b/src/services/item/plugins/embeddedLink/utils.ts
@@ -1,7 +1,8 @@
 import urlHttp from 'url-http';
 
 export const isValidUrl = (url: string): boolean => {
-  return !!urlHttp(ensureProtocol(url));
+  // url-http returns the URL href or false if it is not a URL
+  return Boolean(urlHttp(ensureProtocol(url)));
 };
 
 export const ensureProtocol = (url: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7280,7 +7280,6 @@ __metadata:
     husky: "npm:8.0.3"
     i18next: "npm:23.15.2"
     ioredis: "npm:5.4.1"
-    is-url-http: "npm:2.3.8"
     jest: "npm:29.7.0"
     jsonwebtoken: "npm:9.0.2"
     lodash.groupby: "npm:4.6.0"
@@ -7315,6 +7314,7 @@ __metadata:
     tsyringe: "npm:4.8.0"
     typeorm: "npm:0.3.19"
     typescript: "npm:5.5.4"
+    url-http: "npm:1.2.2"
     uuid: "npm:10.0.0"
     wait-for-expect: "npm:3.0.2"
     ws: "npm:8.18.0"
@@ -8030,15 +8030,6 @@ __metadata:
   dependencies:
     which-typed-array: "npm:^1.1.14"
   checksum: 10/f850ba08286358b9a11aee6d93d371a45e3c59b5953549ee1c1a9a55ba5c1dd1bd9952488ae194ad8f32a9cf5e79c8fa5f0cc4d78c00720aa0bbcf238b38062d
-  languageName: node
-  linkType: hard
-
-"is-url-http@npm:2.3.8":
-  version: 2.3.8
-  resolution: "is-url-http@npm:2.3.8"
-  dependencies:
-    url-http: "npm:~1.2.0"
-  checksum: 10/c744ec67135b9760000fa836f48807e9fdced91c9ba2314e5508e4ca9331b6c63a1e3474ae81c7921292c90bb7ad74ec71a2e4564493725956048cac3d06e7d2
   languageName: node
   linkType: hard
 
@@ -9570,12 +9561,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.13.2, nan@npm:^2.19.0":
+"nan@npm:^2.13.2":
   version: 2.19.0
   resolution: "nan@npm:2.19.0"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10/b97f680753113bcd803cb174e40baa01e04aa4cb95ee62b48841336d9c48b278a2eeff71a4a0d7315b8f639fb1e38049925d3be1c6e266c158dc8f7d95d67eaa
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.20.0":
+  version: 2.20.0
+  resolution: "nan@npm:2.20.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/5f16e4c9953075d9920229c703c1d781c0b74118ce3d9e926b448a4eef92b7d8be5ac6adc748a13a5fafb594436cbfe63250e3471aefdd78e3a0cd14603b9ba7
   languageName: node
   linkType: hard
 
@@ -9686,9 +9686,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "node-gyp@npm:10.1.0"
+"node-gyp@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "node-gyp@npm:10.2.0"
   dependencies:
     env-paths: "npm:^2.2.0"
     exponential-backoff: "npm:^3.1.1"
@@ -9696,13 +9696,13 @@ __metadata:
     graceful-fs: "npm:^4.2.6"
     make-fetch-happen: "npm:^13.0.0"
     nopt: "npm:^7.0.0"
-    proc-log: "npm:^3.0.0"
+    proc-log: "npm:^4.1.0"
     semver: "npm:^7.3.5"
-    tar: "npm:^6.1.2"
+    tar: "npm:^6.2.1"
     which: "npm:^4.0.0"
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 10/89e105e495e66cd4568af3cf79cdeb67d670eb069e33163c7781d3366470a30367c9bd8dea59e46db16370020139e5bf78b1fbc03284cb571754dfaa59744db5
+  checksum: 10/41773093b1275751dec942b985982fd4e7a69b88cae719b868babcef3880ee6168aaec8dcaa8cd0b9fa7c84873e36cc549c6cac6a124ee65ba4ce1f1cc108cfe
   languageName: node
   linkType: hard
 
@@ -10541,7 +10541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^4.2.0":
+"proc-log@npm:^4.1.0, proc-log@npm:^4.2.0":
   version: 4.2.0
   resolution: "proc-log@npm:4.2.0"
   checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
@@ -10702,14 +10702,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"re2@npm:~1.20.1":
-  version: 1.20.11
-  resolution: "re2@npm:1.20.11"
+"re2@npm:~1.21.0":
+  version: 1.21.4
+  resolution: "re2@npm:1.21.4"
   dependencies:
     install-artifact-from-github: "npm:^1.3.5"
-    nan: "npm:^2.19.0"
-    node-gyp: "npm:^10.0.1"
-  checksum: 10/a8665c861c632c67db448832a5a6a0092a1a29b8b6b731d6ce10f0017ba2871620780a745a8b2cbdd77e57ecf9e7bc8983c7ec5e10e6da6c06079a98146db443
+    nan: "npm:^2.20.0"
+    node-gyp: "npm:^10.2.0"
+  checksum: 10/926871cc84dab656afc035118c79d121211f21f4154084d7f6c05a05f746b5355f04e80a773db9ca817718dde03c561421b0a962300698c9f2eeafa4f70fd364
   languageName: node
   linkType: hard
 
@@ -11415,13 +11415,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sodium-native@npm:4.1.1":
-  version: 4.1.1
-  resolution: "sodium-native@npm:4.1.1"
+"sodium-native@npm:4.2.0":
+  version: 4.2.0
+  resolution: "sodium-native@npm:4.2.0"
   dependencies:
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.8.0"
-  checksum: 10/cb30564f07c55b2a7f8016b4df16fd2b0ede10981c6d0b4dfe20ef884f702d55884d2128f22da1ffe9a378aec43a4f0c5539aadf23c4fd3fabc5d05ead1301d2
+  checksum: 10/fa08f69a009f09657a0d9177b3febaea5f28947996bff3dd6489a4341d9eeee74b7399130af089cc261ab9995669ade85a83c38e2c7702987b920ddc0f4fb307
   languageName: node
   linkType: hard
 
@@ -11819,7 +11819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.11, tar@npm:^6.1.2":
+"tar@npm:^6.1.11, tar@npm:^6.1.2, tar@npm:^6.2.1":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
   dependencies:
@@ -12495,14 +12495,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-http@npm:~1.2.0":
-  version: 1.2.1
-  resolution: "url-http@npm:1.2.1"
+"url-http@npm:1.2.2":
+  version: 1.2.2
+  resolution: "url-http@npm:1.2.2"
   dependencies:
     punycode-regex: "npm:~1.0.1"
-    re2: "npm:~1.20.1"
+    re2: "npm:~1.21.0"
     url-regex-safe: "npm:~4.0.0"
-  checksum: 10/a40516bd5daa279c336a068fa55bd6f64f0568309d6369d4b8770d0d87cdf8b4b33e9fe9360b953222320db8911acc852c86d4035e48dbcb7e45aea0e6279dde
+  checksum: 10/4bf2cc9f308ad1d29ec61a09d8999d91a59a88b39468ce44fc328575195d74ca09855ae524f41c374a6d9e312125bf5145c00d48ee40156457bac71d7c46aba8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump resolution for `sodium-native` to `4.2.0`

Remove dependency `is-url-http` and use `url-http` instead as it requires an up-to-date version of `re2` which does not fail the build in docker