### PR TITLE
fix: remove deprecated values for cc licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "5.4.0",
+    "@graasp/sdk": "github:graasp/graasp-sdk#remove-old-cc-license",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.1",

--- a/src/migrations/1733844120221-cc-license-values.ts
+++ b/src/migrations/1733844120221-cc-license-values.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1733844120221 implements MigrationInterface {
+  name = 'cc-license-values-1733751673963';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // remove ccLicenseAdaption keys for empty values
+    await queryRunner.query(
+      `update item set settings = settings::jsonb - 'ccLicenseAdaption' where length((settings::jsonb->'ccLicenseAdaption')::text) = 2`,
+    );
+    // remove deprecated values alike to CC BY-NC-SA
+    await queryRunner.query(
+      `update item set settings = jsonb_set(settings::jsonb, '{ccLicenseAdaption}'::text[], '"CC BY-NC-SA"'::jsonb) where (settings::jsonb->'ccLicenseAdaption')::text = '"alike"';`,
+    );
+    // remove deprecated values allow to CC BY-NC
+    await queryRunner.query(
+      `update item set settings = jsonb_set(settings::jsonb, '{ccLicenseAdaption}'::text[], '"CC BY-NC"'::jsonb) where (settings::jsonb->'ccLicenseAdaption')::text = '"allow"';`,
+    );
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/src/migrations/1733844120221-cc-license-values.ts
+++ b/src/migrations/1733844120221-cc-license-values.ts
@@ -1,20 +1,20 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migrations1733844120221 implements MigrationInterface {
-  name = 'cc-license-values-1733751673963';
+  name = 'cc-license-values-1733844120221';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // remove ccLicenseAdaption keys for empty values
     await queryRunner.query(
-      `update item set settings = settings::jsonb - 'ccLicenseAdaption' where length((settings::jsonb->'ccLicenseAdaption')::text) = 2`,
+      `update item set settings = settings::jsonb - 'ccLicenseAdaption' where length((settings::jsonb->>'ccLicenseAdaption')) = 0`,
     );
     // remove deprecated values alike to CC BY-NC-SA
     await queryRunner.query(
-      `update item set settings = jsonb_set(settings::jsonb, '{ccLicenseAdaption}'::text[], '"CC BY-NC-SA"'::jsonb) where (settings::jsonb->'ccLicenseAdaption')::text = '"alike"';`,
+      `update item set settings = jsonb_set(settings::jsonb, '{ccLicenseAdaption}'::text[], '"CC BY-NC-SA"'::jsonb) where (settings::jsonb->>'ccLicenseAdaption') = 'alike';`,
     );
     // remove deprecated values allow to CC BY-NC
     await queryRunner.query(
-      `update item set settings = jsonb_set(settings::jsonb, '{ccLicenseAdaption}'::text[], '"CC BY-NC"'::jsonb) where (settings::jsonb->'ccLicenseAdaption')::text = '"allow"';`,
+      `update item set settings = jsonb_set(settings::jsonb, '{ccLicenseAdaption}'::text[], '"CC BY-NC"'::jsonb) where (settings::jsonb->>'ccLicenseAdaption') = 'allow';`,
     );
   }
 

--- a/src/services/item/schemas.ts
+++ b/src/services/item/schemas.ts
@@ -11,7 +11,6 @@ import {
   MAX_TARGETS_FOR_MODIFY_REQUEST,
   MAX_TARGETS_FOR_MODIFY_REQUEST_W_RESPONSE,
   MaxWidth,
-  OldCCLicenseAdaptations,
   PermissionLevel,
 } from '@graasp/sdk';
 
@@ -31,10 +30,9 @@ export const settingsSchema = Type.Partial(
       showChatbox: Type.Boolean(),
       isResizable: Type.Boolean(),
       hasThumbnail: Type.Boolean(),
-      ccLicenseAdaption: Type.Union([
-        customType.Nullable(customType.EnumString(Object.values(CCLicenseAdaptions))),
-        customType.EnumString(Object.values(OldCCLicenseAdaptations), { deprecated: true }),
-      ]),
+      ccLicenseAdaption: customType.Nullable(
+        customType.EnumString(Object.values(CCLicenseAdaptions)),
+      ),
       displayCoEditors: Type.Boolean(),
       descriptionPlacement: customType.EnumString(Object.values(DescriptionPlacement)),
       isCollapsible: Type.Boolean(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:5.4.0":
+"@graasp/sdk@github:graasp/graasp-sdk#remove-old-cc-license":
   version: 5.4.0
-  resolution: "@graasp/sdk@npm:5.4.0"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=931d18cc244d3de4ccb68851a382610048b1028c"
   dependencies:
     "@faker-js/faker": "npm:9.2.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/787def776e690aa3a07438c907e6d5adb6c016db243e52fdc1511e35d057380d2d51d98d28bfef5f9f6101987f85c4cf43ba89a0d4d56f970b3801b4b8f2acd7
+  checksum: 10/cd1427ce9ea06732c97b4a305abeb37e89dc4405179d77cbf92f5f228a2bd31508871e8fa309b94310a0349ff12bd6189a068c5f14b5425528576ff48a5cbdc5
   languageName: node
   linkType: hard
 
@@ -7454,7 +7454,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:5.4.0"
+    "@graasp/sdk": "github:graasp/graasp-sdk#remove-old-cc-license"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"


### PR DESCRIPTION
Hopefully fix 

```
GET /item-memberships
The value of 'item#/properties/settings/properties/ccLicenseAdaption' does not match schema definition.
```
close #1073 