### PR TITLE
ON HOLD feat: update get memberships for one item

### DIFF
--- a/src/services/itemMembership/index.ts
+++ b/src/services/itemMembership/index.ts
@@ -9,7 +9,7 @@ import { isAuthenticated, optionalIsAuthenticated } from '../auth/plugins/passpo
 import { matchOne } from '../authorization';
 import { validatedMemberAccountRole } from '../member/strategies/validatedMemberAccountRole';
 import MembershipRequestAPI from './plugins/MembershipRequest';
-import { create, createMany, deleteOne, getItems, updateOne } from './schemas';
+import { create, createMany, deleteOne, getForItem, updateOne } from './schemas';
 import { ItemMembershipService } from './service';
 import { membershipWsHooks } from './ws/hooks';
 
@@ -32,13 +32,11 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
 
       fastify.register(membershipWsHooks);
 
-      // get many item's memberships
-      // returns empty for item not found
       fastify.get(
-        '/',
-        { schema: getItems, preHandler: optionalIsAuthenticated },
-        async ({ user, query: { itemId: ids } }) => {
-          return itemMembershipService.getForManyItems(user?.account, buildRepositories(), ids);
+        '/:itemId',
+        { schema: getForItem, preHandler: optionalIsAuthenticated },
+        async ({ user, params: { itemId } }) => {
+          return itemMembershipService.getForItem(user?.account, buildRepositories(), itemId);
         },
       );
 

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -373,6 +373,15 @@ export class ItemMembershipRepository extends MutableRepository<
     });
   }
 
+  async getForItem(item: Item): Promise<ItemMembership[]> {
+    const query = this.repository
+      .createQueryBuilder('item_membership')
+      .leftJoinAndSelect('item_membership.item', 'item', 'item.path @> :path', { path: item.path })
+      .leftJoinAndSelect('item_membership.account', 'account');
+
+    return await query.getMany();
+  }
+
   async getForManyItems(
     items: Item[],
     {

--- a/src/services/itemMembership/schemas.ts
+++ b/src/services/itemMembership/schemas.ts
@@ -66,17 +66,16 @@ export const createMany = {
   },
 } as const satisfies FastifySchema;
 
-// schema for getting many item's memberships
-export const getItems = {
-  querystring: Type.Object(
-    { itemId: Type.Array(customType.UUID()) },
-    { additionalProperties: false },
-  ),
+export const getForItem = {
+  operationId: 'getMembershipsForItem',
+  tags: ['item-membership'],
+  summary: 'Get item memberships for item',
+  description: 'Get item memberships for item for admin purpose.',
+
+  params: customType.StrictObject({ itemId: customType.UUID() }),
   response: {
-    [StatusCodes.OK]: Type.Object({
-      data: Type.Record(Type.String({ format: 'uuid' }), Type.Array(itemMembershipSchemaRef)),
-      errors: Type.Array(errorSchemaRef),
-    }),
+    [StatusCodes.OK]: Type.Array(itemMembershipSchemaRef),
+    '4xx': errorSchemaRef,
   },
 } as const satisfies FastifySchema;
 

--- a/src/services/itemMembership/service.ts
+++ b/src/services/itemMembership/service.ts
@@ -71,15 +71,18 @@ export class ItemMembershipService {
     return await itemMembershipRepository.getByAccountAndItem(accountId, itemId);
   }
 
-  async getForManyItems(actor: Actor, repositories: Repositories, itemIds: string[]) {
-    // get memberships, containing item
-
+  /**
+   * Get inherited item memberships for item
+   * @param actor user requesting memberships
+   * @param repositories
+   * @param itemId item to get memberships for
+   * @returns item memberships
+   */
+  async getForItem(actor: Actor, repositories: Repositories, itemId: UUID) {
     const { itemMembershipRepository } = repositories;
 
-    const items = await this.itemService.getMany(actor, repositories, itemIds);
-    const result = await itemMembershipRepository.getForManyItems(Object.values(items.data));
-
-    return { data: result.data, errors: [...items.errors, ...result.errors] };
+    const item = await this.itemService.get(actor, repositories, itemId);
+    return await itemMembershipRepository.getForItem(item);
   }
 
   private async _create(


### PR DESCRIPTION
- Remove get memberships for many items
- Update to have a GET memberships for one item

This PR is on hold, because this endpoint (get many) is used by the mobile app.