### PR TITLE
feat: update get liked collections with meilisearch

### DIFF
--- a/src/services/item/plugins/publication/published/index.ts
+++ b/src/services/item/plugins/publication/published/index.ts
@@ -16,7 +16,6 @@ import {
   getCollectionsForMember,
   getInformations,
   getManyInformations,
-  getMostLikedItems,
   getRecentCollections,
   publishItem,
   unpublishItem,
@@ -61,17 +60,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     },
     async ({ user, query: { itemId } }) => {
       return itemPublishedService.getMany(user?.account, buildRepositories(), itemId);
-    },
-  );
-
-  fastify.get(
-    '/collections/liked',
-    {
-      preHandler: optionalIsAuthenticated,
-      schema: getMostLikedItems,
-    },
-    async ({ user, query: { limit } }) => {
-      return itemPublishedService.getLikedItems(user?.account, buildRepositories(), limit);
     },
   );
 

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 import { MultiSearchParams } from 'meilisearch';
+import { v4 } from 'uuid';
 import waitForExpect from 'wait-for-expect';
 
 import { FastifyInstance } from 'fastify';
@@ -448,6 +449,115 @@ describe('Collection Search endpoints', () => {
 
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(res.json()).toEqual(fakeResponse.results[0].facetDistribution.discipline);
+    });
+  });
+
+  describe('GET /collections/liked', () => {
+    it('get most liked items', async () => {
+      // Meilisearch is mocked so format of API doesn't matter, we just want it to proxy MultiSearchParams;
+      const fakeResponse = {
+        results: [
+          {
+            indexUid: 'index',
+            hits: [
+              {
+                name: 'Geogebra',
+                description: 'Interactive tools from geogebra for mathematics.',
+                content: '',
+                creator: {
+                  id: v4(),
+                  name: 'Graasper',
+                },
+                level: [],
+                discipline: [],
+                'resource-type': [],
+                id: v4(),
+                type: 'folder',
+                isPublishedRoot: true,
+                isHidden: false,
+                createdAt: '2021-10-20T13:12:47.821Z',
+                updatedAt: '2021-10-23T09:25:39.798Z',
+                lang: 'en',
+                likes: 9,
+                _formatted: {
+                  name: 'Geogebra',
+                  description: 'Interactive tools from geogebra for mathematics.',
+                  content: '',
+                  creator: {
+                    id: v4(),
+                    name: 'Graasper',
+                  },
+                  level: [],
+                  discipline: [],
+                  'resource-type': [],
+                  id: v4(),
+                  type: 'folder',
+                  isPublishedRoot: true,
+                  isHidden: false,
+                  createdAt: '2021-10-20T13:12:47.821Z',
+                  updatedAt: '2021-10-23T09:25:39.798Z',
+                  lang: 'en',
+                  likes: 9,
+                },
+              },
+              {
+                name: 'PhET',
+                content: '',
+                description: '',
+                creator: {
+                  id: v4(),
+                  name: 'Graasper',
+                },
+                level: [],
+                discipline: [],
+                'resource-type': [],
+                id: v4(),
+                type: 'folder',
+                isPublishedRoot: true,
+                isHidden: false,
+                createdAt: '2021-10-20T13:03:42.712Z',
+                updatedAt: '2021-11-10T10:49:39.296Z',
+                lang: 'en',
+                likes: 7,
+                _formatted: {
+                  name: 'PhET',
+                  description: '',
+                  content: '',
+                  creator: {
+                    id: v4(),
+                    name: 'Graasper',
+                  },
+                  level: [],
+                  discipline: [],
+                  'resource-type': [],
+                  id: v4(),
+                  type: 'folder',
+                  isPublishedRoot: true,
+                  isHidden: false,
+                  createdAt: '2021-10-20T13:03:42.712Z',
+                  updatedAt: '2021-11-10T10:49:39.296Z',
+                  lang: 'en',
+                  likes: 7,
+                },
+              },
+            ] as never[],
+            processingTimeMs: 123,
+            query: '',
+          },
+        ],
+      };
+      jest.spyOn(MeiliSearchWrapper.prototype, 'search').mockResolvedValue(fakeResponse);
+
+      const res = await app.inject({
+        method: HttpMethod.Get,
+        url: `${ITEMS_ROUTE_PREFIX}/collections/liked`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.OK);
+
+      // should return the likes property
+      res.json().hits.forEach(({ likes }) => {
+        expect(likes).toBeGreaterThanOrEqual(0);
+      });
     });
   });
 });

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -88,7 +88,7 @@ describe('Collection Search endpoints', () => {
         queries: [
           {
             attributesToHighlight: ['*'],
-            filter: 'isHidden = false',
+            filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
             q: undefined,
           },
@@ -145,7 +145,8 @@ describe('Collection Search endpoints', () => {
           {
             attributesToHighlight: ['*'],
             q: 'random query',
-            filter: "discipline IN ['random filter'] AND isHidden = false",
+            filter:
+              "discipline IN ['random filter'] AND isPublishedRoot = true AND isHidden = false",
             indexUid: MOCK_INDEX,
           },
         ],
@@ -174,7 +175,7 @@ describe('Collection Search endpoints', () => {
           {
             attributesToHighlight: ['*'],
             q: 'random query',
-            filter: 'isHidden = false',
+            filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
           },
         ],

--- a/src/services/item/plugins/publication/published/plugins/search/index.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.ts
@@ -64,7 +64,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
 
   fastify.get('/collections/search/rebuild', async ({ headers }, reply) => {
     // TODO: in the future, lock this behind admin permission and maybe add a button to the frontend admin panel
-    searchService.rebuildIndex();
     const headerRebuildSecret = headers['meilisearch-rebuild'];
 
     if (MEILISEARCH_REBUILD_SECRET && MEILISEARCH_REBUILD_SECRET === headerRebuildSecret) {

--- a/src/services/item/plugins/publication/published/plugins/search/index.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.ts
@@ -9,7 +9,7 @@ import { MEILISEARCH_REBUILD_SECRET } from '../../../../../../../utils/config';
 import { buildRepositories } from '../../../../../../../utils/repositories';
 import { ActionService } from '../../../../../../action/services/action';
 import { optionalIsAuthenticated } from '../../../../../../auth/plugins/passport';
-import { getFacets, search } from './schemas';
+import { getFacets, getMostLiked, search } from './schemas';
 import { SearchService } from './service';
 
 export type SearchFields = {
@@ -53,8 +53,18 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     },
   );
 
+  fastify.get(
+    '/collections/liked',
+    { preHandler: optionalIsAuthenticated, schema: getMostLiked },
+    async ({ query }) => {
+      const searchResults = await searchService.getMostLiked(query.limit);
+      return searchResults;
+    },
+  );
+
   fastify.get('/collections/search/rebuild', async ({ headers }, reply) => {
     // TODO: in the future, lock this behind admin permission and maybe add a button to the frontend admin panel
+    searchService.rebuildIndex();
     const headerRebuildSecret = headers['meilisearch-rebuild'];
 
     if (MEILISEARCH_REBUILD_SECRET && MEILISEARCH_REBUILD_SECRET === headerRebuildSecret) {

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
@@ -44,7 +44,7 @@ const SEARCHABLE_ATTRIBUTES: (keyof IndexItem)[] = [
   'creator',
   ...Object.values(TagCategory),
 ];
-const SORT_ATTRIBUTES: (keyof IndexItem)[] = ['name', 'updatedAt', 'createdAt'];
+const SORT_ATTRIBUTES: (keyof IndexItem)[] = ['name', 'updatedAt', 'createdAt', 'likes'];
 const DISPLAY_ATTRIBUTES: (keyof IndexItem)[] = [
   'id',
   'name',

--- a/src/services/item/plugins/publication/published/plugins/search/schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/schemas.ts
@@ -7,6 +7,56 @@ import { ItemType, TagCategory } from '@graasp/sdk';
 
 import { customType } from '../../../../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../../../../schemas/global';
+import { GET_MOST_LIKED_ITEMS_MAXIMUM } from '../../../../../../../utils/config';
+
+const meilisearchSearchResponseSchema = customType.StrictObject({
+  totalHits: Type.Optional(Type.Number()),
+  estimatedTotalHits: Type.Optional(Type.Number()),
+  processingTimeMs: Type.Number(),
+  query: Type.String(),
+  hits: Type.Array(
+    customType.StrictObject({
+      name: Type.String(),
+      description: Type.String(),
+      content: Type.String(),
+      creator: customType.StrictObject({
+        id: customType.UUID(),
+        name: Type.String(),
+      }),
+      level: Type.Array(Type.String()),
+      discipline: Type.Array(Type.String()),
+      'resource-type': Type.Array(Type.String()),
+      id: customType.UUID(),
+      type: Type.Enum(ItemType),
+      isPublishedRoot: Type.Boolean(),
+      isHidden: Type.Boolean(),
+      createdAt: customType.DateTime(),
+      updatedAt: customType.DateTime(),
+      lang: Type.String(),
+      likes: Type.Number(),
+      _formatted: customType.StrictObject({
+        name: Type.String(),
+        description: Type.String(),
+        content: Type.String(),
+        creator: customType.StrictObject({
+          id: customType.UUID(),
+          name: Type.String(),
+        }),
+        level: Type.Array(Type.String()),
+        discipline: Type.Array(Type.String()),
+        'resource-type': Type.Array(Type.String()),
+        id: customType.UUID(),
+        type: Type.String(),
+        isPublishedRoot: Type.Boolean(),
+        isHidden: Type.Boolean(),
+        createdAt: customType.DateTime(),
+        updatedAt: customType.DateTime(),
+        lang: Type.String(),
+        likes: Type.Number(),
+      }),
+    }),
+  ),
+});
 
 export const search = {
   operationId: 'collectionSearch',
@@ -33,54 +83,24 @@ export const search = {
     }),
   ),
   response: {
-    [StatusCodes.OK]: customType.StrictObject({
-      totalHits: Type.Optional(Type.Number()),
-      estimatedTotalHits: Type.Optional(Type.Number()),
-      processingTimeMs: Type.Number(),
-      query: Type.String(),
-      hits: Type.Array(
-        customType.StrictObject({
-          name: Type.String(),
-          description: Type.String(),
-          content: Type.String(),
-          creator: customType.StrictObject({
-            id: customType.UUID(),
-            name: Type.String(),
-          }),
-          level: Type.Array(Type.String()),
-          discipline: Type.Array(Type.String()),
-          'resource-type': Type.Array(Type.String()),
-          id: customType.UUID(),
-          type: Type.Enum(ItemType),
-          isPublishedRoot: Type.Boolean(),
-          isHidden: Type.Boolean(),
-          createdAt: customType.DateTime(),
-          updatedAt: customType.DateTime(),
-          lang: Type.String(),
-          likes: Type.Number(),
-          _formatted: customType.StrictObject({
-            name: Type.String(),
-            description: Type.String(),
-            content: Type.String(),
-            creator: customType.StrictObject({
-              id: customType.UUID(),
-              name: Type.String(),
-            }),
-            level: Type.Array(Type.String()),
-            discipline: Type.Array(Type.String()),
-            'resource-type': Type.Array(Type.String()),
-            id: customType.UUID(),
-            type: Type.String(),
-            isPublishedRoot: Type.Boolean(),
-            isHidden: Type.Boolean(),
-            createdAt: customType.DateTime(),
-            updatedAt: customType.DateTime(),
-            lang: Type.String(),
-            likes: Type.Number(),
-          }),
-        }),
-      ),
-    }),
+    [StatusCodes.OK]: meilisearchSearchResponseSchema,
+    '4xx': errorSchemaRef,
+  },
+} as const satisfies FastifySchema;
+
+export const getMostLiked = {
+  operationId: 'getMostLikedCollections',
+  tags: ['collection', 'like'],
+  summary: 'Get most liked collections',
+  description: 'Get most liked collections.',
+
+  querystring: customType.StrictObject({
+    limit: Type.Optional(
+      Type.Number({ minimum: 1, maximum: GET_MOST_LIKED_ITEMS_MAXIMUM, default: 12 }),
+    ),
+  }),
+  response: {
+    [StatusCodes.OK]: meilisearchSearchResponseSchema,
     '4xx': errorSchemaRef,
   },
 } as const satisfies FastifySchema;

--- a/src/services/item/plugins/publication/published/plugins/search/service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.test.ts
@@ -48,6 +48,7 @@ describe('search', () => {
     expect(filter).toContain("discipline IN ['fiction','hello']");
     expect(filter).toContain("level IN ['secondary school','tag:\\'hello\\'']");
     expect(filter).toContain("resource-type IN ['type']");
+    expect(filter).toContain('isHidden = false');
   });
   it('filter by langs', async () => {
     const MOCK_RESULT = { hits: [] } as never;
@@ -62,6 +63,7 @@ describe('search', () => {
 
     const { filter } = spy.mock.calls[0][0].queries[0];
     expect(filter).toContain('lang IN [fr,en]');
+    expect(filter).toContain('isHidden = false');
   });
   it('filter by published root', async () => {
     const MOCK_RESULT = { hits: [] } as never;
@@ -76,6 +78,7 @@ describe('search', () => {
 
     const { filter } = spy.mock.calls[0][0].queries[0];
     expect(filter).toContain('isPublishedRoot = true');
+    expect(filter).toContain('isHidden = false');
   });
   it('filter by query', async () => {
     const MOCK_RESULT = { hits: [] } as never;
@@ -90,6 +93,39 @@ describe('search', () => {
 
     const { q } = spy.mock.calls[0][0].queries[0];
     expect(q).toEqual('hello');
+  });
+  it('apply sort', async () => {
+    const MOCK_RESULT = { hits: [] } as never;
+    const spy = jest
+      .spyOn(meilisearchClient, 'search')
+      .mockResolvedValue({ results: [MOCK_RESULT] });
+
+    const results = await searchService.search({
+      sort: ['likes:desc'],
+    });
+    expect(results).toEqual(MOCK_RESULT);
+
+    const { sort } = spy.mock.calls[0][0].queries[0];
+    expect(sort).toEqual(['likes:desc']);
+  });
+});
+
+describe('getMostLiked', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('apply sort by likes', async () => {
+    const MOCK_RESULT = { hits: [] } as never;
+    const spy = jest
+      .spyOn(meilisearchClient, 'search')
+      .mockResolvedValue({ results: [MOCK_RESULT] });
+
+    const results = await searchService.getMostLiked(4);
+    expect(results).toEqual(MOCK_RESULT);
+
+    const { sort, limit } = spy.mock.calls[0][0].queries[0];
+    expect(sort).toEqual(['likes:desc']);
+    expect(limit).toEqual(4);
   });
 });
 

--- a/src/services/item/plugins/publication/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/publication/published/repositories/itemPublished.ts
@@ -126,20 +126,4 @@ export class ItemPublishedRepository extends AbstractRepository<ItemPublished> {
 
     return publishedInfos.map(({ item }) => item);
   }
-
-  // return public items sorted by most liked
-  // bug: does not take into account child items
-  async getLikedItems(limit: number = 10): Promise<Item[]> {
-    const itemPublished = await this.repository
-      .createQueryBuilder('item_published')
-      .innerJoinAndSelect('item_published.item', 'item')
-      .innerJoinAndSelect('item.creator', 'member')
-      .innerJoin('item_like', 'il', 'il.item_id = item.id')
-      .groupBy('item.id, member.id, item_published.id')
-      .orderBy('COUNT(il.id)', 'DESC')
-      .limit(limit)
-      .getMany();
-
-    return itemPublished.map(({ item }) => item);
-  }
 }

--- a/src/services/item/plugins/publication/published/schemas.ts
+++ b/src/services/item/plugins/publication/published/schemas.ts
@@ -5,10 +5,7 @@ import { MAX_TARGETS_FOR_READ_REQUEST } from '@graasp/sdk';
 
 import { customType } from '../../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../../schemas/global';
-import {
-  GET_MOST_LIKED_ITEMS_MAXIMUM,
-  GET_MOST_RECENT_ITEMS_MAXIMUM,
-} from '../../../../../utils/config';
+import { GET_MOST_RECENT_ITEMS_MAXIMUM } from '../../../../../utils/config';
 import { nullableMemberSchemaRef } from '../../../../member/schemas';
 import { itemSchemaRef } from '../../../schemas';
 import { packedItemSchemaRef } from '../../../schemas.packed';
@@ -39,25 +36,6 @@ export const getRecentCollections = {
     }),
   }),
 
-  response: {
-    [StatusCodes.OK]: Type.Array(itemSchemaRef),
-    '4xx': errorSchemaRef,
-  },
-};
-
-export const getMostLikedItems = {
-  operationId: 'getMostLikedCollections',
-  tags: ['collection'],
-  summary: 'Get most liked items',
-  description: 'Get most liked items (collections)',
-
-  querystring: customType.StrictObject({
-    limit: Type.Number({
-      maximum: GET_MOST_LIKED_ITEMS_MAXIMUM,
-      minimum: 1,
-      default: 24,
-    }),
-  }),
   response: {
     [StatusCodes.OK]: Type.Array(itemSchemaRef),
     '4xx': errorSchemaRef,

--- a/src/services/item/plugins/publication/published/service.ts
+++ b/src/services/item/plugins/publication/published/service.ts
@@ -235,12 +235,6 @@ export class ItemPublishedService {
     return ItemWrapper.createPackedItems(actor, repositories, this.itemThumbnailService, items);
   }
 
-  async getLikedItems(actor: Actor, repositories: Repositories, limit?: number) {
-    const { itemPublishedRepository } = repositories;
-    const items = await itemPublishedRepository.getLikedItems(limit);
-    return filterOutHiddenItems(repositories, items);
-  }
-
   async getRecentItems(actor: Actor, repositories: Repositories, limit?: number) {
     const { itemPublishedRepository } = repositories;
     const items = await itemPublishedRepository.getRecentItems(limit);

--- a/src/services/item/plugins/publication/published/test/index.test.ts
+++ b/src/services/item/plugins/publication/published/test/index.test.ts
@@ -16,7 +16,7 @@ import { AppDataSource } from '../../../../../../plugins/datasource';
 import { MailerService } from '../../../../../../plugins/mailer/service';
 import { ITEMS_ROUTE_PREFIX } from '../../../../../../utils/config';
 import { ItemNotFound, MemberCannotAdminItem } from '../../../../../../utils/errors';
-import { saveMember, saveMembers } from '../../../../../member/test/fixtures/members';
+import { saveMember } from '../../../../../member/test/fixtures/members';
 import { Item } from '../../../../entities/Item';
 import {
   ItemTestUtils,
@@ -24,8 +24,6 @@ import {
   expectManyItems,
   expectManyPackedItems,
 } from '../../../../test/fixtures/items';
-import { ItemLike } from '../../../itemLike/itemLike';
-import { saveItemLikes } from '../../../itemLike/test/utils';
 import { ItemVisibility } from '../../../itemVisibility/ItemVisibility';
 import { ItemVisibilityNotFound } from '../../../itemVisibility/errors';
 import { saveItemValidation } from '../../validation/test/utils';

--- a/src/services/item/plugins/publication/published/test/index.test.ts
+++ b/src/services/item/plugins/publication/published/test/index.test.ts
@@ -190,57 +190,6 @@ describe('Item Published', () => {
     });
   });
 
-  describe('GET /collections/liked', () => {
-    describe('Signed Out', () => {
-      let members;
-      let collections: Item[];
-      const likes: ItemLike[] = [];
-
-      beforeEach(async () => {
-        members = await saveMembers();
-        ({ items: collections } = await testUtils.saveCollections(members[0]));
-
-        // add idx x likes
-        for (const [idx, c] of collections.entries()) {
-          for (const m of members.slice(idx)) {
-            likes.concat(await saveItemLikes([c], m));
-          }
-        }
-      });
-
-      it('Get 2 most liked collections', async () => {
-        const res = await app.inject({
-          method: HttpMethod.Get,
-          url: `${ITEMS_ROUTE_PREFIX}/collections/liked`,
-          query: { limit: '2' },
-        });
-
-        const result = collections.slice(0, -1);
-
-        expect(res.statusCode).toBe(StatusCodes.OK);
-        expectManyItems(res.json(), result);
-      });
-
-      it('Get 2 most liked collections without hidden', async () => {
-        // hide first collection
-        const hiddenCollection = collections[0];
-        await rawRepository.save({
-          item: hiddenCollection,
-          creator: actor,
-          type: ItemVisibilityType.Hidden,
-        });
-
-        const res = await app.inject({
-          method: HttpMethod.Get,
-          url: `${ITEMS_ROUTE_PREFIX}/collections/liked`,
-        });
-
-        expect(res.statusCode).toBe(StatusCodes.OK);
-        expect(res.json().map(({ id }) => id)).not.toContain(hiddenCollection.id);
-      });
-    });
-  });
-
   describe('GET /collections/members/:memberId', () => {
     describe('Signed Out', () => {
       it('Returns published collections for member', async () => {


### PR DESCRIPTION
- moved `/collections/liked` from published -> search 
- use meilisearch to get the most liked items

ref #1714