### PR TITLE
fix: allow local file in update schema

### DIFF
--- a/src/services/item/plugins/file/schema.ts
+++ b/src/services/item/plugins/file/schema.ts
@@ -1,7 +1,4 @@
 import { Type } from '@sinclair/typebox';
-import { S } from 'fluent-json-schema';
-
-import { FileItemType } from '@graasp/sdk';
 
 import { customType } from '../../../../plugins/typebox';
 import { entityIdSchemaRef } from '../../../../schemas/global';
@@ -27,14 +24,3 @@ export const download = {
     { additionalProperties: false },
   ),
 };
-
-export const updateSchema = (type: FileItemType) =>
-  S.object()
-    // TODO: .additionalProperties(false) in schemas don't seem to work properly and
-    // are very counter-intuitive. We should change to JTD format (as soon as it is supported)
-    // .additionalProperties(false)
-    .prop(
-      type,
-      S.object().additionalProperties(false).prop('altText', S.string()).required(['altText']),
-    )
-    .required([type]);

--- a/src/services/item/plugins/file/test/index.test.ts
+++ b/src/services/item/plugins/file/test/index.test.ts
@@ -524,6 +524,15 @@ describe('File Item routes tests', () => {
       }));
     });
 
+    it('Edit name for file item', async () => {
+      const response = await app.inject({
+        method: HttpMethod.Patch,
+        url: `${ITEMS_ROUTE_PREFIX}/${item.id}`,
+        payload: { name: 'newName' },
+      });
+      expect(response.json().name).toEqual('newName');
+    });
+
     it('Edit file item altText', async () => {
       const response = await app.inject({
         method: HttpMethod.Patch,

--- a/src/services/item/schemas.ts
+++ b/src/services/item/schemas.ts
@@ -124,6 +124,14 @@ export const itemUpdateSchemaRef = registerSchemaAsRef(
               ),
               Type.Object(
                 {
+                  file: Type.Object({
+                    altText: Type.String(),
+                  }),
+                },
+                { additionalProperties: false },
+              ),
+              Type.Object(
+                {
                   embeddedLink: Type.Object(
                     { url: Type.String() },
                     { additionalProperties: false },


### PR DESCRIPTION
Added handling for local files. Also added a test, and removed a non-used fn.

PS: file edition is actually broken because the frontend sends the complete extra, while the backend only accepts editable fields. PR for the frontend: https://github.com/graasp/graasp-builder/pull/1552