### PR TITLE
fix: allow guests in members app context, allow to get context as guest

### DIFF
--- a/src/services/item/plugins/app/appData/test/index.test.ts
+++ b/src/services/item/plugins/app/appData/test/index.test.ts
@@ -10,7 +10,7 @@ import { AppDataSource } from '../../../../../../plugins/datasource';
 import { APP_ITEMS_PREFIX } from '../../../../../../utils/config';
 import { Guest } from '../../../../../itemLogin/entities/guest';
 import { Member } from '../../../../../member/entities/member';
-import { expectMinimalMember, saveMember } from '../../../../../member/test/fixtures/members';
+import { expectAccount, saveMember } from '../../../../../member/test/fixtures/members';
 import { AppTestUtils } from '../../test/fixtures';
 import { AppData } from '../appData';
 import { PreventUpdateAppDataFile } from '../errors';
@@ -321,8 +321,8 @@ describe('App Data Tests', () => {
         // we don't use the util function because it does not contain an id for iteration
         expect(newAppData.type).toEqual(payload.type);
         expect(newAppData.data).toEqual(payload.data);
-        expectMinimalMember(newAppData.account, bob);
-        expectMinimalMember(newAppData.creator, actor);
+        expectAccount(newAppData.account, bob);
+        expectAccount(newAppData.creator, actor);
 
         const savedAppData = await new AppDataRepository().getOne(newAppData.id);
         expectAppData([newAppData], [savedAppData]);
@@ -363,8 +363,8 @@ describe('App Data Tests', () => {
         // we don't use the util function because it does not contain an id for iteration
         expect(newAppData.type).toEqual(payload.type);
         expect(newAppData.data).toEqual(payload.data);
-        expectMinimalMember(newAppData.account, bob);
-        expectMinimalMember(newAppData.creator, actor);
+        expectAccount(newAppData.account, bob);
+        expectAccount(newAppData.creator, actor);
 
         const savedAppData = await new AppDataRepository().getOne(newAppData.id);
         expectAppData([newAppData], [savedAppData]);

--- a/src/services/item/plugins/app/schemas.ts
+++ b/src/services/item/plugins/app/schemas.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from 'http-status-codes';
 import { FastifySchema } from 'fastify';
 
 import { customType, registerSchemaAsRef } from '../../../../plugins/typebox';
-import { memberSchemaRef } from '../../../member/schemas';
+import { accountSchemaRef } from '../../../account/schemas';
 import { itemIdSchemaRef, itemSchemaRef } from '../../schema';
 
 export const appContextSchemaRef = registerSchemaAsRef(
@@ -14,7 +14,7 @@ export const appContextSchemaRef = registerSchemaAsRef(
     {
       // Object Definition
       item: itemSchemaRef,
-      members: Type.Array(memberSchemaRef),
+      members: Type.Array(accountSchemaRef),
     },
     {
       // Schema Options

--- a/src/services/item/plugins/app/service.ts
+++ b/src/services/item/plugins/app/service.ts
@@ -70,14 +70,13 @@ export class AppService {
     itemId: string,
     requestDetails?: AuthTokenSubject,
   ) {
-    const { itemRepository, memberRepository } = repositories;
+    const { itemRepository, accountRepository } = repositories;
 
     const item = await itemRepository.getOneOrThrow(itemId);
     if (!isItemType(item, ItemType.APP)) {
       throw new Error('Item is not an app');
     }
-    const member = actorId ? await memberRepository.get(actorId) : undefined;
-
+    const account = actorId ? await accountRepository.get(actorId) : undefined;
     if (requestDetails) {
       const { itemId: tokenItemId } = requestDetails;
       checkTargetItemAndTokenItemMatch(itemId, tokenItemId);
@@ -85,8 +84,8 @@ export class AppService {
 
     // return member data only if authenticated
     let members: Member[] = [];
-    if (member) {
-      members = await this.getTreeMembers(member, repositories, item);
+    if (account) {
+      members = await this.getTreeMembers(account, repositories, item);
     }
 
     return { item, members };

--- a/src/services/itemLogin/test/index.test.ts
+++ b/src/services/itemLogin/test/index.test.ts
@@ -26,7 +26,7 @@ import { ItemTag } from '../../item/plugins/itemTag/ItemTag';
 import { ItemTestUtils } from '../../item/test/fixtures/items';
 import { ItemMembership } from '../../itemMembership/entities/ItemMembership';
 import { Member } from '../../member/entities/member';
-import { expectMinimalMember, saveMember } from '../../member/test/fixtures/members';
+import { expectAccount, saveMember } from '../../member/test/fixtures/members';
 import { Guest } from '../entities/guest';
 import { GuestPassword } from '../entities/guestPassword';
 import { ItemLoginSchema as ItemLoginSchemaEntity } from '../entities/itemLoginSchema';
@@ -80,7 +80,7 @@ export async function saveItemLoginSchema({
 }
 
 const expectItemLogin = (member, m) => {
-  expectMinimalMember(member, m);
+  expectAccount(member, m);
 };
 
 describe('Item Login Tests', () => {

--- a/src/services/member/test/fixtures/members.ts
+++ b/src/services/member/test/fixtures/members.ts
@@ -2,6 +2,7 @@ import { AccountType, CompleteMember, MemberFactory } from '@graasp/sdk';
 import { DEFAULT_LANG } from '@graasp/translations';
 
 import { AppDataSource } from '../../../../plugins/datasource';
+import { Account } from '../../../account/entities/account';
 import { Member } from '../../entities/member';
 
 export const saveMember = async (m: CompleteMember = MemberFactory()) => {
@@ -30,9 +31,9 @@ export const expectMember = (
   expect(m.extra).toEqual(validation.extra ?? { lang: DEFAULT_LANG });
 };
 
-export const expectMinimalMember = (
-  m: Member | undefined | null,
-  validation: Partial<Member> & Pick<Member, 'name' | 'email'>,
+export const expectAccount = (
+  m: Account | undefined | null,
+  validation: Partial<Account> & Pick<Account, 'name' | 'id'>,
 ) => {
   if (!m) {
     throw 'member does not exist';

--- a/src/services/member/test/setup.ts
+++ b/src/services/member/test/setup.ts
@@ -7,14 +7,14 @@ import { HttpMethod, ItemLoginSchemaType } from '@graasp/sdk';
 
 import { AppDataSource } from '../../../plugins/datasource';
 import { ITEMS_ROUTE_PREFIX } from '../../../utils/config';
-import { Account } from '../../account/entities/account';
 import { ItemTestUtils } from '../../item/test/fixtures/items';
+import { Guest } from '../../itemLogin/entities/guest';
 import { ItemLoginSchema } from '../../itemLogin/entities/itemLoginSchema';
 
 const testUtils = new ItemTestUtils();
 
 const rawItemLoginSchemaRepository = AppDataSource.getRepository(ItemLoginSchema);
-const rawAccountRepository = AppDataSource.getRepository(Account);
+const rawGuestRepository = AppDataSource.getRepository(Guest);
 
 /**
  * Setup environment for a guest logging in
@@ -36,7 +36,7 @@ export const setupGuest = async (app: FastifyInstance) => {
   });
 
   // necessary to fetch complete guest to return correct current account
-  const currentGuest = await rawAccountRepository.findOneBy({ id: loginResponse.json().id });
+  const currentGuest = await rawGuestRepository.findOneBy({ id: loginResponse.json().id });
   assert(currentGuest);
 
   return { guest: currentGuest };


### PR DESCRIPTION
Restrict `members` in schema to `account`.
Also fixed getting context as a guest.

fix #1553 