### PR TITLE
fix: update core container log group to match infra

### DIFF
--- a/.aws/graasp-dev.json
+++ b/.aws/graasp-dev.json
@@ -9,7 +9,7 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-          "awslogs-group": "/ecs/graasp-development",
+          "awslogs-group": "/ecs/graasp",
           "awslogs-region": "eu-central-1",
           "awslogs-stream-prefix": "ecs"
         }
@@ -178,7 +178,9 @@
   "family": "graasp",
   "requiresAttributes": [],
   "pidMode": null,
-  "requiresCompatibilities": ["FARGATE"],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
   "networkMode": "awsvpc",
   "runtimePlatform": {
     "operatingSystemFamily": "LINUX",


### PR DESCRIPTION
This changes the log group to match the one defined in the infrastructure