### PR TITLE
fix: analytics query schema error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,11 +7,14 @@
     "prettier"
   ],
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": "latest",
     "sourceType": "module"
   },
   "rules": {
-    "semi": ["error", "always"],
+    "semi": [
+      "error",
+      "always"
+    ],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": 1,
     "@typescript-eslint/no-inferrable-types": [
@@ -23,7 +26,21 @@
     "import/no-extraneous-dependencies": [
       "error",
       {
-        "devDependencies": ["**/*.test.*", "**/test/*", "**/test/**/*"]
+        "devDependencies": [
+          "**/*.test.*",
+          "**/test/*",
+          "**/test/**/*"
+        ]
+      }
+    ],
+    "no-console": [
+      "warn",
+      {
+        "allow": [
+          "error",
+          "warn",
+          "debug"
+        ]
       }
     ],
     "@typescript-eslint/no-unused-vars": [

--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -61,6 +61,7 @@ const start = async () => {
     instance.log.info('App is running version %s in %s mode', APP_VERSION, ENVIRONMENT);
     if (DEV) {
       // greet the world
+      // eslint-disable-next-line no-console
       console.log(`${GREETING}`);
     }
   } catch (err) {

--- a/src/plugins/typebox.ts
+++ b/src/plugins/typebox.ts
@@ -70,7 +70,7 @@ export const customType = {
   Username: (options?: StringOptions) =>
     Type.String({
       ...options,
-      format: 'username',
+      format: 'graaspUsername',
       minLength: MIN_USERNAME_LENGTH,
       maxLength: MAX_USERNAME_LENGTH,
     }),
@@ -81,7 +81,7 @@ export const customType = {
     }),
   EnumString: <T extends string[]>(values: [...T], options?: SchemaOptions) =>
     Object.assign(
-      /* 
+      /*
       Object Assign is used so the return type contains the intersection with `{ type: 'string' }`,
       and so can be used in combination with `customType.Nullable(...)`
        */

--- a/src/schemas/ajvFormats.ts
+++ b/src/schemas/ajvFormats.ts
@@ -1,4 +1,4 @@
-import { Ajv } from 'ajv';
+import type { Ajv } from 'ajv';
 
 import { MemberConstants } from '@graasp/sdk';
 

--- a/src/schemas/ajvFormats.ts
+++ b/src/schemas/ajvFormats.ts
@@ -13,5 +13,5 @@ export default function plugin(ajv: Ajv) {
   ajv.addFormat('strongPassword', /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/);
 
   // No special characters and no Unicode control characters in the username
-  ajv.addFormat('username', MemberConstants.USERNAME_FORMAT_REGEX);
+  ajv.addFormat('graaspUsername', MemberConstants.USERNAME_FORMAT_REGEX);
 }

--- a/src/scripts/generateOpenAPI.ts
+++ b/src/scripts/generateOpenAPI.ts
@@ -17,6 +17,7 @@ const output = 'openapi.json';
   await writeFile(output, schema, { flag: 'w+' });
 
   instance.close(() => {
+    // eslint-disable-next-line no-console
     console.log(`OpenAPI schema generated at ${output}`);
     process.exit(1);
   });

--- a/src/services/action/entities/action.ts
+++ b/src/services/action/entities/action.ts
@@ -42,7 +42,7 @@ export class Action extends BaseEntity {
     nullable: false,
     enum: Object.values(Context),
   })
-  view: Context | 'Unknown';
+  view: Context;
 
   @Column({
     nullable: false,

--- a/src/services/item/plugins/action/base-analytics.ts
+++ b/src/services/item/plugins/action/base-analytics.ts
@@ -1,6 +1,6 @@
 import { Ajv } from 'ajv';
 
-import { UUID } from '@graasp/sdk';
+import { MemberConstants, UUID } from '@graasp/sdk';
 
 import { Account } from '../../../account/entities/account';
 import { Action } from '../../../action/entities/action';
@@ -18,18 +18,12 @@ const memberSchema = {
   properties: {
     id: { type: 'string' },
     name: { type: 'string' },
-    email: { type: 'string' },
-    extra: {
-      type: 'object',
-      additionalProperties: false,
-      properties: { lang: { type: 'string' } },
-    },
   },
 };
 
 export class BaseAnalytics {
   readonly actions: Action[];
-  readonly members: Account[];
+  readonly members: { id: string; name: string }[];
   readonly itemMemberships: ItemMembership[];
   readonly descendants: Item[];
   readonly item: Item;
@@ -68,15 +62,19 @@ export class BaseAnalytics {
     // TODO: all other schemas
 
     // validate and remove additional properties from member
-    const ajv = new Ajv({ removeAdditional: 'all' });
+    const ajv = new Ajv({ removeAdditional: 'all' }).addFormat(
+      'username',
+      MemberConstants.USERNAME_FORMAT_REGEX,
+    );
 
     const validateMember = ajv.compile(memberSchema);
     const validateMembers = ajv.compile({
       type: 'array',
       items: memberSchema,
     });
+    console.log('before validation members', args.members);
     validateMembers(args.members);
-
+    console.log('validate members', args.members);
     validateMember(args.item.creator);
 
     args.descendants.forEach((i) => validateMember(i.creator));

--- a/src/services/item/plugins/action/base-analytics.ts
+++ b/src/services/item/plugins/action/base-analytics.ts
@@ -1,6 +1,6 @@
 import { Ajv } from 'ajv';
 
-import { MemberConstants, UUID } from '@graasp/sdk';
+import { UUID } from '@graasp/sdk';
 
 import { Account } from '../../../account/entities/account';
 import { Action } from '../../../action/entities/action';
@@ -62,10 +62,7 @@ export class BaseAnalytics {
     // TODO: all other schemas
 
     // validate and remove additional properties from member
-    const ajv = new Ajv({ removeAdditional: 'all' }).addFormat(
-      'username',
-      MemberConstants.USERNAME_FORMAT_REGEX,
-    );
+    const ajv = new Ajv({ removeAdditional: 'all' });
 
     const validateMember = ajv.compile(memberSchema);
     const validateMembers = ajv.compile({

--- a/src/services/item/plugins/action/base-analytics.ts
+++ b/src/services/item/plugins/action/base-analytics.ts
@@ -72,9 +72,9 @@ export class BaseAnalytics {
       type: 'array',
       items: memberSchema,
     });
-    console.log('before validation members', args.members);
+
     validateMembers(args.members);
-    console.log('validate members', args.members);
+
     validateMember(args.item.creator);
 
     args.descendants.forEach((i) => validateMember(i.creator));

--- a/src/services/item/plugins/action/index.ts
+++ b/src/services/item/plugins/action/index.ts
@@ -49,13 +49,18 @@ const plugin: FastifyPluginAsyncTypebox<GraaspActionsOptions> = async (fastify) 
       preHandler: isAuthenticated,
     },
     async ({ user, params: { id }, query }) => {
-      return actionItemService.getBaseAnalyticsForItem(user?.account, buildRepositories(), {
-        sampleSize: query.requestedSampleSize,
-        itemId: id,
-        view: query.view?.toLowerCase(),
-        startDate: query.startDate,
-        endDate: query.endDate,
-      });
+      const res = await actionItemService.getBaseAnalyticsForItem(
+        user?.account,
+        buildRepositories(),
+        {
+          sampleSize: query.requestedSampleSize,
+          itemId: id,
+          view: query.view?.toLowerCase(),
+          startDate: query.startDate,
+          endDate: query.endDate,
+        },
+      );
+      return res;
     },
   );
 
@@ -67,20 +72,25 @@ const plugin: FastifyPluginAsyncTypebox<GraaspActionsOptions> = async (fastify) 
       preHandler: isAuthenticated,
     },
     async ({ user, params: { id }, query }) => {
-      return actionItemService.getAnalyticsAggregation(user?.account, buildRepositories(), {
-        sampleSize: query.requestedSampleSize,
-        itemId: id,
-        view: query.view?.toLowerCase(),
-        type: query.type,
-        countGroupBy: query.countGroupBy,
-        aggregationParams: {
-          aggregateFunction: query.aggregateFunction,
-          aggregateMetric: query.aggregateMetric,
-          aggregateBy: query.aggregateBy,
+      const res = await actionItemService.getAnalyticsAggregation(
+        user?.account,
+        buildRepositories(),
+        {
+          sampleSize: query.requestedSampleSize,
+          itemId: id,
+          view: query.view?.toLowerCase(),
+          type: query.type,
+          countGroupBy: query.countGroupBy,
+          aggregationParams: {
+            aggregateFunction: query.aggregateFunction,
+            aggregateMetric: query.aggregateMetric,
+            aggregateBy: query.aggregateBy,
+          },
+          startDate: query.startDate,
+          endDate: query.endDate,
         },
-        startDate: query.startDate,
-        endDate: query.endDate,
-      });
+      );
+      return res;
     },
   );
 

--- a/src/services/item/plugins/action/index.ts
+++ b/src/services/item/plugins/action/index.ts
@@ -49,7 +49,8 @@ const plugin: FastifyPluginAsyncTypebox<GraaspActionsOptions> = async (fastify) 
       preHandler: isAuthenticated,
     },
     async ({ user, params: { id }, query }) => {
-      const res = await actionItemService.getBaseAnalyticsForItem(
+      // remove itemMemberships from return
+      const { itemMemberships: _, ...result } = await actionItemService.getBaseAnalyticsForItem(
         user?.account,
         buildRepositories(),
         {
@@ -60,7 +61,7 @@ const plugin: FastifyPluginAsyncTypebox<GraaspActionsOptions> = async (fastify) 
           endDate: query.endDate,
         },
       );
-      return res;
+      return result;
     },
   );
 
@@ -72,25 +73,20 @@ const plugin: FastifyPluginAsyncTypebox<GraaspActionsOptions> = async (fastify) 
       preHandler: isAuthenticated,
     },
     async ({ user, params: { id }, query }) => {
-      const res = await actionItemService.getAnalyticsAggregation(
-        user?.account,
-        buildRepositories(),
-        {
-          sampleSize: query.requestedSampleSize,
-          itemId: id,
-          view: query.view?.toLowerCase(),
-          type: query.type,
-          countGroupBy: query.countGroupBy,
-          aggregationParams: {
-            aggregateFunction: query.aggregateFunction,
-            aggregateMetric: query.aggregateMetric,
-            aggregateBy: query.aggregateBy,
-          },
-          startDate: query.startDate,
-          endDate: query.endDate,
+      return actionItemService.getAnalyticsAggregation(user?.account, buildRepositories(), {
+        sampleSize: query.requestedSampleSize,
+        itemId: id,
+        view: query.view?.toLowerCase(),
+        type: query.type,
+        countGroupBy: query.countGroupBy,
+        aggregationParams: {
+          aggregateFunction: query.aggregateFunction,
+          aggregateMetric: query.aggregateMetric,
+          aggregateBy: query.aggregateBy,
         },
-      );
-      return res;
+        startDate: query.startDate,
+        endDate: query.endDate,
+      });
     },
   );
 

--- a/src/services/item/plugins/action/schemas.ts
+++ b/src/services/item/plugins/action/schemas.ts
@@ -67,15 +67,9 @@ export const getItemActions = {
       apps: Type.Record(
         customType.UUID(),
         customType.StrictObject({
-          data: Type.Array(
-            // remove deprecated member property from the schema
-            Type.Omit(appDataSchemaRef, ['member']),
-          ),
+          data: Type.Array(appDataSchemaRef),
           settings: Type.Array(appSettingSchemaRef),
-          actions: Type.Array(
-            // remove deprecated `member` prop
-            Type.Omit(appActionSchemaRef, ['member']),
-          ),
+          actions: Type.Array(appActionSchemaRef),
         }),
       ),
       metadata: customType.StrictObject({

--- a/src/services/item/plugins/action/service.ts
+++ b/src/services/item/plugins/action/service.ts
@@ -141,7 +141,7 @@ export class ActionItemService {
       startDate?: string;
       endDate?: string;
     },
-  ): Promise<Omit<BaseAnalytics, 'itemMemberships'>> {
+  ): Promise<BaseAnalytics> {
     // prevent access from unautorized members
     if (!actor) {
       throw new UnauthorizedMember();
@@ -172,7 +172,6 @@ export class ActionItemService {
       startDate: payload.startDate,
       endDate: payload.endDate,
     });
-    console.log('actions', actions);
 
     // get memberships
     const inheritedMemberships =
@@ -182,7 +181,7 @@ export class ActionItemService {
     // get members
     const members =
       permission === PermissionLevel.Admin ? allMemberships.map(({ account }) => account) : [actor];
-    console.log('members', members);
+
     // get descendants items
     const descendants = await this.itemService.getFilteredDescendants(
       actor,
@@ -223,10 +222,9 @@ export class ActionItemService {
 
       apps[appId] = { data: appData, actions: appActions, settings: appSettings };
     }
-    console.log(allMemberships);
+
     // set all data in last task's result
-    // remove the itemMemberships
-    const { itemMemberships: _, ...result } = new BaseAnalytics({
+    return new BaseAnalytics({
       item,
       descendants,
       actions,
@@ -239,7 +237,6 @@ export class ActionItemService {
         requestedSampleSize: payload.sampleSize ?? MAX_ACTIONS_SAMPLE_SIZE,
       },
     });
-    return result;
   }
 
   async postPostAction(request: FastifyRequest, repositories: Repositories, item: Item) {

--- a/src/services/item/plugins/action/service.ts
+++ b/src/services/item/plugins/action/service.ts
@@ -141,7 +141,7 @@ export class ActionItemService {
       startDate?: string;
       endDate?: string;
     },
-  ): Promise<BaseAnalytics> {
+  ): Promise<Omit<BaseAnalytics, 'itemMemberships'>> {
     // prevent access from unautorized members
     if (!actor) {
       throw new UnauthorizedMember();
@@ -172,6 +172,7 @@ export class ActionItemService {
       startDate: payload.startDate,
       endDate: payload.endDate,
     });
+    console.log('actions', actions);
 
     // get memberships
     const inheritedMemberships =
@@ -181,7 +182,7 @@ export class ActionItemService {
     // get members
     const members =
       permission === PermissionLevel.Admin ? allMemberships.map(({ account }) => account) : [actor];
-
+    console.log('members', members);
     // get descendants items
     const descendants = await this.itemService.getFilteredDescendants(
       actor,
@@ -222,9 +223,10 @@ export class ActionItemService {
 
       apps[appId] = { data: appData, actions: appActions, settings: appSettings };
     }
-
+    console.log(allMemberships);
     // set all data in last task's result
-    return new BaseAnalytics({
+    // remove the itemMemberships
+    const { itemMemberships: _, ...result } = new BaseAnalytics({
       item,
       descendants,
       actions,
@@ -237,6 +239,7 @@ export class ActionItemService {
         requestedSampleSize: payload.sampleSize ?? MAX_ACTIONS_SAMPLE_SIZE,
       },
     });
+    return result;
   }
 
   async postPostAction(request: FastifyRequest, repositories: Repositories, item: Item) {

--- a/src/services/item/plugins/action/test/fixtures/actions.ts
+++ b/src/services/item/plugins/action/test/fixtures/actions.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Context } from '@graasp/sdk';
+import { ActionTriggers, Context } from '@graasp/sdk';
 
 import { Account } from '../../../../../account/entities/account';
 import { Action } from '../../../../../action/entities/action';
@@ -9,9 +9,9 @@ import { Member } from '../../../../../member/entities/member';
 import { Item } from '../../../../entities/Item';
 import { ItemActionType } from '../../utils';
 
-const getDummyAction = (
+export const getDummyAction = (
   view: Context,
-  type: ItemActionType,
+  type: ItemActionType | ActionTriggers,
   createdAt: Date,
   account: Account,
   item: Item,
@@ -62,6 +62,20 @@ const buildActions = (item: Item, member: Member[]) => {
     getDummyAction(
       Context.Builder,
       ItemActionType.Update,
+      new Date('2023-05-21T03:46:52.939Z'),
+      member[2],
+      item,
+    ),
+    getDummyAction(
+      Context.Player,
+      ItemActionType.Update,
+      new Date('2023-05-21T03:46:52.939Z'),
+      member[2],
+      item,
+    ),
+    getDummyAction(
+      Context.Builder,
+      ActionTriggers.CollectionView,
       new Date('2023-05-21T03:46:52.939Z'),
       member[2],
       item,

--- a/src/services/item/plugins/action/test/index.test.ts
+++ b/src/services/item/plugins/action/test/index.test.ts
@@ -35,10 +35,6 @@ import { ActionRequestExportRepository } from '../requestExport/repository';
 import { ItemActionType } from '../utils';
 import { getDummyAction, saveActions } from './fixtures/actions';
 
-function ActionArrayFrom(length: number, actionTemplate: Partial<Action>) {
-  return Array.from({ length }, () => actionTemplate);
-}
-
 const actionRequestExportRepository = new ActionRequestExportRepository();
 const rawActionRepository = AppDataSource.getRepository(Action);
 const testUtils = new ItemTestUtils();

--- a/src/services/item/plugins/action/test/index.test.ts
+++ b/src/services/item/plugins/action/test/index.test.ts
@@ -427,15 +427,25 @@ describe('Action Plugin Tests', () => {
         query: parameters,
       });
 
-      expect(response.json()).toHaveProperty([0, 'actionType'], ItemActionType.Create);
-      expect(response.json()).toHaveProperty([0, 'aggregateResult']);
-      expect(parseFloat(response.json()[0]['aggregateResult'])).toBeCloseTo(1);
-      expect(response.json()).toHaveProperty([0, 'createdDay'], '2023-05-20T00:00:00.000Z');
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      const result = await response.json();
 
-      expect(response.json()).toHaveProperty([1, 'actionType'], ItemActionType.Update);
-      expect(response.json()).toHaveProperty([1, 'aggregateResult']);
-      expect(parseFloat(response.json()[1]['aggregateResult'])).toBeCloseTo(1.33);
-      expect(response.json()).toHaveProperty([1, 'createdDay'], '2023-05-21T00:00:00.000Z');
+      const expectCreate = result.find((r) => r.actionType === ItemActionType.Create);
+      expect(expectCreate).toBeDefined();
+      expect(parseFloat(expectCreate['aggregateResult'])).toBeCloseTo(1);
+      expect(expectCreate['createdDay']).toEqual('2023-05-20T00:00:00.000Z');
+
+      const expectUpdate = result.find((r) => r.actionType === ItemActionType.Update);
+      expect(expectUpdate).toBeDefined();
+      expect(parseFloat(expectUpdate['aggregateResult'])).toBeCloseTo(1.33);
+      expect(expectUpdate['createdDay']).toEqual('2023-05-21T00:00:00.000Z');
+
+      const expectCollectionView = result.find(
+        (r) => r.actionType === ActionTriggers.CollectionView,
+      );
+      expect(expectCollectionView).toBeDefined();
+      expect(parseFloat(expectCollectionView['aggregateResult'])).toBeCloseTo(1);
+      expect(expectCollectionView['createdDay']).toEqual('2023-05-21T00:00:00.000Z');
     });
 
     it('Successfully get the number of active user by day', async () => {
@@ -489,13 +499,22 @@ describe('Action Plugin Tests', () => {
         query: parameters,
       });
 
-      expect(response.json()).toHaveProperty([0, 'actionType'], ItemActionType.Create);
-      expect(response.json()).toHaveProperty([0, 'aggregateResult']);
-      expect(parseFloat(response.json()[0]['aggregateResult'])).toBeCloseTo(1);
+      expect(response.statusCode).toEqual(StatusCodes.OK);
+      const result = await response.json();
 
-      expect(response.json()).toHaveProperty([1, 'actionType'], ItemActionType.Update);
-      expect(response.json()).toHaveProperty([1, 'aggregateResult']);
-      expect(parseFloat(response.json()[1]['aggregateResult'])).toBeCloseTo(4);
+      const expectCreate = result.find((r) => r.actionType === ItemActionType.Create);
+      expect(expectCreate).toBeDefined();
+      expect(parseFloat(expectCreate['aggregateResult'])).toBeCloseTo(1);
+
+      const expectUpdate = result.find((r) => r.actionType === ItemActionType.Update);
+      expect(expectUpdate).toBeDefined();
+      expect(parseFloat(expectUpdate['aggregateResult'])).toBeCloseTo(4);
+
+      const expectCollectionView = result.find(
+        (r) => r.actionType === ActionTriggers.CollectionView,
+      );
+      expect(expectCollectionView).toBeDefined();
+      expect(parseFloat(expectCollectionView['aggregateResult'])).toBeCloseTo(1);
     });
 
     it('Successfully get the total action count within specific period', async () => {
@@ -519,10 +538,17 @@ describe('Action Plugin Tests', () => {
         url: `items/${item.id}/actions/aggregation`,
         query: parameters,
       });
+      const result = await response.json();
 
-      expect(response.json()).toHaveProperty([0, 'actionType'], ItemActionType.Update);
-      expect(response.json()).toHaveProperty([0, 'aggregateResult']);
-      expect(parseFloat(response.json()[0]['aggregateResult'])).toBeCloseTo(4);
+      const expectUpdate = result.find((r) => r.actionType === ItemActionType.Update);
+      expect(expectUpdate).toBeDefined();
+      expect(expectUpdate['aggregateResult']).toBeCloseTo(4);
+
+      const expectCollectionView = result.find(
+        (r) => r.actionType === ActionTriggers.CollectionView,
+      );
+      expect(expectCollectionView).toBeDefined();
+      expect(expectCollectionView['aggregateResult']).toBeCloseTo(1);
     });
 
     it('Successfully get the total action count aggregated by time of day', async () => {
@@ -546,13 +572,15 @@ describe('Action Plugin Tests', () => {
         query: parameters,
       });
 
-      expect(response.json()).toHaveProperty([0, 'createdTimeOfDay'], '3');
-      expect(response.json()).toHaveProperty([0, 'aggregateResult']);
-      expect(parseFloat(response.json()[0]['aggregateResult'])).toBeCloseTo(1);
+      const result = await response.json();
 
-      expect(response.json()).toHaveProperty([1, 'createdTimeOfDay'], '8');
-      expect(response.json()).toHaveProperty([1, 'aggregateResult']);
-      expect(parseFloat(response.json()[1]['aggregateResult'])).toBeCloseTo(4);
+      const expectCreatedAt3 = result.find((r) => r.createdTimeOfDay === '3');
+      expect(expectCreatedAt3).toBeDefined();
+      expect(parseFloat(expectCreatedAt3['aggregateResult'])).toBeCloseTo(2);
+
+      const expectCreatedAt8 = result.find((r) => r.createdTimeOfDay === '8');
+      expect(expectCreatedAt8).toBeDefined();
+      expect(parseFloat(expectCreatedAt8['aggregateResult'])).toBeCloseTo(4);
     });
 
     it('Bad request if query parameters are invalid (aggregated by user)', async () => {

--- a/src/services/item/plugins/app/appData/plugins/file/schema.ts
+++ b/src/services/item/plugins/app/appData/plugins/file/schema.ts
@@ -6,7 +6,7 @@ import { AppDataVisibility } from '@graasp/sdk';
 import { customType } from '../../../../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../../../../schemas/global';
 import { APP_DATA_TYPE_FILE } from '../../../constants';
-import { appDataSchemaRef } from '../../schemas';
+import { appDataWithLegacyPropsSchemaRef } from '../../schemas';
 
 export const upload = {
   operationId: 'createAppDataFile',
@@ -15,7 +15,7 @@ export const upload = {
   description: `Upload a file to create a corresponding app data. The created app data will be "${APP_DATA_TYPE_FILE}" and visibility ${AppDataVisibility.Member}. The data property will contain the file properties.`,
 
   response: {
-    [StatusCodes.OK]: appDataSchemaRef,
+    [StatusCodes.OK]: appDataWithLegacyPropsSchemaRef,
     '4xx': errorSchemaRef,
   },
 };

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -33,5 +33,6 @@ export const printFilledSQL = <T extends ObjectLiteral>(query: QueryBuilder<T>) 
     }
   });
 
+  // eslint-disable-next-line no-console
   console.log(`SQLPRINT: ${sql}`);
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es5", "es6", "esnext.asynciterable"],
+    "lib": ["es2021", "es6", "esnext.asynciterable"],
     "target": "es6",
     "module": "Node16",
     // "strict": true, // TODO: enable


### PR DESCRIPTION
In this PR: 
- fix some schema issues with the aggregation and action endpoints used by analytics.

Question:
@pyphilia Can you give me feedback on these issues:
- I have modified the appActionSchema definition in the analytics return since we do not return the deprecated `member` attribute in the data. Do you think I should instead create a "standard appAction schema" and then extend that one with the legacy `member` prop for use in the appAction endpoint ? So all other schemas that may build on top of appAction can use the "standard" instead of having to each time strip the legacy prop ?
- I have removed the `itemMemberships` props from the return. But we still retrieve it from the DB and process it. Ideally we would use a different function.Should this be done now, or later ? 
- I haven't implemented specific tests for this, and it looks like there were no such tests before since the issue was present in production. How much coverage do you think we should have on this ? If we plan on improving these endpoints, do we need to fully cover their current functionality ?
