### PR TITLE
feat: add post and patch item folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "github:graasp/graasp-sdk#remove-old-cc-license",
+    "@graasp/sdk": "5.5.0",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.1",

--- a/src/services/item/controller.ts
+++ b/src/services/item/controller.ts
@@ -75,7 +75,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     },
   );
 
-  // isolate inside a register because of the mutlipart
+  // isolate inside a register because of the multipart
   fastify.register(async (fastify: FastifyInstanceTypebox) => {
     fastify.register(fastifyMultipart, {
       limits: {

--- a/src/services/item/errors.ts
+++ b/src/services/item/errors.ts
@@ -1,0 +1,24 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { ErrorFactory, ItemTypeUnion } from '@graasp/sdk';
+
+const PLUGIN_NAME = 'graasp-plugin-item';
+
+/**
+ * Errors thrown by the item services
+ */
+
+export const GraaspItemError = ErrorFactory(PLUGIN_NAME);
+
+export class WrongItemTypeError extends GraaspItemError {
+  constructor(data?: ItemTypeUnion) {
+    super(
+      {
+        code: 'GIERR001',
+        statusCode: StatusCodes.BAD_REQUEST,
+        message: 'Item does not have the correct type',
+      },
+      data,
+    );
+  }
+}

--- a/src/services/item/index.ts
+++ b/src/services/item/index.ts
@@ -21,6 +21,7 @@ import { PREFIX_EMBEDDED_LINK } from './plugins/embeddedLink/service';
 import graaspEnrollPlugin from './plugins/enroll';
 import graaspEtherpadPlugin from './plugins/etherpad/controller';
 import graaspFileItem from './plugins/file';
+import graaspFolderItem from './plugins/folder/controller';
 import itemGeolocationPlugin from './plugins/geolocation/index';
 import graaspH5PPlugin from './plugins/html/h5p';
 import graaspZipPlugin from './plugins/importExport';
@@ -75,6 +76,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       fastify.register(graaspFileItem, {});
 
       fastify.register(graaspItemVisibility);
+
+      fastify.register(graaspFolderItem);
 
       fastify.register(ShortLinkService, {
         prefix: SHORT_LINKS_ROUTE_PREFIX,

--- a/src/services/item/plugins/folder/controller.test.ts
+++ b/src/services/item/plugins/folder/controller.test.ts
@@ -320,7 +320,7 @@ describe('Folder routes tests', () => {
       });
 
       it('Create successfully with empty display name', async () => {
-        const payload = FolderItemFactory({ displayName: '' });
+        const payload = FolderItemFactory();
         const response = await app.inject({
           method: HttpMethod.Post,
           url: `/items/folders`,

--- a/src/services/item/plugins/folder/controller.test.ts
+++ b/src/services/item/plugins/folder/controller.test.ts
@@ -319,23 +319,6 @@ describe('Folder routes tests', () => {
         expect(Object.keys(newItem.settings)).not.toContain(Object.keys(BAD_SETTING)[0]);
       });
 
-      it('Create successfully with empty display name', async () => {
-        const payload = FolderItemFactory();
-        const response = await app.inject({
-          method: HttpMethod.Post,
-          url: `/items/folders`,
-          payload: { ...payload },
-        });
-
-        const newItem = response.json();
-        expectItem(newItem, payload, actor);
-        expect(newItem.displayName).toEqual('');
-        expect(response.statusCode).toBe(StatusCodes.OK);
-        await waitForPostCreation();
-
-        expect(await AppDataSource.getRepository(Item).countBy({ id: newItem.id })).toEqual(1);
-      });
-
       it('Create successfully with between children', async () => {
         const payload = FolderItemFactory();
         const { item: parentItem } = await testUtils.saveItemAndMembership({ member: actor });

--- a/src/services/item/plugins/folder/controller.test.ts
+++ b/src/services/item/plugins/folder/controller.test.ts
@@ -1,0 +1,902 @@
+import { faker } from '@faker-js/faker';
+import FormData from 'form-data';
+import fs from 'fs';
+import { ReasonPhrases, StatusCodes } from 'http-status-codes';
+import path from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
+import waitForExpect from 'wait-for-expect';
+
+import { FastifyInstance } from 'fastify';
+
+import {
+  DescriptionPlacement,
+  FolderItemFactory,
+  HttpMethod,
+  ItemType,
+  MAX_NUMBER_OF_CHILDREN,
+  MAX_TARGETS_FOR_MODIFY_REQUEST,
+  MAX_TREE_LEVELS,
+  PermissionLevel,
+  buildPathFromIds,
+} from '@graasp/sdk';
+
+import build, {
+  clearDatabase,
+  mockAuthenticate,
+  unmockAuthenticate,
+} from '../../../../../test/app';
+import { resolveDependency } from '../../../../di/utils';
+import { AppDataSource } from '../../../../plugins/datasource';
+import {
+  HierarchyTooDeep,
+  ItemNotFolder,
+  ItemNotFound,
+  MemberCannotAccess,
+  MemberCannotWriteItem,
+  TooManyChildren,
+} from '../../../../utils/errors';
+import { ItemMembership } from '../../../itemMembership/entities/ItemMembership';
+import { saveMember } from '../../../member/test/fixtures/members';
+import { Item } from '../../entities/Item';
+import { ItemService } from '../../service';
+import { ItemTestUtils, expectItem } from '../../test/fixtures/items';
+import { saveUntilMaxDescendants } from '../../test/utils';
+import { ActionItemService } from '../action/service';
+import { ItemGeolocation } from '../geolocation/ItemGeolocation';
+
+const itemMembershipRawRepository = AppDataSource.getRepository(ItemMembership);
+const testUtils = new ItemTestUtils();
+
+// Mock S3 libraries
+const deleteObjectMock = jest.fn(async () => console.debug('deleteObjectMock'));
+const copyObjectMock = jest.fn(async () => console.debug('copyObjectMock'));
+const headObjectMock = jest.fn(async () => ({ ContentLength: 10 }));
+const uploadDoneMock = jest.fn(async () => console.debug('aws s3 storage upload'));
+const MOCK_SIGNED_URL = 'signed-url';
+jest.mock('@aws-sdk/client-s3', () => {
+  return {
+    GetObjectCommand: jest.fn(),
+    S3: function () {
+      return {
+        copyObject: copyObjectMock,
+        deleteObject: deleteObjectMock,
+        headObject: headObjectMock,
+      };
+    },
+  };
+});
+jest.mock('@aws-sdk/s3-request-presigner', () => {
+  const getSignedUrl = jest.fn(async () => MOCK_SIGNED_URL);
+  return {
+    getSignedUrl,
+  };
+});
+jest.mock('@aws-sdk/lib-storage', () => {
+  return {
+    Upload: jest.fn().mockImplementation(() => {
+      return {
+        done: uploadDoneMock,
+      };
+    }),
+  };
+});
+
+describe('Folder routes tests', () => {
+  let app: FastifyInstance;
+  let actor;
+
+  beforeAll(async () => {
+    ({ app } = await build({ member: null }));
+  });
+
+  afterAll(async () => {
+    await clearDatabase(app.db);
+    app.close();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    unmockAuthenticate();
+    actor = null;
+  });
+  describe('POST /items', () => {
+    it('Throws if signed out', async () => {
+      const payload = FolderItemFactory();
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: '/items',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    });
+
+    describe('Signed In', () => {
+      let waitForPostCreation: () => Promise<unknown>;
+      beforeEach(async () => {
+        actor = await saveMember();
+        mockAuthenticate(actor);
+
+        const itemService = resolveDependency(ItemService);
+        const actionItemService = resolveDependency(ActionItemService);
+
+        const itemServiceRescaleOrderForParent = jest.spyOn(itemService, 'rescaleOrderForParent');
+        const actionItemServicePostPostAction = jest.spyOn(actionItemService, 'postPostAction');
+
+        // The API's is still working with the database after responding to an item post request,
+        // so we need to wait for the work to be done so we don't have flacky deadlock exceptions.
+        waitForPostCreation = async () => {
+          return await waitForExpect(async () => {
+            expect(itemServiceRescaleOrderForParent).toHaveBeenCalled();
+            expect(actionItemServicePostPostAction).toHaveBeenCalled();
+          });
+        };
+      });
+
+      it('Create successfully', async () => {
+        const payload = FolderItemFactory();
+
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: '/items/folders',
+          payload,
+        });
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        // check response value
+        const newItem = response.json();
+        expectItem(newItem, payload);
+        await waitForPostCreation();
+
+        // check item exists in db
+        const item = await testUtils.itemRepository.getOne(newItem.id);
+        expect(item?.id).toEqual(newItem.id);
+
+        // a membership is created for this item
+        const membership = await itemMembershipRawRepository.findOneBy({
+          item: { id: newItem.id },
+        });
+        expect(membership?.permission).toEqual(PermissionLevel.Admin);
+        // check some creator properties are not leaked
+        expect(newItem.creator.id).toBeTruthy();
+        expect(newItem.creator.createdAt).toBeFalsy();
+
+        // order is null for root
+        expect(await testUtils.getOrderForItemId(newItem.id)).toBeNull();
+      });
+
+      it('Create successfully in parent item', async () => {
+        const { item: parent } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        // child
+        const child = await testUtils.saveItem({
+          actor,
+          parentItem: parent,
+        });
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parent.id}`,
+          payload,
+        });
+        const newItem = response.json();
+
+        expectItem(newItem, payload, actor, parent);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        // a membership does not need to be created for item with admin rights
+        const nbItemMemberships = await itemMembershipRawRepository.countBy({
+          item: { id: newItem.id },
+        });
+        expect(nbItemMemberships).toEqual(0);
+
+        // add at beginning
+        await testUtils.expectOrder(newItem.id, undefined, child.id);
+      });
+
+      it('Create successfully in shared parent item', async () => {
+        const member = await saveMember();
+        const { item: parent } = await testUtils.saveItemAndMembership({ member });
+        await testUtils.saveMembership({
+          account: actor,
+          item: parent,
+          permission: PermissionLevel.Write,
+        });
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parent.id}`,
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor, parent);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        // a membership is created for this item
+        // one membership for the owner
+        // one membership for sharing
+        // admin for the new item
+        expect(
+          await itemMembershipRawRepository.countBy({
+            permission: PermissionLevel.Admin,
+            item: { id: newItem.id },
+            account: { id: actor.id },
+          }),
+        ).toEqual(1);
+      });
+
+      it('Create successfully with geolocation', async () => {
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload: { ...payload, geolocation: { lat: 1, lng: 2 } },
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        expect(
+          await AppDataSource.getRepository(ItemGeolocation).countBy({ item: { id: newItem.id } }),
+        ).toEqual(1);
+      });
+
+      it('Create successfully with language', async () => {
+        const payload = FolderItemFactory({ lang: 'fr' });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+      });
+
+      it('Create successfully with parent language', async () => {
+        const lang = 'es';
+        const { item: parentItem } = await testUtils.saveItemAndMembership({
+          member: actor,
+          item: { lang },
+        });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload: { name: faker.word.adverb(), type: ItemType.FOLDER },
+          query: { parentId: parentItem.id },
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        const newItem = response.json();
+        expect(newItem.lang).toEqual(lang);
+        await waitForPostCreation();
+      });
+
+      it('Create successfully with description placement above and should not erase default thumbnail', async () => {
+        const payload = FolderItemFactory({
+          settings: { descriptionPlacement: DescriptionPlacement.ABOVE },
+        });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+        expect(newItem.settings.descriptionPlacement).toBe(DescriptionPlacement.ABOVE);
+        expect(newItem.settings.hasThumbnail).toBe(false);
+      });
+
+      it('Filter out bad setting when creating', async () => {
+        const BAD_SETTING = { INVALID: 'Not a valid setting' };
+        const VALID_SETTING = { descriptionPlacement: DescriptionPlacement.ABOVE };
+
+        const payload = FolderItemFactory({
+          settings: {
+            ...BAD_SETTING,
+            ...VALID_SETTING,
+          },
+        });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, { ...payload, settings: VALID_SETTING }, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+        expect(newItem.settings.descriptionPlacement).toBe(VALID_SETTING.descriptionPlacement);
+        expect(Object.keys(newItem.settings)).not.toContain(Object.keys(BAD_SETTING)[0]);
+      });
+
+      it('Create successfully with empty display name', async () => {
+        const payload = FolderItemFactory({ displayName: '' });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload: { ...payload },
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(newItem.displayName).toEqual('');
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        expect(await AppDataSource.getRepository(Item).countBy({ id: newItem.id })).toEqual(1);
+      });
+
+      it('Create successfully with between children', async () => {
+        const payload = FolderItemFactory();
+        const { item: parentItem } = await testUtils.saveItemAndMembership({ member: actor });
+        const previousItem = await testUtils.saveItem({ parentItem, item: { order: 1 } });
+        const afterItem = await testUtils.saveItem({ parentItem, item: { order: 2 } });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          query: { parentId: parentItem.id, previousItemId: previousItem.id },
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        await testUtils.expectOrder(newItem.id, previousItem.id, afterItem.id);
+      });
+
+      it('Create successfully at end', async () => {
+        const payload = FolderItemFactory();
+        const { item: parentItem } = await testUtils.saveItemAndMembership({ member: actor });
+        // first item noise
+        await testUtils.saveItem({ parentItem, item: { order: 1 } });
+        const previousItem = await testUtils.saveItem({ parentItem, item: { order: 40 } });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          query: { parentId: parentItem.id, previousItemId: previousItem.id },
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        await testUtils.expectOrder(newItem.id, previousItem.id);
+      });
+
+      it('Create successfully after invalid child adds at end', async () => {
+        const payload = FolderItemFactory();
+        const { item: parentItem } = await testUtils.saveItemAndMembership({ member: actor });
+        const child = await testUtils.saveItem({ parentItem, item: { order: 30 } });
+
+        // noise, child in another parent
+        const { item: otherParent } = await testUtils.saveItemAndMembership({ member: actor });
+        const anotherChild = await testUtils.saveItem({
+          parentItem: otherParent,
+          item: { order: 100 },
+        });
+
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          query: { parentId: parentItem.id, previousItemId: anotherChild.id },
+          payload,
+        });
+
+        const newItem = response.json();
+        expectItem(newItem, payload, actor);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        await waitForPostCreation();
+
+        // should be after child, since another child is not valid
+        await testUtils.expectOrder(newItem.id, child.id, anotherChild.id);
+      });
+
+      it('Throw if geolocation is partial', async () => {
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload: { ...payload, geolocation: { lat: 1 } },
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        // no item nor geolocation is created
+        expect(await testUtils.rawItemRepository.countBy({ name: payload.name })).toEqual(0);
+
+        const response1 = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders`,
+          payload: { ...payload, geolocation: { lng: 1 } },
+        });
+
+        expect(response1.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        // no item nor geolocation is created
+        expect(await testUtils.rawItemRepository.countBy({ name: payload.name })).toEqual(0);
+      });
+
+      it('Bad request if name is invalid', async () => {
+        // by default the item creator use an invalid item type
+        const newItem = FolderItemFactory({ name: '' });
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: '/items/folders',
+          payload: newItem,
+        });
+        expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+
+        // by default the item creator use an invalid item type
+        const newItem1 = FolderItemFactory({ name: ' ' });
+        const response1 = await app.inject({
+          method: HttpMethod.Post,
+          url: '/items/folders',
+          payload: newItem1,
+        });
+        expect(response1.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+        expect(response1.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      });
+
+      it('Bad request if type is invalid', async () => {
+        // by default the item creator use an invalid item type
+        const newItem = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: '/items/folders',
+          payload: { ...newItem, type: 'invalid-type' },
+        });
+        expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      });
+
+      it('Bad request if parentId id is invalid', async () => {
+        const payload = FolderItemFactory();
+        const parentId = 'invalid-id';
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items?parentId=${parentId}`,
+          payload,
+        });
+
+        expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      });
+      it('Cannot create item in non-existing parent', async () => {
+        const payload = FolderItemFactory();
+        const parentId = uuidv4();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parentId}`,
+          payload,
+        });
+
+        expect(response.statusMessage).toEqual('Not Found');
+        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
+      });
+
+      it('Cannot create item if member does not have membership on parent', async () => {
+        const member = await saveMember();
+        const { item: parent } = await testUtils.saveItemAndMembership({ member });
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parent.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
+        expect(response.json()).toEqual(new MemberCannotAccess(parent.id));
+      });
+
+      it('Cannot create item if member can only read parent', async () => {
+        const owner = await saveMember();
+        const { item: parent } = await testUtils.saveItemAndMembership({
+          member: actor,
+          creator: owner,
+          permission: PermissionLevel.Read,
+        });
+
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parent.id}`,
+          payload,
+        });
+        expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
+        expect(response.json()).toEqual(new MemberCannotWriteItem(parent.id));
+      });
+
+      it('Cannot create item if parent item has too many children', async () => {
+        const { item: parent } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        const payload = FolderItemFactory();
+
+        // save maximum children
+        await testUtils.saveItems({
+          nb: MAX_NUMBER_OF_CHILDREN,
+          parentItem: parent,
+          member: actor,
+        });
+
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parent.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
+        expect(response.json()).toEqual(new TooManyChildren());
+      });
+
+      it('Cannot create item if parent is too deep in hierarchy', async () => {
+        const payload = FolderItemFactory();
+        const { item: parent } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        const currentParent = await saveUntilMaxDescendants(parent, actor);
+
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${currentParent.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
+        expect(response.json()).toEqual(new HierarchyTooDeep());
+      });
+
+      it('Cannot create inside non-folder item', async () => {
+        const { item: parent } = await testUtils.saveItemAndMembership({
+          member: actor,
+          item: { type: ItemType.DOCUMENT },
+        });
+        const payload = FolderItemFactory();
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/folders?parentId=${parent.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+        expect(response.json()).toMatchObject(new ItemNotFolder({ id: parent.id }));
+      });
+    });
+  });
+
+  describe('POST /items/with-thumbnail', () => {
+    beforeEach(async () => {
+      actor = await saveMember();
+      mockAuthenticate(actor);
+    });
+    it('Post item with thumbnail', async () => {
+      const imageStream = fs.createReadStream(
+        path.resolve(__dirname, '../../test/fixtures/image.png'),
+      );
+      const itemName = 'Test Item';
+      const payload = new FormData();
+      payload.append('name', itemName);
+      payload.append('type', ItemType.FOLDER);
+      payload.append('description', '');
+      payload.append('file', imageStream);
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: `/items/folders-with-thumbnail`,
+        payload,
+        headers: payload.getHeaders(),
+      });
+
+      const newItem = response.json();
+      expectItem(
+        newItem,
+        FolderItemFactory({
+          name: itemName,
+          type: ItemType.FOLDER,
+          description: '',
+          settings: { hasThumbnail: true },
+          lang: 'en',
+        }),
+        actor,
+      );
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expect(uploadDoneMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /items/:id', () => {
+    it('Throws if signed out', async () => {
+      const member = await saveMember();
+      const { item } = await testUtils.saveItemAndMembership({ member });
+
+      const response = await app.inject({
+        method: HttpMethod.Patch,
+        url: `/items/folders/${item.id}`,
+        payload: { name: 'new name' },
+      });
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    });
+
+    describe('Signed In', () => {
+      beforeEach(async () => {
+        actor = await saveMember();
+        mockAuthenticate(actor);
+      });
+
+      it('Update successfully', async () => {
+        const { item } = await testUtils.saveItemAndMembership({
+          item: {
+            type: ItemType.DOCUMENT,
+            extra: {
+              [ItemType.DOCUMENT]: {
+                content: 'content',
+              },
+            },
+          },
+          member: actor,
+        });
+        const payload = {
+          name: 'new name',
+          extra: {
+            [ItemType.DOCUMENT]: {
+              content: 'new content',
+            },
+          },
+          settings: {
+            hasThumbnail: true,
+          },
+        };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        // this test a bit how we deal with extra: it replaces existing keys
+        expectItem(response.json(), {
+          ...item,
+          ...payload,
+          // BUG: folder extra should not contain extra
+          extra: {
+            document: {
+              ...item.extra[item.type],
+              ...payload.extra[item.type],
+            },
+          },
+        });
+      });
+
+      it('Update successfully new language', async () => {
+        const { item } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        const payload = {
+          lang: 'fr',
+        };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        // this test a bit how we deal with extra: it replaces existing keys
+        expectItem(response.json(), {
+          ...item,
+          ...payload,
+        });
+      });
+
+      it('Update successfully description placement above', async () => {
+        const { item } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        const payload = {
+          settings: {
+            ...item.settings,
+            descriptionPlacement: DescriptionPlacement.ABOVE,
+          },
+        };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        const newItem = response.json();
+
+        // this test a bit how we deal with extra: it replaces existing keys
+        expectItem(newItem, {
+          ...item,
+          ...payload,
+        });
+        expect(newItem.settings.descriptionPlacement).toBe(DescriptionPlacement.ABOVE);
+        expect(newItem.settings.hasThumbnail).toBeFalsy();
+      });
+
+      it('Update successfully link settings', async () => {
+        const { item } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        const payload = {
+          settings: {
+            showLinkButton: false,
+            showLinkIframe: true,
+          },
+        };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        const newItem = response.json();
+
+        expectItem(newItem, {
+          ...item,
+          ...payload,
+        });
+        expect(newItem.settings.showLinkButton).toBe(false);
+        expect(newItem.settings.showLinkIframe).toBe(true);
+        expect(newItem.settings.hasThumbnail).toBeFalsy();
+      });
+
+      it('Update successfully with empty display name', async () => {
+        const { item } = await testUtils.saveItemAndMembership({
+          member: actor,
+          item: { displayName: 'Not empty' },
+        });
+
+        const payload = { displayName: '' };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        const newItem = response.json();
+        expect(newItem.displayName).toEqual('');
+      });
+
+      it('Filter out bad setting when updating', async () => {
+        const BAD_SETTING = { INVALID: 'Not a valid setting' };
+        const VALID_SETTING = { descriptionPlacement: DescriptionPlacement.ABOVE };
+
+        const { item } = await testUtils.saveItemAndMembership({
+          member: actor,
+        });
+        const payload = {
+          settings: {
+            ...item.settings,
+            ...VALID_SETTING,
+            ...BAD_SETTING,
+          },
+        };
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.statusCode).toBe(StatusCodes.OK);
+
+        const newItem = response.json();
+
+        // this test a bit how we deal with extra: it replaces existing keys
+        expectItem(newItem, {
+          ...item,
+          ...payload,
+          settings: VALID_SETTING,
+        });
+        expect(newItem.settings.descriptionPlacement).toBe(VALID_SETTING.descriptionPlacement);
+        expect(Object.keys(newItem.settings)).not.toContain(Object.keys(BAD_SETTING)[0]);
+      });
+
+      it('Bad request if id is invalid', async () => {
+        const payload = {
+          name: 'new name',
+        };
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: '/items/folders/invalid-id',
+          payload,
+        });
+
+        expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      });
+      it('Bad Request if extra is invalid', async () => {
+        const payload = {
+          name: 'new name',
+          extra: { key: 'false' },
+        };
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${uuidv4()}`,
+          payload,
+        });
+
+        expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      });
+
+      it('Cannot update not found item given id', async () => {
+        const payload = {
+          name: 'new name',
+        };
+        const id = uuidv4();
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${id}`,
+          payload,
+        });
+
+        expect(response.json()).toEqual(new ItemNotFound(id));
+        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
+      });
+      it('Cannot update item if does not have membership', async () => {
+        const payload = {
+          name: 'new name',
+        };
+        const member = await saveMember();
+        const { item } = await testUtils.saveItemAndMembership({ member });
+
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.json()).toEqual(new MemberCannotAccess(item.id));
+        expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
+      });
+      it('Cannot update item if has only read membership', async () => {
+        const payload = {
+          name: 'new name',
+        };
+        const member = await saveMember();
+        const { item } = await testUtils.saveItemAndMembership({ member });
+        await testUtils.saveMembership({ item, account: actor, permission: PermissionLevel.Read });
+        const response = await app.inject({
+          method: HttpMethod.Patch,
+          url: `/items/folders/${item.id}`,
+          payload,
+        });
+
+        expect(response.json()).toEqual(new MemberCannotWriteItem(item.id));
+        expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
+      });
+    });
+  });
+});

--- a/src/services/item/plugins/folder/controller.ts
+++ b/src/services/item/plugins/folder/controller.ts
@@ -1,8 +1,6 @@
 import { fastifyMultipart } from '@fastify/multipart';
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { ItemType } from '@graasp/sdk';
-
 import { resolveDependency } from '../../../../di/utils';
 import { FastifyInstanceTypebox } from '../../../../plugins/typebox';
 import { asDefined } from '../../../../utils/assertions';
@@ -11,7 +9,6 @@ import { isAuthenticated } from '../../../auth/plugins/passport';
 import { matchOne } from '../../../authorization';
 import { assertIsMember } from '../../../member/entities/member';
 import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
-import { Item } from '../../entities/Item';
 import { getPostItemPayloadFromFormData } from '../../utils';
 import { ActionItemService } from '../action/service';
 import { createFolder, createFolderWithThumbnail, updateFolder } from './schemas';
@@ -42,7 +39,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         const item = await folderItemService.post(member, repositories, {
           // Because of an incoherence between the service and the schema, we need to cast the data to the correct type
           // This need to be fixed in issue #1288 https://github.com/graasp/graasp/issues/1288
-          item: { ...data, type: ItemType.FOLDER } as Partial<Item> & Pick<Item, 'name' | 'type'>,
+          item: data,
           previousItemId,
           parentId,
           geolocation: data.geolocation,
@@ -74,7 +71,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     });
     fastify.post(
-      'folders-with-thumbnail',
+      '/folders-with-thumbnail',
       {
         schema: createFolderWithThumbnail,
         preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],

--- a/src/services/item/plugins/folder/controller.ts
+++ b/src/services/item/plugins/folder/controller.ts
@@ -62,12 +62,8 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   fastify.register(async (fastify: FastifyInstanceTypebox) => {
     fastify.register(fastifyMultipart, {
       limits: {
-        // fieldNameSize: 0,             // Max field name size in bytes (Default: 100 bytes).
-        // fieldSize: 1000000,           // Max field value size in bytes (Default: 1MB).
-        // fields: 5, // Max number of non-file fields (Default: Infinity).
         fileSize: 1024 * 1024 * 10, // 10Mb For multipart forms, the max file size (Default: Infinity).
         files: 1, // Max number of file fields (Default: Infinity).
-        // headerPairs: 2000             // Max number of header key=>value pairs (Default: 2000 - same as node's http).
       },
     });
     fastify.post(

--- a/src/services/item/plugins/folder/controller.ts
+++ b/src/services/item/plugins/folder/controller.ts
@@ -1,0 +1,139 @@
+import { fastifyMultipart } from '@fastify/multipart';
+import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
+
+import { ItemType } from '@graasp/sdk';
+
+import { resolveDependency } from '../../../../di/utils';
+import { FastifyInstanceTypebox } from '../../../../plugins/typebox';
+import { asDefined } from '../../../../utils/assertions';
+import { buildRepositories } from '../../../../utils/repositories';
+import { isAuthenticated } from '../../../auth/plugins/passport';
+import { matchOne } from '../../../authorization';
+import { assertIsMember } from '../../../member/entities/member';
+import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
+import { Item } from '../../entities/Item';
+import { ItemService } from '../../service';
+import { getPostItemPayloadFromFormData } from '../../utils';
+import { ActionItemService } from '../action/service';
+import { createFolder, createFolderWithThumbnail, updateFolder } from './schemas';
+import { FolderItemService } from './service';
+
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
+  const { db } = fastify;
+  const itemService = resolveDependency(ItemService);
+  const folderService = resolveDependency(FolderItemService);
+  const actionItemService = resolveDependency(ActionItemService);
+
+  fastify.post(
+    '/folder',
+    {
+      schema: createFolder,
+      preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
+    },
+    async (request, reply) => {
+      const {
+        user,
+        query: { parentId, previousItemId },
+        body: data,
+      } = request;
+      const member = asDefined(user?.account);
+      assertIsMember(member);
+
+      const item = await db.transaction(async (manager) => {
+        const repositories = buildRepositories(manager);
+        const item = await itemService.post(member, repositories, {
+          // Because of an incoherence between the service and the schema, we need to cast the data to the correct type
+          // This need to be fixed in issue #1288 https://github.com/graasp/graasp/issues/1288
+          item: { ...data, type: ItemType.FOLDER } as Partial<Item> & Pick<Item, 'name' | 'type'>,
+          previousItemId,
+          parentId,
+          geolocation: data.geolocation,
+        });
+        return item;
+      });
+
+      reply.send(item);
+
+      // background operations
+      await actionItemService.postPostAction(request, buildRepositories(), item);
+      await db.transaction(async (manager) => {
+        const repositories = buildRepositories(manager);
+        await itemService.rescaleOrderForParent(member, repositories, item);
+      });
+    },
+  );
+
+  // isolate inside a register because of the mutlipart
+  fastify.register(async (fastify: FastifyInstanceTypebox) => {
+    fastify.register(fastifyMultipart, {
+      limits: {
+        // fieldNameSize: 0,             // Max field name size in bytes (Default: 100 bytes).
+        // fieldSize: 1000000,           // Max field value size in bytes (Default: 1MB).
+        // fields: 5, // Max number of non-file fields (Default: Infinity).
+        fileSize: 1024 * 1024 * 10, // 10Mb For multipart forms, the max file size (Default: Infinity).
+        files: 1, // Max number of file fields (Default: Infinity).
+        // headerPairs: 2000             // Max number of header key=>value pairs (Default: 2000 - same as node's http).
+      },
+    });
+    fastify.post(
+      'folder/with-thumbnail',
+      {
+        schema: createFolderWithThumbnail,
+        preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
+      },
+      async (request) => {
+        const {
+          user,
+          query: { parentId },
+        } = request;
+        const member = asDefined(user?.account);
+        assertIsMember(member);
+
+        // get the formData from the request
+        const formData = await request.file();
+        const {
+          item: itemPayload,
+          geolocation,
+          thumbnail,
+        } = getPostItemPayloadFromFormData(formData);
+
+        return await db.transaction(async (manager) => {
+          const repositories = buildRepositories(manager);
+          const item = await itemService.post(member, repositories, {
+            item: itemPayload,
+            parentId,
+            geolocation,
+            thumbnail,
+          });
+          await actionItemService.postPostAction(request, repositories, item);
+          return item;
+        });
+      },
+    );
+  });
+
+  fastify.patch(
+    '/folder/:id',
+    {
+      schema: updateFolder,
+      preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
+    },
+    async (request) => {
+      const {
+        user,
+        params: { id },
+        body,
+      } = request;
+      const member = asDefined(user?.account);
+      assertIsMember(member);
+      return await db.transaction(async (manager) => {
+        const repositories = buildRepositories(manager);
+        const item = await folderService.patchFolder(member, repositories, id, body);
+        await actionItemService.postPatchAction(request, repositories, item);
+        return item;
+      });
+    },
+  );
+};
+
+export default plugin;

--- a/src/services/item/plugins/folder/schemas.ts
+++ b/src/services/item/plugins/folder/schemas.ts
@@ -1,0 +1,66 @@
+import { Type } from '@sinclair/typebox';
+import { StatusCodes } from 'http-status-codes';
+
+import { FastifySchema } from 'fastify';
+
+import { customType } from '../../../../plugins/typebox';
+import { errorSchemaRef } from '../../../../schemas/global';
+import { itemSchema } from '../../schemas';
+import { geoCoordinateSchemaRef } from '../geolocation/schemas';
+
+export const folderSchema = Type.Composite([
+  itemSchema,
+  customType.StrictObject(
+    {
+      extra: customType.StrictObject({}),
+    },
+    {
+      title: 'Folder',
+      description: 'Item of type folder, can contain other items and maintain an order.',
+    },
+  ),
+]);
+
+export const createFolder = {
+  operationId: 'createFolder',
+  tags: ['item', 'folder'],
+  summary: 'Create folder',
+  description: 'Create folder.',
+
+  querystring: Type.Partial(
+    customType.StrictObject({ parentId: customType.UUID(), previousItemId: customType.UUID() }),
+  ),
+  body: Type.Composite([
+    Type.Pick(folderSchema, ['name']),
+    Type.Partial(Type.Pick(folderSchema, ['description', 'lang', 'settings'])),
+    customType.StrictObject({
+      geolocation: Type.Optional(geoCoordinateSchemaRef),
+    }),
+  ]),
+  response: { [StatusCodes.OK]: folderSchema, '4xx': errorSchemaRef },
+} as const satisfies FastifySchema;
+
+export const createFolderWithThumbnail = {
+  operationId: 'createItemWithThumbnail',
+  tags: ['item', 'thumbnail'],
+  summary: 'Create an item with a thumbnail',
+  description: 'Create an item with a thumbnail. The data is sent using a form-data.',
+
+  querystring: Type.Partial(customType.StrictObject({ parentId: customType.UUID() })),
+  response: { [StatusCodes.OK]: folderSchema, '4xx': errorSchemaRef },
+} as const satisfies FastifySchema;
+
+export const updateFolder = {
+  operationId: 'updateFolder',
+  tags: ['item'],
+  summary: 'Update folder',
+  description: 'Update folder given body.',
+
+  params: customType.StrictObject({
+    id: customType.UUID(),
+  }),
+  body: Type.Partial(Type.Pick(folderSchema, ['name', 'description', 'lang']), {
+    minProperties: 1,
+  }),
+  response: { [StatusCodes.OK]: folderSchema, '4xx': errorSchemaRef },
+} as const satisfies FastifySchema;

--- a/src/services/item/plugins/folder/schemas.ts
+++ b/src/services/item/plugins/folder/schemas.ts
@@ -12,7 +12,11 @@ export const folderSchema = Type.Composite([
   itemSchema,
   customType.StrictObject(
     {
-      extra: customType.StrictObject({}),
+      extra: customType.StrictObject({
+        folder: customType.StrictObject({
+          isRoot: Type.Optional(Type.Boolean()),
+        }),
+      }),
     },
     {
       title: 'Folder',
@@ -59,7 +63,7 @@ export const updateFolder = {
   params: customType.StrictObject({
     id: customType.UUID(),
   }),
-  body: Type.Partial(Type.Pick(folderSchema, ['name', 'description', 'lang']), {
+  body: Type.Partial(Type.Pick(folderSchema, ['name', 'description', 'lang', 'settings']), {
     minProperties: 1,
   }),
   response: { [StatusCodes.OK]: folderSchema, '4xx': errorSchemaRef },

--- a/src/services/item/plugins/folder/service.test.ts
+++ b/src/services/item/plugins/folder/service.test.ts
@@ -1,0 +1,82 @@
+import { v4 } from 'uuid';
+
+import { ItemType } from '@graasp/sdk';
+
+import { MOCK_LOGGER } from '../../../../../test/app';
+import { Repositories } from '../../../../utils/repositories';
+import { Member } from '../../../member/entities/member';
+import { ThumbnailService } from '../../../thumbnail/service';
+import { Item } from '../../entities/Item';
+import { ItemRepository } from '../../repository';
+import { ItemService } from '../../service';
+import { ItemThumbnailService } from '../thumbnail/service';
+import { FolderItemService } from './service';
+
+const folderService = new FolderItemService(
+  {} as unknown as ThumbnailService,
+  {} as unknown as ItemThumbnailService,
+  MOCK_LOGGER,
+);
+const id = v4();
+const MOCK_ITEM = { id, type: ItemType.FOLDER } as Item;
+
+const MOCK_MEMBER = {} as Member;
+const repositories = {
+  itemRepository: {
+    getOneOrThrow: async () => {
+      return MOCK_ITEM;
+    },
+  } as unknown as ItemRepository,
+} as Repositories;
+
+describe('Folder Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('post', () => {
+    it('set correct type and extra', async () => {
+      const itemServicePostMock = jest
+        .spyOn(ItemService.prototype, 'post')
+        .mockImplementation(async () => {
+          return {} as Item;
+        });
+
+      await folderService.post(MOCK_MEMBER, repositories, { item: { name: 'name' } });
+
+      expect(itemServicePostMock).toHaveBeenCalledWith(MOCK_MEMBER, repositories, {
+        item: { name: 'name', extra: { [ItemType.FOLDER]: {} }, type: ItemType.FOLDER },
+      });
+    });
+  });
+  describe('patch', () => {
+    it('throw if item is not a folder', async () => {
+      await expect(() =>
+        folderService.patch(MOCK_MEMBER, repositories, MOCK_ITEM.id, { name: 'name' }),
+      ).rejects.toThrow();
+    });
+    it('use item service patch', async () => {
+      const itemServicePatchMock = jest
+        .spyOn(ItemService.prototype, 'patch')
+        .mockImplementation(async () => {
+          return MOCK_ITEM;
+        });
+
+      await folderService.patch(MOCK_MEMBER, repositories, MOCK_ITEM.id, { name: 'name' });
+
+      expect(itemServicePatchMock).toHaveBeenCalledWith(MOCK_MEMBER, repositories, MOCK_ITEM.id, {
+        name: 'name',
+      });
+    });
+
+    it('Cannot update not found item given id', async () => {
+      jest.spyOn(repositories.itemRepository, 'getOneOrThrow').mockImplementation(() => {
+        throw new Error();
+      });
+
+      await expect(() =>
+        folderService.patch(MOCK_MEMBER, repositories, v4(), { name: 'name' }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/services/item/plugins/folder/service.ts
+++ b/src/services/item/plugins/folder/service.ts
@@ -21,7 +21,7 @@ export class FolderItemService extends ItemService {
     super(thumbnailService, itemThumbnailService, log);
   }
 
-  async patchFolder(
+  async patch(
     member: Member,
     repositories: Repositories,
     itemId: UUID,
@@ -36,6 +36,6 @@ export class FolderItemService extends ItemService {
       throw new WrongItemTypeError(item.type);
     }
 
-    return await super._patch(member, repositories, item, { ...body, type: ItemType.FOLDER });
+    return await super.patch(member, repositories, item.id, body);
   }
 }

--- a/src/services/item/plugins/folder/service.ts
+++ b/src/services/item/plugins/folder/service.ts
@@ -1,0 +1,41 @@
+import { singleton } from 'tsyringe';
+
+import { ItemType, UUID } from '@graasp/sdk';
+
+import { BaseLogger } from '../../../../logger';
+import { Repositories } from '../../../../utils/repositories';
+import { Member } from '../../../member/entities/member';
+import { ThumbnailService } from '../../../thumbnail/service';
+import { Item } from '../../entities/Item';
+import { WrongItemTypeError } from '../../errors';
+import { ItemService } from '../../service';
+import { ItemThumbnailService } from '../thumbnail/service';
+
+@singleton()
+export class FolderItemService extends ItemService {
+  constructor(
+    thumbnailService: ThumbnailService,
+    itemThumbnailService: ItemThumbnailService,
+    log: BaseLogger,
+  ) {
+    super(thumbnailService, itemThumbnailService, log);
+  }
+
+  async patchFolder(
+    member: Member,
+    repositories: Repositories,
+    itemId: UUID,
+    body: Partial<Pick<Item, 'name' | 'description' | 'settings' | 'lang'>>,
+  ) {
+    const { itemRepository } = repositories;
+
+    const item = await itemRepository.getOneOrThrow(itemId);
+
+    // check item is folder
+    if (item.type !== ItemType.FOLDER) {
+      throw new WrongItemTypeError(item.type);
+    }
+
+    return await super._patch(member, repositories, item, { ...body, type: ItemType.FOLDER });
+  }
+}

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -161,7 +161,11 @@ export class ItemService {
     }
 
     this.log.debug(`create item ${item.name}`);
-    const createdItem = await itemRepository.addOne({ item, creator: member, parentItem });
+    const createdItem = await itemRepository.addOne({
+      item,
+      creator: member,
+      parentItem,
+    });
     this.log.debug(`item ${item.name} is created: ${createdItem}`);
 
     // create membership if inherited is less than admin

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -476,13 +476,11 @@ export class ItemService {
     return ItemWrapper.merge(items, itemMemberships, visibilities, thumbnails);
   }
 
-  protected async _patch(
-    member: Member,
-    repositories: Repositories,
-    item: Item,
-    body: DeepPartial<Item>,
-  ) {
+  async patch(member: Member, repositories: Repositories, itemId: UUID, body: DeepPartial<Item>) {
     const { itemRepository } = repositories;
+
+    // check memberships
+    const item = await itemRepository.getOneOrThrow(itemId);
 
     await validatePermission(repositories, PermissionLevel.Write, member, item);
 
@@ -495,15 +493,6 @@ export class ItemService {
     await this.hooks.runPostHooks('update', member, repositories, { item: updated });
 
     return updated;
-  }
-
-  async patch(member: Member, repositories: Repositories, itemId: UUID, body: DeepPartial<Item>) {
-    const { itemRepository } = repositories;
-
-    // check memberships
-    const item = await itemRepository.getOneOrThrow(itemId);
-
-    return this._patch(member, repositories, item, body);
   }
 
   // QUESTION? DELETE BY PATH???

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -476,22 +476,34 @@ export class ItemService {
     return ItemWrapper.merge(items, itemMemberships, visibilities, thumbnails);
   }
 
-  async patch(member: Member, repositories: Repositories, itemId: UUID, body: DeepPartial<Item>) {
+  protected async _patch(
+    member: Member,
+    repositories: Repositories,
+    item: Item,
+    body: DeepPartial<Item>,
+  ) {
     const { itemRepository } = repositories;
 
-    // check memberships
-    const item = await itemRepository.getOneOrThrow(itemId);
     await validatePermission(repositories, PermissionLevel.Write, member, item);
 
     // TODO: if updating a link item, fetch the new informations
 
     await this.hooks.runPreHooks('update', member, repositories, { item: item });
 
-    const updated = await itemRepository.updateOne(itemId, body);
+    const updated = await itemRepository.updateOne(item.id, body);
 
     await this.hooks.runPostHooks('update', member, repositories, { item: updated });
 
     return updated;
+  }
+
+  async patch(member: Member, repositories: Repositories, itemId: UUID, body: DeepPartial<Item>) {
+    const { itemRepository } = repositories;
+
+    // check memberships
+    const item = await itemRepository.getOneOrThrow(itemId);
+
+    return this._patch(member, repositories, item, body);
   }
 
   // QUESTION? DELETE BY PATH???

--- a/src/services/item/test/index.update.test.ts
+++ b/src/services/item/test/index.update.test.ts
@@ -16,7 +16,6 @@ import {
   ItemType,
   MAX_NUMBER_OF_CHILDREN,
   MAX_TARGETS_FOR_MODIFY_REQUEST,
-  MAX_TREE_LEVELS,
   PermissionLevel,
   buildPathFromIds,
 } from '@graasp/sdk';
@@ -41,6 +40,7 @@ import { ActionItemService } from '../plugins/action/service';
 import { ItemGeolocation } from '../plugins/geolocation/ItemGeolocation';
 import { ItemService } from '../service';
 import { ItemTestUtils, expectItem } from './fixtures/items';
+import { saveUntilMaxDescendants } from './utils';
 
 const itemMembershipRawRepository = AppDataSource.getRepository(ItemMembership);
 const testUtils = new ItemTestUtils();
@@ -78,21 +78,6 @@ jest.mock('@aws-sdk/lib-storage', () => {
     }),
   };
 });
-
-const saveUntilMaxDescendants = async (parent: Item, actor: Member) => {
-  // save maximum depth
-  // TODO: DYNAMIC
-  let currentParent = parent;
-  for (let i = 0; i < MAX_TREE_LEVELS - 1; i++) {
-    const newCurrentParent = await testUtils.saveItem({
-      actor,
-      parentItem: currentParent,
-    });
-    currentParent = newCurrentParent;
-  }
-  // return last child
-  return currentParent;
-};
 
 const saveNbOfItems = async ({
   nb,

--- a/src/services/item/test/utils.ts
+++ b/src/services/item/test/utils.ts
@@ -1,0 +1,22 @@
+import { MAX_TREE_LEVELS } from '@graasp/sdk';
+
+import { Member } from '../../member/entities/member';
+import { Item } from '../entities/Item';
+import { ItemTestUtils } from './fixtures/items';
+
+const testUtils = new ItemTestUtils();
+
+export const saveUntilMaxDescendants = async (parent: Item, actor: Member) => {
+  // save maximum depth
+  // TODO: DYNAMIC
+  let currentParent = parent;
+  for (let i = 0; i < MAX_TREE_LEVELS - 1; i++) {
+    const newCurrentParent = await testUtils.saveItem({
+      actor,
+      parentItem: currentParent,
+    });
+    currentParent = newCurrentParent;
+  }
+  // return last child
+  return currentParent;
+};

--- a/src/services/itemMembership/plugins/MembershipRequest/index.test.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/index.test.ts
@@ -60,10 +60,10 @@ describe('MembershipRequest', () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
-    await clearDatabase(app.db);
   });
 
   afterAll(async () => {
+    await clearDatabase(app.db);
     app.close();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#remove-old-cc-license":
-  version: 5.4.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=931d18cc244d3de4ccb68851a382610048b1028c"
+"@graasp/sdk@npm:5.5.0":
+  version: 5.5.0
+  resolution: "@graasp/sdk@npm:5.5.0"
   dependencies:
     "@faker-js/faker": "npm:9.2.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/cd1427ce9ea06732c97b4a305abeb37e89dc4405179d77cbf92f5f228a2bd31508871e8fa309b94310a0349ff12bd6189a068c5f14b5425528576ff48a5cbdc5
+  checksum: 10/4ae3ffbe9df6a351d849e30561f248390f0928f2664eb82b6c50c43a88c2f2ad3f76ab8e296296765716541e009262f9c76c3035f5d6da5572501bf9a295e51b
   languageName: node
   linkType: hard
 
@@ -7454,7 +7454,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "github:graasp/graasp-sdk#remove-old-cc-license"
+    "@graasp/sdk": "npm:5.5.0"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"


### PR DESCRIPTION
This PR is based on another PR: item schemas.

I'd like a very quick review, to discuss structure and endpoint paths.

I added the following endpoints
- POST /items/folder
- POST /items/folder/with-thumbnail
- PATCH /items/folder/id

I created a `FolderItemService` that extends `ItemService` so it can reuse the service's functions and attributes.

close #1623 