### PR TITLE
fix: fix packed tag

### DIFF
--- a/src/services/account/repository.test.ts
+++ b/src/services/account/repository.test.ts
@@ -8,7 +8,7 @@ import { AccountRepository } from './repository';
 
 const accountRepository = new AccountRepository();
 
-describe('MemberRepository', () => {
+describe('AccountRepository', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {

--- a/src/services/item/ItemWrapper.test.ts
+++ b/src/services/item/ItemWrapper.test.ts
@@ -1,0 +1,44 @@
+import { FastifyInstance } from 'fastify';
+
+import { ItemTagType } from '@graasp/sdk';
+
+import build, { clearDatabase } from '../../../test/app';
+import { ItemWrapper } from './ItemWrapper';
+import { createTag } from './plugins/itemTag/test/fixtures';
+import { ItemTestUtils } from './test/fixtures/items';
+
+const testUtils = new ItemTestUtils();
+
+describe('ItemWrapper', () => {
+  let app: FastifyInstance;
+
+  // datasource needs to be set
+  beforeAll(async () => {
+    ({ app } = await build());
+  });
+  afterAll(async () => {
+    await clearDatabase(app.db);
+    app.close();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  it('Return highest tags for child item', async () => {
+    const parentItem = testUtils.createItem();
+    const item = testUtils.createItem({ parentItem });
+
+    const publicTag = await createTag({ item, type: ItemTagType.Public });
+    const parentHiddenTag = await createTag({ item: parentItem, type: ItemTagType.Hidden });
+    const hiddenTag = await createTag({ item, type: ItemTagType.Hidden });
+    // unordered tags
+    const tags = [hiddenTag, publicTag, parentHiddenTag];
+    const itemWrapper = new ItemWrapper(item, undefined, tags);
+
+    const packedItem = itemWrapper.packed();
+    expect(packedItem.public!.id).toEqual(publicTag.id);
+    // should return parent tag, not item tag
+    expect(packedItem.hidden!.id).toEqual(parentHiddenTag.id);
+  });
+});

--- a/src/services/item/ItemWrapper.test.ts
+++ b/src/services/item/ItemWrapper.test.ts
@@ -1,13 +1,23 @@
+import { describe } from 'node:test';
+
 import { FastifyInstance } from 'fastify';
 
 import { ItemTagType } from '@graasp/sdk';
 
-import build, { clearDatabase } from '../../../test/app';
+import build, { MOCK_LOGGER, clearDatabase } from '../../../test/app';
+import { AppDataSource } from '../../plugins/datasource';
+import { buildRepositories } from '../../utils/repositories';
+import { saveMember } from '../member/test/fixtures/members';
+import { ThumbnailService } from '../thumbnail/service';
 import { ItemWrapper } from './ItemWrapper';
-import { createTag } from './plugins/itemTag/test/fixtures';
+import { ItemTag } from './plugins/itemTag/ItemTag';
+import { createTag, setItemPublic } from './plugins/itemTag/test/fixtures';
+import { ItemThumbnailService } from './plugins/thumbnail/service';
+import { ItemService } from './service';
 import { ItemTestUtils } from './test/fixtures/items';
 
 const testUtils = new ItemTestUtils();
+const rawItemTagRepository = AppDataSource.getRepository(ItemTag);
 
 describe('ItemWrapper', () => {
   let app: FastifyInstance;
@@ -25,20 +35,54 @@ describe('ItemWrapper', () => {
     jest.clearAllMocks();
   });
 
-  it('Return highest tags for child item', async () => {
-    const parentItem = testUtils.createItem();
-    const item = testUtils.createItem({ parentItem });
+  describe('createPackedItems', () => {
+    it('Return highest tags for child item', async () => {
+      const repositories = buildRepositories();
+      const itemThumbnailService = new ItemThumbnailService(
+        {} as unknown as ItemService,
+        {} as unknown as ThumbnailService,
+        MOCK_LOGGER,
+      );
+      jest.spyOn(itemThumbnailService, 'getUrlsByItems').mockImplementation(async () => ({}));
 
-    const publicTag = await createTag({ item, type: ItemTagType.Public });
-    const parentHiddenTag = await createTag({ item: parentItem, type: ItemTagType.Hidden });
-    const hiddenTag = await createTag({ item, type: ItemTagType.Hidden });
-    // unordered tags
-    const tags = [hiddenTag, publicTag, parentHiddenTag];
-    const itemWrapper = new ItemWrapper(item, undefined, tags);
+      const actor = await saveMember();
+      const { item: parentItem } = await testUtils.saveItemAndMembership({});
+      const { item } = await testUtils.saveItemAndMembership({ parentItem });
 
-    const packedItem = itemWrapper.packed();
-    expect(packedItem.public!.id).toEqual(publicTag.id);
-    // should return parent tag, not item tag
-    expect(packedItem.hidden!.id).toEqual(parentHiddenTag.id);
+      const hiddenTag = await rawItemTagRepository.save(
+        await createTag({ item, type: ItemTagType.Hidden }),
+      );
+      const parentPublicTag = await setItemPublic(parentItem);
+      await setItemPublic(item);
+
+      const [packedItem] = await ItemWrapper.createPackedItems(
+        actor,
+        repositories,
+        itemThumbnailService,
+        [item],
+      );
+      expect(packedItem.public!.id).toEqual(parentPublicTag.id);
+      // should return parent tag, not item tag
+      expect(packedItem.hidden!.id).toEqual(hiddenTag.id);
+    });
+  });
+
+  describe('packed', () => {
+    it('Return highest tags for child item', async () => {
+      const parentItem = testUtils.createItem();
+      const item = testUtils.createItem({ parentItem });
+
+      const publicTag = await createTag({ item, type: ItemTagType.Public });
+      const parentHiddenTag = await createTag({ item: parentItem, type: ItemTagType.Hidden });
+      const hiddenTag = await createTag({ item, type: ItemTagType.Hidden });
+      // unordered tags
+      const tags = [hiddenTag, publicTag, parentHiddenTag];
+      const itemWrapper = new ItemWrapper(item, undefined, tags);
+
+      const packedItem = itemWrapper.packed();
+      expect(packedItem.public!.id).toEqual(publicTag.id);
+      // should return parent tag, not item tag
+      expect(packedItem.hidden!.id).toEqual(parentHiddenTag.id);
+    });
   });
 });

--- a/src/services/item/ItemWrapper.ts
+++ b/src/services/item/ItemWrapper.ts
@@ -148,6 +148,11 @@ export class ItemWrapper {
    * @returns item unit with permission
    */
   packed(): PackedItem {
+    // sort tags to retrieve most relevant (highest) tag first
+    if (this.tags) {
+      this.tags.sort((a, b) => (a.item.path.length > b.item.path.length ? 1 : -1));
+    }
+
     return {
       ...this.item,
       permission: this.actorPermission?.permission ?? null,

--- a/src/services/item/ItemWrapper.ts
+++ b/src/services/item/ItemWrapper.ts
@@ -129,15 +129,21 @@ export class ItemWrapper {
 
     const itemsThumbnails = await itemThumbnailService.getUrlsByItems(items);
 
-    // TODO
     return items.map((item) => {
       const permission = m.data[item.id][0]?.permission;
       const thumbnails = itemsThumbnails[item.id];
+
+      // sort tags to retrieve most relevant (highest) tag first
+      const thisTags = tags?.data?.[item.id] ?? [];
+      if (thisTags) {
+        thisTags.sort((a, b) => (a.item.path.length > b.item.path.length ? 1 : -1));
+      }
+
       return {
         ...item,
         permission,
-        hidden: (tags?.data?.[item.id] ?? [])?.find((t) => t.type === ItemTagType.Hidden),
-        public: (tags?.data?.[item.id] ?? [])?.find((t) => t.type === ItemTagType.Public),
+        hidden: thisTags.find((t) => t.type === ItemTagType.Hidden),
+        public: thisTags.find((t) => t.type === ItemTagType.Public),
         ...(thumbnails ? { thumbnails } : {}),
       } as unknown as PackedItem;
     });

--- a/src/services/item/plugins/itemTag/test/fixtures.ts
+++ b/src/services/item/plugins/itemTag/test/fixtures.ts
@@ -1,3 +1,5 @@
+import { DeepPartial } from 'typeorm';
+
 import { ItemTagType } from '@graasp/sdk';
 
 import { Member } from '../../../../member/entities/member';
@@ -6,4 +8,8 @@ import { ItemTag } from '../ItemTag';
 
 export const setItemPublic = async (item: Item, creator?: Member | null) => {
   return ItemTag.save({ item, creator, type: ItemTagType.Public });
+};
+
+export const createTag = async (args: DeepPartial<ItemTag>) => {
+  return ItemTag.create(args);
 };

--- a/src/services/item/test/index.read.test.ts
+++ b/src/services/item/test/index.read.test.ts
@@ -1574,6 +1574,7 @@ describe('Item routes tests', () => {
         });
 
         const data = response.json();
+        expect(data).toHaveLength(descendants.length);
         descendants.forEach(({ id }) => {
           expectPackedItem(
             data.find(({ id: thisId }) => thisId === id),

--- a/src/services/item/test/index.read.test.ts
+++ b/src/services/item/test/index.read.test.ts
@@ -1574,7 +1574,6 @@ describe('Item routes tests', () => {
         });
 
         const data = response.json();
-        expect(data).toHaveLength(descendants.length);
         descendants.forEach(({ id }) => {
           expectPackedItem(
             data.find(({ id: thisId }) => thisId === id),


### PR DESCRIPTION
Packed returns tags such as `public` and `hidden`. But sometimes it does not return the correct one: we want to return the highest inherited tag. It happens because it depends on the array order (usually fetched from db). I've also added sorting for `createPackedItems`.

That will hopefully fix the flacky test. 

I don't think it's the best fix, I would prefer to order from the db, or actually get the correct tag right away from the db. 
With the packed we actually removed the use of `GET /tags` and so we can remove `ResultOf` from getting tags.

I would apply this fix first, then I will deprecate getting tags, and finally remove `ResultOf`. 

fix #1547 