### PR TITLE
feat: add tag and item to tag entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "5.0.0",
+    "@graasp/sdk": "github:graasp/graasp-sdk#tag-type",
     "@graasp/translations": "1.40.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "github:graasp/graasp-sdk#tag-type",
+    "@graasp/sdk": "5.1.0",
     "@graasp/translations": "1.40.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.1",

--- a/src/migrations/1730995045487-new-tags.ts
+++ b/src/migrations/1730995045487-new-tags.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1730995045487 implements MigrationInterface {
+  name = 'new-tags-1730995045487';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."tag_category_enum" AS ENUM('level', 'discipline', 'resource-type')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "tag" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "category" "public"."tag_category_enum" NOT NULL, CONSTRAINT "tag-name-category" UNIQUE ("name", "category"), CONSTRAINT "PK_8e4052373c579afc1471f526760" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "item_tag" ("tag_id" uuid NOT NULL, "item_id" uuid NOT NULL, CONSTRAINT "UQ_item_tag" UNIQUE ("item_id", "tag_id"), CONSTRAINT "PK_a04bb2298e37d95233a0c92347e" PRIMARY KEY ("tag_id", "item_id"))`,
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_item_tag_item" ON "item_tag" ("item_id") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_item_tag_item"`);
+    await queryRunner.query(`DROP TABLE "item_tag"`);
+    await queryRunner.query(`DROP TABLE "tag"`);
+    await queryRunner.query(`DROP TYPE "public"."tag_category_enum"`);
+  }
+}

--- a/src/migrations/1730995045487-new-tags.ts
+++ b/src/migrations/1730995045487-new-tags.ts
@@ -8,7 +8,7 @@ export class Migrations1730995045487 implements MigrationInterface {
       `CREATE TYPE "public"."tag_category_enum" AS ENUM('level', 'discipline', 'resource-type')`,
     );
     await queryRunner.query(
-      `CREATE TABLE "tag" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "category" "public"."tag_category_enum" NOT NULL, CONSTRAINT "tag-name-category" UNIQUE ("name", "category"), CONSTRAINT "PK_8e4052373c579afc1471f526760" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "tag" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "category" "public"."tag_category_enum" NOT NULL, CONSTRAINT "UQ_tag_name_category" UNIQUE ("name", "category"), CONSTRAINT "PK_8e4052373c579afc1471f526760" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE TABLE "item_tag" ("tag_id" uuid NOT NULL, "item_id" uuid NOT NULL, CONSTRAINT "UQ_item_tag" UNIQUE ("item_id", "tag_id"), CONSTRAINT "PK_a04bb2298e37d95233a0c92347e" PRIMARY KEY ("tag_id", "item_id"))`,

--- a/src/migrations/1730995045487-new-tags.ts
+++ b/src/migrations/1730995045487-new-tags.ts
@@ -5,10 +5,10 @@ export class Migrations1730995045487 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TYPE "public"."tag_category_enum" AS ENUM('level', 'discipline', 'resource-type')`,
+      `CREATE TYPE "tag_category_enum" AS ENUM('level', 'discipline', 'resource-type')`,
     );
     await queryRunner.query(
-      `CREATE TABLE "tag" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "category" "public"."tag_category_enum" NOT NULL, CONSTRAINT "UQ_tag_name_category" UNIQUE ("name", "category"), CONSTRAINT "PK_8e4052373c579afc1471f526760" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "tag" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "category" "tag_category_enum" NOT NULL, CONSTRAINT "UQ_tag_name_category" UNIQUE ("name", "category"), CONSTRAINT "PK_8e4052373c579afc1471f526760" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE TABLE "item_tag" ("tag_id" uuid NOT NULL, "item_id" uuid NOT NULL, CONSTRAINT "UQ_item_tag" UNIQUE ("item_id", "tag_id"), CONSTRAINT "PK_a04bb2298e37d95233a0c92347e" PRIMARY KEY ("tag_id", "item_id"))`,
@@ -19,13 +19,13 @@ export class Migrations1730995045487 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "item_tag" ADD CONSTRAINT "FK_39b492fda03c7ac846afe164b58" FOREIGN KEY ("item_id") REFERENCES "item"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
-    await queryRunner.query(`CREATE INDEX "IDX_item_tag_item" ON "item_tag" ("item_id") `);
+    await queryRunner.query(`CREATE INDEX "IDX_item_tag_item" ON "item_tag" ("item_id")`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "public"."IDX_item_tag_item"`);
+    await queryRunner.query(`DROP INDEX "IDX_item_tag_item"`);
     await queryRunner.query(`DROP TABLE "item_tag"`);
     await queryRunner.query(`DROP TABLE "tag"`);
-    await queryRunner.query(`DROP TYPE "public"."tag_category_enum"`);
+    await queryRunner.query(`DROP TYPE "tag_category_enum"`);
   }
 }

--- a/src/migrations/1730995045487-new-tags.ts
+++ b/src/migrations/1730995045487-new-tags.ts
@@ -13,6 +13,12 @@ export class Migrations1730995045487 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TABLE "item_tag" ("tag_id" uuid NOT NULL, "item_id" uuid NOT NULL, CONSTRAINT "UQ_item_tag" UNIQUE ("item_id", "tag_id"), CONSTRAINT "PK_a04bb2298e37d95233a0c92347e" PRIMARY KEY ("tag_id", "item_id"))`,
     );
+    await queryRunner.query(
+      `ALTER TABLE "item_tag" ADD CONSTRAINT "FK_16ab8afb42f763f7cbaa4bff66a" FOREIGN KEY ("tag_id") REFERENCES "tag"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "item_tag" ADD CONSTRAINT "FK_39b492fda03c7ac846afe164b58" FOREIGN KEY ("item_id") REFERENCES "item"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
     await queryRunner.query(`CREATE INDEX "IDX_item_tag_item" ON "item_tag" ("item_id") `);
   }
 

--- a/src/plugins/datasource.ts
+++ b/src/plugins/datasource.ts
@@ -26,6 +26,8 @@ import { ItemValidationGroup } from '../services/item/plugins/publication/valida
 import { ItemValidationReview } from '../services/item/plugins/publication/validation/entities/itemValidationReview';
 import { RecycledItemData } from '../services/item/plugins/recycled/RecycledItemData';
 import { ShortLink } from '../services/item/plugins/shortLink/entities/ShortLink';
+import { ItemTag } from '../services/item/plugins/tag/ItemTag.entity';
+import { Tag } from '../services/item/plugins/tag/Tag.entity';
 import { Guest } from '../services/itemLogin/entities/guest';
 import { GuestPassword } from '../services/itemLogin/entities/guestPassword';
 import { ItemLoginSchema } from '../services/itemLogin/entities/itemLoginSchema';
@@ -106,6 +108,8 @@ export const AppDataSource = new DataSource({
     MemberProfile,
     ShortLink,
     ItemGeolocation,
+    Tag,
+    ItemTag,
   ],
   // refer to built files in js because it cannot run ts files
   migrations: ['dist/migrations/*.js'],

--- a/src/services/item/plugins/tag/ItemTag.entity.ts
+++ b/src/services/item/plugins/tag/ItemTag.entity.ts
@@ -15,11 +15,11 @@ export class ItemTag extends BaseEntity {
   @PrimaryColumn({ name: 'item_id' })
   itemId: UUID;
 
-  @OneToOne(() => Tag, (t) => t.id)
+  @OneToOne(() => Tag, (t) => t.id, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'tag_id' })
   tag: Tag;
 
-  @OneToOne(() => Item, (item) => item.id)
+  @OneToOne(() => Item, (item) => item.id, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'item_id' })
   item: Item;
 }

--- a/src/services/item/plugins/tag/ItemTag.entity.ts
+++ b/src/services/item/plugins/tag/ItemTag.entity.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, Entity, Index, JoinColumn, OneToOne, PrimaryColumn, Unique } from 'typeorm';
+
+import { UUID } from '@graasp/sdk';
+
+import { Item } from '../../entities/Item';
+import { Tag } from './Tag.entity';
+
+@Entity()
+@Unique('UQ_item_tag', ['itemId', 'tagId'])
+@Index('IDX_item_tag_item', ['itemId'])
+export class ItemTag extends BaseEntity {
+  @PrimaryColumn({ name: 'tag_id' })
+  tagId: UUID;
+
+  @PrimaryColumn({ name: 'item_id' })
+  itemId: UUID;
+
+  @OneToOne(() => Tag, (t) => t.id)
+  @JoinColumn({ name: 'tag_id' })
+  tag: Tag;
+
+  @OneToOne(() => Item, (item) => item.id)
+  @JoinColumn({ name: 'item_id' })
+  item: Item;
+}

--- a/src/services/item/plugins/tag/Tag.entity.ts
+++ b/src/services/item/plugins/tag/Tag.entity.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 import { TagCategory } from '@graasp/sdk';
 
 @Entity()
-@Unique('tag-name-category', ['name', 'category'])
+@Unique('UQ_tag_name_category', ['name', 'category'])
 export class Tag extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string = v4();

--- a/src/services/item/plugins/tag/Tag.entity.ts
+++ b/src/services/item/plugins/tag/Tag.entity.ts
@@ -1,0 +1,20 @@
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { TagCategory } from '@graasp/sdk';
+
+@Entity()
+@Unique('tag-name-category', ['name', 'category'])
+export class Tag extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string = v4();
+
+  @Column()
+  name: string;
+
+  @Column({
+    type: 'enum',
+    enum: Object.values(TagCategory),
+  })
+  category: TagCategory;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#tag-type":
-  version: 5.0.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=bbe2a2e2dfd2b018bad788cd61c378fc317f2945"
+"@graasp/sdk@npm:5.1.0":
+  version: 5.1.0
+  resolution: "@graasp/sdk@npm:5.1.0"
   dependencies:
     "@faker-js/faker": "npm:9.2.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/a3c2888ac9b267c76e65dda760863c8a1da5b18e032c6ca6ff9652ea7c1542294c1bb744e5b2dbf907903524b4cf1d6e61f434a7da2137b8722752bc234088c0
+  checksum: 10/3a9b52fffa1eda465795ccdf92d02fc74c6da2e32a59dfbc78f77046757a8a749ccd46963fe4dd4e128d89743e928e82f160e33e368f1bcc7d1d6d7b63392ed4
   languageName: node
   linkType: hard
 
@@ -7454,7 +7454,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "github:graasp/graasp-sdk#tag-type"
+    "@graasp/sdk": "npm:5.1.0"
     "@graasp/translations": "npm:1.40.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:5.0.0":
+"@graasp/sdk@github:graasp/graasp-sdk#tag-type":
   version: 5.0.0
-  resolution: "@graasp/sdk@npm:5.0.0"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=bbe2a2e2dfd2b018bad788cd61c378fc317f2945"
   dependencies:
     "@faker-js/faker": "npm:9.2.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/33f0d46a2f00e70b69212f1a7104e967ab6c0732dc4c58f561076bfcd04580702bec2ab2c3dc7ce757baed5d62a9e1ee756e8a05d359e7dac2da035704ef5f62
+  checksum: 10/a3c2888ac9b267c76e65dda760863c8a1da5b18e032c6ca6ff9652ea7c1542294c1bb744e5b2dbf907903524b4cf1d6e61f434a7da2137b8722752bc234088c0
   languageName: node
   linkType: hard
 
@@ -7454,7 +7454,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:5.0.0"
+    "@graasp/sdk": "github:graasp/graasp-sdk#tag-type"
     "@graasp/translations": "npm:1.40.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"


### PR DESCRIPTION
Create entities and migrations for creating those tables.
The migration to go from `item.settings.tags` -> `tags` will be done after, when the ip is ready (otherwise we might miss some tags that are added in between).

I'm not fan of the naming `ItemToTag`, I think it should be `ItemTag`. Should we move the current `ItemTag` to `ItemStatus`?

close #1609