### PR TITLE
refactor: remove member hooks

### DIFF
--- a/src/services/auth/plugins/magicLink/index.ts
+++ b/src/services/auth/plugins/magicLink/index.ts
@@ -12,6 +12,7 @@ import { asDefined } from '../../../../utils/assertions';
 import { AUTH_CLIENT_HOST } from '../../../../utils/config';
 import { MemberAlreadySignedUp } from '../../../../utils/errors';
 import { buildRepositories } from '../../../../utils/repositories';
+import { InvitationService } from '../../../item/plugins/invitation/service';
 import { isMember } from '../../../member/entities/member';
 import { MemberService } from '../../../member/service';
 import { getRedirectionUrl } from '../../utils';
@@ -29,6 +30,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
 
   const memberService = resolveDependency(MemberService);
   const magicLinkService = resolveDependency(MagicLinkService);
+  const invitationService = resolveDependency(InvitationService);
 
   // register
   fastify.post(
@@ -43,20 +45,14 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
 
       return db.transaction(async (manager) => {
         try {
+          const repositories = buildRepositories(manager);
           // we use member service to allow post hook for invitation
-          const member = await memberService.post(
-            undefined,
-            buildRepositories(manager),
-            body,
-            lang,
-          );
+          const member = await memberService.post(undefined, repositories, body, lang);
+          await magicLinkService.sendRegisterMail(undefined, repositories, member, url);
 
-          await magicLinkService.sendRegisterMail(
-            undefined,
-            buildRepositories(manager),
-            member,
-            url,
-          );
+          // transform memberships from existing invitations
+          await invitationService.createToMemberships(repositories, member);
+
           reply.status(StatusCodes.NO_CONTENT);
         } catch (e) {
           if (!(e instanceof MemberAlreadySignedUp)) {

--- a/src/services/auth/plugins/magicLink/magicLink.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.test.ts
@@ -6,13 +6,7 @@ import { v4 } from 'uuid';
 
 import { FastifyInstance } from 'fastify';
 
-import {
-  HttpMethod,
-  MAX_USERNAME_LENGTH,
-  MemberFactory,
-  RecaptchaAction,
-  RecaptchaActionType,
-} from '@graasp/sdk';
+import { HttpMethod, MemberFactory, RecaptchaAction, RecaptchaActionType } from '@graasp/sdk';
 import { FAILURE_MESSAGES } from '@graasp/translations';
 
 import build, { clearDatabase } from '../../../../../test/app';
@@ -22,7 +16,7 @@ import { AppDataSource } from '../../../../plugins/datasource';
 import { MailerService } from '../../../../plugins/mailer/service';
 import { AUTH_CLIENT_HOST, JWT_SECRET } from '../../../../utils/config';
 import { Member } from '../../../member/entities/member';
-import { expectMember, saveMember } from '../../../member/test/fixtures/members';
+import { saveMember } from '../../../member/test/fixtures/members';
 import { MOCK_CAPTCHA } from '../captcha/test/utils';
 
 jest.mock('node-fetch');
@@ -50,183 +44,6 @@ describe('Auth routes tests', () => {
     jest.clearAllMocks();
     await clearDatabase(app.db);
     app.close();
-  });
-
-  describe('POST /register', () => {
-    beforeEach(() => {
-      // mock captcha validation
-      mockCaptchaValidation(RecaptchaAction.SignUp);
-    });
-
-    it('Sign Up successfully', async () => {
-      const email = 'someemail@email.com';
-      const name = 'anna';
-      const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: '/register',
-        payload: { email, name, captcha: MOCK_CAPTCHA },
-      });
-      const m = await memberRawRepository.findOneBy({ email, name });
-
-      expectMember(m, { name, email });
-      expect(m?.lastAuthenticatedAt).toBeNull();
-      expect(m?.isValidated).toBeFalsy();
-
-      // ensure that the user agreements are set for new registration
-      expect(m?.userAgreementsDate).toBeDefined();
-      expect(m?.userAgreementsDate).toBeInstanceOf(Date);
-
-      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-      expect(mockSendEmail.mock.calls[0][1]).toBe(email);
-    });
-
-    it('Sign Up successfully with given lang', async () => {
-      const email = 'someemail@email.com';
-      const name = 'anna';
-      const lang = 'fr';
-
-      const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: `/register?lang=${lang}`,
-        payload: { email, name, captcha: MOCK_CAPTCHA },
-      });
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-      expect(mockSendEmail.mock.calls[0][1]).toBe(email);
-      const m = await memberRawRepository.findOneBy({ email, name });
-      expectMember(m, { name, email, extra: { lang } });
-      expect(m?.lastAuthenticatedAt).toBeNull();
-      expect(m?.isValidated).toBeFalsy();
-
-      // ensure that the user agreements are set for new registration
-      expect(m?.userAgreementsDate).toBeDefined();
-      expect(m?.userAgreementsDate).toBeInstanceOf(Date);
-      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
-    });
-
-    it('Rejects if username is too long', async () => {
-      const email = 'some@email.com';
-      const name = Array(MAX_USERNAME_LENGTH + 1).fill(() => 'a');
-
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: `/register`,
-        payload: { email, name, captcha: MOCK_CAPTCHA },
-      });
-
-      const m = await memberRawRepository.findOneBy({ email });
-      expect(m).toBeFalsy();
-      expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
-    });
-
-    it('Save actions is disabled when explicitly asked', async () => {
-      const email = 'someemail@email.com';
-      const name = 'anna';
-      const enableSaveActions = false;
-
-      const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: `/register`,
-        payload: { email, name, captcha: MOCK_CAPTCHA, enableSaveActions },
-      });
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-      expect(mockSendEmail.mock.calls[0][1]).toBe(email);
-      const m = await memberRawRepository.findOneBy({ email, name });
-      expectMember(m, { name, email });
-      expect(m?.enableSaveActions).toBe(enableSaveActions);
-      // ensure that the user agreements are set for new registration
-      expect(m?.userAgreementsDate).toBeDefined();
-      expect(m?.userAgreementsDate).toBeInstanceOf(Date);
-      expect(m?.lastAuthenticatedAt).toBeNull();
-      expect(m?.isValidated).toBeFalsy();
-
-      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
-    });
-
-    it('Enable save actions when explicitly asked', async () => {
-      const email = 'someemail@email.com';
-      const name = 'anna';
-      const enableSaveActions = true;
-
-      const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: `/register`,
-        payload: { email, name, enableSaveActions, captcha: MOCK_CAPTCHA },
-      });
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-      expect(mockSendEmail.mock.calls[0][1]).toBe(email);
-      const m = await memberRawRepository.findOneBy({ email, name });
-      expectMember(m, { name, email });
-      expect(m?.enableSaveActions).toBe(enableSaveActions);
-      // ensure that the user agreements are set for new registration
-      expect(m?.userAgreementsDate).toBeDefined();
-      expect(m?.userAgreementsDate).toBeInstanceOf(Date);
-      expect(m?.lastAuthenticatedAt).toBeNull();
-      expect(m?.isValidated).toBeFalsy();
-
-      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
-    });
-
-    it('Sign Up fallback to login for already register member', async () => {
-      // register already existing member
-      const member = await saveMember(MemberFactory({ isValidated: false }));
-      const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
-
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: '/register',
-        payload: { ...member, captcha: MOCK_CAPTCHA },
-      });
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-      expect(mockSendEmail.mock.calls[0][1]).toBe(member.email);
-
-      const members = await memberRawRepository.findBy({ email: member.email });
-      expect(members).toHaveLength(1);
-      expectMember(member, members[0]);
-      expect(members[0]?.lastAuthenticatedAt).toBeNull();
-      expect(members[0]?.isValidated).toBeFalsy();
-      expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
-    });
-
-    it('Bad request for invalid email', async () => {
-      const email = 'wrongemail';
-      const name = 'anna';
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: '/register',
-        payload: { email, name, captcha: MOCK_CAPTCHA },
-      });
-
-      const members = await memberRawRepository.findBy({ email });
-      expect(members).toHaveLength(0);
-
-      expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
-      expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
-    });
-
-    it('Bad request if the username contains special characters', async () => {
-      const email = faker.internet.email().toLowerCase();
-      const name = '<div>%"^';
-      const response = await app.inject({
-        method: HttpMethod.Post,
-        url: '/register',
-        payload: { email, name, captcha: MOCK_CAPTCHA },
-      });
-
-      const members = await memberRawRepository.findBy({ email });
-      expect(members).toHaveLength(0);
-
-      expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
-      expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
-    });
   });
 
   describe('POST /login', () => {

--- a/src/services/item/plugins/action/test/ws.test.ts
+++ b/src/services/item/plugins/action/test/ws.test.ts
@@ -107,6 +107,6 @@ describe('asynchronous feedback', () => {
       expect(feedbackUpdate).toMatchObject(
         ItemOpFeedbackErrorEvent('export', [item.id], new Error('mock error')),
       );
-    });
+    }, 10000);
   });
 });

--- a/src/services/item/plugins/invitation/repository.ts
+++ b/src/services/item/plugins/invitation/repository.ts
@@ -2,7 +2,6 @@ import { EntityManager, FindOptionsRelations } from 'typeorm';
 
 import { MutableRepository } from '../../../../repositories/MutableRepository';
 import { DEFAULT_PRIMARY_KEY } from '../../../../repositories/const';
-import { EntryNotFoundBeforeDeleteException } from '../../../../repositories/errors';
 import { AncestorOf } from '../../../../utils/typeorm/treeOperators';
 import { Member } from '../../../member/entities/member';
 import { Item } from '../../entities/Item';
@@ -146,13 +145,9 @@ export class InvitationRepository extends MutableRepository<Invitation, UpdateIn
     return [];
   }
 
-  async deleteByEmail(email: Email) {
+  async deleteManyByEmail(email: Email) {
     this.throwsIfParamIsInvalid('email', email);
 
-    const entity = await this.repository.findOne({ where: { email } });
-    if (!entity) {
-      throw new EntryNotFoundBeforeDeleteException(this.entity);
-    }
-    await this.delete(entity.id);
+    await this.repository.delete({ email });
   }
 }

--- a/src/services/item/plugins/invitation/service.ts
+++ b/src/services/item/plugins/invitation/service.ts
@@ -145,7 +145,6 @@ export class InvitationService {
   }
 
   async createToMemberships(
-    actor: Actor,
     { invitationRepository, itemMembershipRepository }: Repositories,
     member: Member,
   ) {
@@ -157,6 +156,7 @@ export class InvitationService {
       permission,
     }));
     await itemMembershipRepository.addMany(memberships);
+    await invitationRepository.deleteManyByEmail(member.email);
   }
 
   async _partitionExistingUsersAndNewUsers(

--- a/src/services/item/plugins/invitation/test/index.test.ts
+++ b/src/services/item/plugins/invitation/test/index.test.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker';
 import FormData from 'form-data';
 import fs from 'fs';
 import { StatusCodes } from 'http-status-codes';
@@ -21,13 +20,13 @@ import { AppDataSource } from '../../../../../plugins/datasource';
 import { MailerService } from '../../../../../plugins/mailer/service';
 import { ITEMS_ROUTE_PREFIX } from '../../../../../utils/config';
 import { MOCK_CAPTCHA } from '../../../../auth/plugins/captcha/test/utils';
-import { Item } from '../../../../item/entities/Item';
 import { ItemMembership } from '../../../../itemMembership/entities/ItemMembership';
 import { Member } from '../../../../member/entities/member';
 import { saveMember } from '../../../../member/test/fixtures/members';
 import { ItemTestUtils } from '../../../test/fixtures/items';
 import { Invitation } from '../entity';
 import { MissingGroupColumnInCSVError } from '../errors';
+import { createInvitations, saveInvitations } from './utils';
 
 const testUtils = new ItemTestUtils();
 const invitationRawRepository = AppDataSource.getRepository(Invitation);
@@ -65,27 +64,6 @@ const expectInvitations = (invitations: Invitation[], correctInvitations: Invita
     expect(inv.permission).toEqual(correctInv!.permission);
     expect(inv.email).toEqual(correctInv!.email);
   }
-};
-
-const createInvitations = async ({ member, parentItem }: { member: Member; parentItem?: Item }) => {
-  const { item } = await testUtils.saveItemAndMembership({ member, parentItem });
-  const invitations = Array.from({ length: 3 }, () =>
-    invitationRawRepository.create({
-      item,
-      creator: member,
-      permission: PermissionLevel.Read,
-      email: faker.internet.email().toLowerCase(),
-    }),
-  );
-  return { item, invitations };
-};
-
-const saveInvitations = async ({ member }) => {
-  const { item, invitations } = await createInvitations({ member });
-  for (const inv of invitations) {
-    await invitationRawRepository.save(inv);
-  }
-  return { item, invitations };
 };
 
 describe('Invitation Plugin', () => {

--- a/src/services/item/plugins/invitation/test/utils.ts
+++ b/src/services/item/plugins/invitation/test/utils.ts
@@ -1,0 +1,40 @@
+import { faker } from '@faker-js/faker';
+
+import { PermissionLevel } from '@graasp/sdk';
+
+import { AppDataSource } from '../../../../../plugins/datasource';
+import { Member } from '../../../../member/entities/member';
+import { Item } from '../../../entities/Item';
+import { ItemTestUtils } from '../../../test/fixtures/items';
+import { Invitation } from '../entity';
+
+const invitationRawRepository = AppDataSource.getRepository(Invitation);
+
+const testUtils = new ItemTestUtils();
+
+export const createInvitations = async ({
+  member,
+  parentItem,
+}: {
+  member: Member;
+  parentItem?: Item;
+}) => {
+  const { item } = await testUtils.saveItemAndMembership({ member, parentItem });
+  const invitations = Array.from({ length: 3 }, () =>
+    invitationRawRepository.create({
+      item,
+      creator: member,
+      permission: PermissionLevel.Read,
+      email: faker.internet.email().toLowerCase(),
+    }),
+  );
+  return { item, invitations };
+};
+
+export const saveInvitations = async ({ member }) => {
+  const { item, invitations } = await createInvitations({ member });
+  for (const inv of invitations) {
+    await invitationRawRepository.save(inv);
+  }
+  return { item, invitations };
+};

--- a/src/services/member/service.ts
+++ b/src/services/member/service.ts
@@ -14,14 +14,12 @@ import {
   EMAIL_CHANGE_JWT_SECRET,
 } from '../../utils/config';
 import { MemberAlreadySignedUp } from '../../utils/errors';
-import HookManager from '../../utils/hook';
 import { Repositories } from '../../utils/repositories';
 import { NEW_EMAIL_PARAM, SHORT_TOKEN_PARAM } from '../auth/plugins/passport';
 import { Actor, Member } from './entities/member';
 
 @singleton()
 export class MemberService {
-  hooks = new HookManager();
   private readonly mailerService: MailerService;
   private readonly log: BaseLogger;
 
@@ -71,9 +69,6 @@ export class MemberService {
       };
 
       const member = await memberRepository.post(newMember);
-
-      // post hook
-      await this.hooks.runPostHooks('create', actor, repositories, { member });
 
       return member;
     } else {

--- a/src/services/member/test/register.test.ts
+++ b/src/services/member/test/register.test.ts
@@ -1,0 +1,283 @@
+import { faker } from '@faker-js/faker';
+import { ReasonPhrases, StatusCodes } from 'http-status-codes';
+import fetch from 'node-fetch';
+
+import { FastifyInstance } from 'fastify';
+
+import { HttpMethod, MAX_USERNAME_LENGTH, MemberFactory, RecaptchaAction } from '@graasp/sdk';
+
+import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../../test/app';
+import { mockCaptchaValidation } from '../../../../test/utils';
+import { resolveDependency } from '../../../di/utils';
+import { AppDataSource } from '../../../plugins/datasource';
+import { MailerService } from '../../../plugins/mailer/service';
+import { MOCK_CAPTCHA } from '../../auth/plugins/captcha/test/utils';
+import { Invitation } from '../../item/plugins/invitation/entity';
+import { saveInvitations } from '../../item/plugins/invitation/test/utils';
+import { ItemMembership } from '../../itemMembership/entities/ItemMembership';
+import { Member } from '../entities/member';
+import { expectMember, saveMember } from './fixtures/members';
+
+const invitationRawRepository = AppDataSource.getRepository(Invitation);
+const itemMembershipRawRepository = AppDataSource.getRepository(ItemMembership);
+const memberRawRepository = AppDataSource.getRepository(Member);
+
+jest.mock('node-fetch');
+(fetch as jest.MockedFunction<typeof fetch>).mockImplementation(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { json: async () => ({ success: true, action: RecaptchaAction.SignUp, score: 1 }) } as any;
+});
+
+describe('POST /register', () => {
+  let app: FastifyInstance;
+  let mailerService: MailerService;
+
+  beforeAll(async () => {
+    ({ app } = await build({ member: null }));
+  });
+
+  afterAll(async () => {
+    await clearDatabase(app.db);
+    app.close();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    unmockAuthenticate();
+  });
+
+  beforeEach(() => {
+    // mock captcha validation
+    mockCaptchaValidation(RecaptchaAction.SignUp);
+    mailerService = resolveDependency(MailerService);
+  });
+
+  it('Sign Up successfully', async () => {
+    const { email, name } = MemberFactory();
+    const lowercaseEmail = email.toLowerCase();
+    const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: '/register',
+      payload: { email, name, captcha: MOCK_CAPTCHA },
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+    const m = await memberRawRepository.findOneBy({ email: lowercaseEmail, name });
+
+    expectMember(m, { name, email: lowercaseEmail });
+    expect(m?.lastAuthenticatedAt).toBeNull();
+    expect(m?.isValidated).toBeFalsy();
+
+    // ensure that the user agreements are set for new registration
+    expect(m?.userAgreementsDate).toBeDefined();
+    expect(m?.userAgreementsDate).toBeInstanceOf(Date);
+
+    expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail.mock.calls[0][1]).toBe(lowercaseEmail);
+  });
+
+  it('Sign Up successfully with given lang', async () => {
+    const { email, name } = MemberFactory();
+    const lowercaseEmail = email.toLowerCase();
+    const lang = 'fr';
+
+    const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: `/register?lang=${lang}`,
+      payload: { email, name, captcha: MOCK_CAPTCHA },
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail.mock.calls[0][1]).toBe(lowercaseEmail);
+    const m = await memberRawRepository.findOneBy({ email: lowercaseEmail, name });
+    expectMember(m, { name, email: lowercaseEmail, extra: { lang } });
+    expect(m?.lastAuthenticatedAt).toBeNull();
+    expect(m?.isValidated).toBeFalsy();
+
+    // ensure that the user agreements are set for new registration
+    expect(m?.userAgreementsDate).toBeDefined();
+    expect(m?.userAgreementsDate).toBeInstanceOf(Date);
+    expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+  });
+
+  it('Rejects if username is too long', async () => {
+    const email = faker.internet.email().toLowerCase();
+    const name = Array(MAX_USERNAME_LENGTH + 1).fill(() => 'a');
+
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: `/register`,
+      payload: { email, name, captcha: MOCK_CAPTCHA },
+    });
+
+    const m = await memberRawRepository.findOneBy({ email });
+    expect(m).toBeFalsy();
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+  });
+
+  it('Save actions is disabled when explicitly asked', async () => {
+    const email = faker.internet.email().toLowerCase();
+    const name = 'anna';
+    const enableSaveActions = false;
+
+    const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: `/register`,
+      payload: { email, name, captcha: MOCK_CAPTCHA, enableSaveActions },
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail.mock.calls[0][1]).toBe(email);
+    const m = await memberRawRepository.findOneBy({ email, name });
+    expectMember(m, { name, email });
+    expect(m?.enableSaveActions).toBe(enableSaveActions);
+    // ensure that the user agreements are set for new registration
+    expect(m?.userAgreementsDate).toBeDefined();
+    expect(m?.userAgreementsDate).toBeInstanceOf(Date);
+    expect(m?.lastAuthenticatedAt).toBeNull();
+    expect(m?.isValidated).toBeFalsy();
+
+    expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+  });
+
+  it('Enable save actions when explicitly asked', async () => {
+    const email = faker.internet.email().toLowerCase();
+    const name = 'anna';
+    const enableSaveActions = true;
+
+    const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: `/register`,
+      payload: { email, name, enableSaveActions, captcha: MOCK_CAPTCHA },
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail.mock.calls[0][1]).toBe(email);
+    const m = await memberRawRepository.findOneBy({ email, name });
+    expectMember(m, { name, email });
+    expect(m?.enableSaveActions).toBe(enableSaveActions);
+    // ensure that the user agreements are set for new registration
+    expect(m?.userAgreementsDate).toBeDefined();
+    expect(m?.userAgreementsDate).toBeInstanceOf(Date);
+    expect(m?.lastAuthenticatedAt).toBeNull();
+    expect(m?.isValidated).toBeFalsy();
+
+    expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+  });
+
+  it('Sign Up fallback to login for already register member', async () => {
+    // register already existing member
+    const member = await saveMember(MemberFactory({ isValidated: false }));
+    const mockSendEmail = jest.spyOn(mailerService, 'sendRaw');
+
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: '/register',
+      payload: { ...member, captcha: MOCK_CAPTCHA },
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail.mock.calls[0][1]).toBe(member.email);
+
+    const members = await memberRawRepository.findBy({ email: member.email });
+    expect(members).toHaveLength(1);
+    expectMember(member, members[0]);
+    expect(members[0]?.lastAuthenticatedAt).toBeNull();
+    expect(members[0]?.isValidated).toBeFalsy();
+    expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
+  });
+
+  it('Bad request for invalid email', async () => {
+    const email = 'wrongemail';
+    const name = 'anna';
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: '/register',
+      payload: { email, name, captcha: MOCK_CAPTCHA },
+    });
+
+    const members = await memberRawRepository.findBy({ email });
+    expect(members).toHaveLength(0);
+
+    expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+  });
+
+  it('Bad request if the username contains special characters', async () => {
+    const email = faker.internet.email().toLowerCase();
+    const name = '<div>%"^';
+    const response = await app.inject({
+      method: HttpMethod.Post,
+      url: '/register',
+      payload: { email, name, captcha: MOCK_CAPTCHA },
+    });
+
+    const members = await memberRawRepository.findBy({ email });
+    expect(members).toHaveLength(0);
+
+    expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
+    expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
+  });
+
+  it('remove invitation on member registration and create memberships successfully', async () => {
+    const actor = await saveMember();
+    mockAuthenticate(actor);
+    const { invitations } = await saveInvitations({ member: actor });
+
+    const { id, email, item, permission } = invitations[0];
+
+    // register
+    await app.inject({
+      method: HttpMethod.Post,
+      url: '/register',
+      payload: { email, name: 'some-name', captcha: MOCK_CAPTCHA },
+    });
+    const member = await AppDataSource.getRepository(Member).findOneBy({ email });
+    expect(member).not.toBeNull();
+    // invitations should be removed and memberships created
+    await new Promise((done) => {
+      setTimeout(async () => {
+        const savedInvitation = await invitationRawRepository.findOneBy({ id });
+        expect(savedInvitation).toBeFalsy();
+        const membership = await itemMembershipRawRepository.findOne({
+          where: { permission, account: { id: member!.id }, item: { id: item.id } },
+          relations: { account: true, item: true },
+        });
+        expect(membership).toBeTruthy();
+        done(true);
+      }, 1000);
+    });
+  });
+
+  it('does not throw if no invitation found', async () => {
+    const actor = await saveMember();
+    mockAuthenticate(actor);
+    await saveInvitations({ member: actor });
+
+    const email = faker.internet.email().toLowerCase();
+    const allInvitationsCount = await invitationRawRepository.count();
+    const allMembershipsCount = await itemMembershipRawRepository.count();
+
+    // register
+    await app.inject({
+      method: HttpMethod.Post,
+      url: '/register',
+      payload: { email, name: 'some-name', captcha: MOCK_CAPTCHA },
+    });
+
+    await new Promise((done) => {
+      setTimeout(async () => {
+        // all invitations and memberships should exist
+        expect(await invitationRawRepository.count()).toEqual(allInvitationsCount);
+        expect(await itemMembershipRawRepository.count()).toEqual(allMembershipsCount);
+
+        done(true);
+      }, 1000);
+    });
+  });
+});


### PR DESCRIPTION
- Remove member hooks: only one use is to create memberships from invitations for the new registered emails
- Create invitation utils for tests.
- Move /register tests in its own file, with regular tests and related invitation creation tests.