### PR TITLE
refactor: remove copy post hooks

### DIFF
--- a/src/services/action/services/action.test.ts
+++ b/src/services/action/services/action.test.ts
@@ -7,6 +7,7 @@ import { BaseLogger } from '../../../logger';
 import { AppDataSource } from '../../../plugins/datasource';
 import { MailerService } from '../../../plugins/mailer/service';
 import { buildRepositories } from '../../../utils/repositories';
+import { MeiliSearchWrapper } from '../../item/plugins/publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../../item/plugins/thumbnail/service';
 import { ItemService } from '../../item/service';
 import { MemberService } from '../../member/service';
@@ -16,7 +17,12 @@ import { Action } from '../entities/action';
 import { ActionService } from './action';
 
 const service = new ActionService(
-  new ItemService({} as ThumbnailService, {} as ItemThumbnailService, {} as BaseLogger),
+  new ItemService(
+    {} as ThumbnailService,
+    {} as ItemThumbnailService,
+    {} as MeiliSearchWrapper,
+    {} as BaseLogger,
+  ),
   new MemberService({} as MailerService, {} as BaseLogger),
 );
 const rawRepository = AppDataSource.getRepository(Action);

--- a/src/services/item/plugins/action/service.test.ts
+++ b/src/services/item/plugins/action/service.test.ts
@@ -33,6 +33,7 @@ import { ThumbnailService } from '../../../thumbnail/service';
 import { ItemService } from '../../service';
 import { ItemTestUtils, expectItem } from '../../test/fixtures/items';
 import { saveAppActions } from '../app/appAction/test/fixtures';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { ActionItemService } from './service';
 import { ItemActionType } from './utils';
@@ -40,6 +41,7 @@ import { ItemActionType } from './utils';
 const itemService = new ItemService(
   {} as ThumbnailService,
   {} as ItemThumbnailService,
+  {} as MeiliSearchWrapper,
   {} as BaseLogger,
 );
 const memberService = new MemberService({} as MailerService, {} as BaseLogger);

--- a/src/services/item/plugins/document/service.test.ts
+++ b/src/services/item/plugins/document/service.test.ts
@@ -15,12 +15,14 @@ import { DocumentItem, Item } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
 import { ItemRepository } from '../../repository';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { DocumentItemService } from './service';
 
 const documentService = new DocumentItemService(
   {} as unknown as ThumbnailService,
   {} as unknown as ItemThumbnailService,
+  {} as unknown as MeiliSearchWrapper,
   MOCK_LOGGER,
 );
 const id = v4();

--- a/src/services/item/plugins/document/service.ts
+++ b/src/services/item/plugins/document/service.ts
@@ -10,6 +10,7 @@ import { ThumbnailService } from '../../../thumbnail/service';
 import { DocumentItem, Item, isItemType } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 
 export const PREFIX_DOCUMENT = 'documents';
@@ -19,9 +20,10 @@ export class DocumentItemService extends ItemService {
   constructor(
     thumbnailService: ThumbnailService,
     itemThumbnailService: ItemThumbnailService,
+    meilisearchWrapper: MeiliSearchWrapper,
     log: BaseLogger,
   ) {
-    super(thumbnailService, itemThumbnailService, log);
+    super(thumbnailService, itemThumbnailService, meilisearchWrapper, log);
   }
 
   /**

--- a/src/services/item/plugins/embeddedLink/service.test.ts
+++ b/src/services/item/plugins/embeddedLink/service.test.ts
@@ -12,6 +12,7 @@ import { EmbeddedLinkItem, Item } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
 import { ItemRepository } from '../../repository';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { EmbeddedLinkItemService } from './service';
 
@@ -20,6 +21,7 @@ jest.mock('node-fetch');
 const linkService = new EmbeddedLinkItemService(
   {} as unknown as ThumbnailService,
   {} as unknown as ItemThumbnailService,
+  {} as MeiliSearchWrapper,
   MOCK_LOGGER,
   EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN,
 );

--- a/src/services/item/plugins/embeddedLink/service.ts
+++ b/src/services/item/plugins/embeddedLink/service.ts
@@ -20,6 +20,7 @@ import { ThumbnailService } from '../../../thumbnail/service';
 import { EmbeddedLinkItem, Item, isItemType } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { InvalidUrl } from './errors';
 import { isValidUrl } from './utils';
@@ -64,10 +65,11 @@ export class EmbeddedLinkItemService extends ItemService {
   constructor(
     thumbnailService: ThumbnailService,
     itemThumbnailService: ItemThumbnailService,
+    meilisearchWrapper: MeiliSearchWrapper,
     log: BaseLogger,
     @inject(IFRAMELY_API_DI_KEY) iframelyHrefOrigin: string,
   ) {
-    super(thumbnailService, itemThumbnailService, log);
+    super(thumbnailService, itemThumbnailService, meilisearchWrapper, log);
     this.iframelyHrefOrigin = iframelyHrefOrigin;
   }
 

--- a/src/services/item/plugins/embeddedLink/test/service.test.ts
+++ b/src/services/item/plugins/embeddedLink/test/service.test.ts
@@ -3,6 +3,7 @@ import fetch, { Response } from 'node-fetch';
 import { BaseLogger } from '../../../../../logger';
 import { EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN } from '../../../../../utils/config';
 import { ThumbnailService } from '../../../../thumbnail/service';
+import { MeiliSearchWrapper } from '../../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../../thumbnail/service';
 import { EmbeddedLinkItemService } from '../service';
 import { FAKE_URL, FETCH_RESULT, expectedResult } from './fixtures';
@@ -24,6 +25,7 @@ export const mockHeaderResponse = (headers: { [key: string]: string }) => {
 const embeddedLinkService = new EmbeddedLinkItemService(
   {} as ThumbnailService,
   {} as ItemThumbnailService,
+  {} as MeiliSearchWrapper,
   {} as BaseLogger,
   EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN,
 );

--- a/src/services/item/plugins/etherpad/service.test.ts
+++ b/src/services/item/plugins/etherpad/service.test.ts
@@ -14,6 +14,7 @@ import { EtherpadItem } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
 import { ItemRepository } from '../../repository';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { EtherpadItemService } from './service';
 import { EtherpadServiceConfig } from './serviceConfig';
@@ -26,6 +27,7 @@ const etherPadConfig = resolveDependency(EtherpadServiceConfig);
 const itemService = new ItemService(
   {} as ThumbnailService,
   {} as ItemThumbnailService,
+  {} as MeiliSearchWrapper,
   MOCK_LOGGER,
 );
 const etherpad = {

--- a/src/services/item/plugins/folder/service.test.ts
+++ b/src/services/item/plugins/folder/service.test.ts
@@ -9,12 +9,14 @@ import { ThumbnailService } from '../../../thumbnail/service';
 import { Item } from '../../entities/Item';
 import { ItemRepository } from '../../repository';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 import { FolderItemService } from './service';
 
 const folderService = new FolderItemService(
   {} as unknown as ThumbnailService,
   {} as unknown as ItemThumbnailService,
+  {} as MeiliSearchWrapper,
   MOCK_LOGGER,
 );
 const id = v4();

--- a/src/services/item/plugins/folder/service.ts
+++ b/src/services/item/plugins/folder/service.ts
@@ -10,6 +10,7 @@ import { ThumbnailService } from '../../../thumbnail/service';
 import { FolderItem, Item } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
 import { ItemService } from '../../service';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { ItemThumbnailService } from '../thumbnail/service';
 
 @singleton()
@@ -17,9 +18,10 @@ export class FolderItemService extends ItemService {
   constructor(
     thumbnailService: ThumbnailService,
     itemThumbnailService: ItemThumbnailService,
+    meilisearchWrapper: MeiliSearchWrapper,
     log: BaseLogger,
   ) {
-    super(thumbnailService, itemThumbnailService, log);
+    super(thumbnailService, itemThumbnailService, meilisearchWrapper, log);
   }
 
   async post(

--- a/src/services/item/plugins/geolocation/service.test.ts
+++ b/src/services/item/plugins/geolocation/service.test.ts
@@ -16,6 +16,7 @@ import { ThumbnailService } from '../../../thumbnail/service';
 import { ItemWrapper } from '../../ItemWrapper';
 import { ItemService } from '../../service';
 import { ItemTestUtils } from '../../test/fixtures/items';
+import { MeiliSearchWrapper } from '../publication/published/plugins/search/meilisearch';
 import { StubItemThumbnailService } from '../thumbnail/test/fixtures/itemThumbnailService';
 import { ItemGeolocation } from './ItemGeolocation';
 import { ItemGeolocationService } from './service';
@@ -25,7 +26,12 @@ const testUtils = new ItemTestUtils();
 const stubItemThumbnailService = StubItemThumbnailService();
 
 const service = new ItemGeolocationService(
-  new ItemService({} as ThumbnailService, stubItemThumbnailService, {} as BaseLogger),
+  new ItemService(
+    {} as ThumbnailService,
+    stubItemThumbnailService,
+    {} as MeiliSearchWrapper,
+    {} as BaseLogger,
+  ),
   stubItemThumbnailService,
   'geolocation-key',
 );

--- a/src/services/item/plugins/itemVisibility/index.ts
+++ b/src/services/item/plugins/itemVisibility/index.ts
@@ -1,7 +1,5 @@
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { ItemVisibilityType } from '@graasp/sdk';
-
 import { resolveDependency } from '../../../../di/utils';
 import { asDefined } from '../../../../utils/assertions';
 import { buildRepositories } from '../../../../utils/repositories';
@@ -9,8 +7,6 @@ import { isAuthenticated } from '../../../auth/plugins/passport';
 import { matchOne } from '../../../authorization';
 import { assertIsMember } from '../../../member/entities/member';
 import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
-import { Item } from '../../entities/Item';
-import { ItemService } from '../../service';
 import { create, deleteOne } from './schemas';
 import { ItemVisibilityService } from './service';
 
@@ -27,16 +23,7 @@ import { ItemVisibilityService } from './service';
 const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   const { db } = fastify;
 
-  const itemService = resolveDependency(ItemService);
   const itemVisibilityService = resolveDependency(ItemVisibilityService);
-
-  // copy visibilities alongside item
-  const hook = async (actor, repositories, { original, copy }: { original: Item; copy: Item }) => {
-    await repositories.itemVisibilityRepository.copyAll(actor, original, copy, [
-      ItemVisibilityType.Public,
-    ]);
-  };
-  itemService.hooks.setPostHook('copy', hook);
 
   fastify.post(
     '/:itemId/visibilities/:type',

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -344,35 +344,6 @@ describe('Collection Search endpoints', () => {
           expect(deleteSpy.mock.calls[0][0].id).toEqual(unpublishedItem.id);
         });
       });
-
-      it('Copy', async () => {
-        const { item: unpublishedItem } = await testUtils.saveItemAndMembership({
-          member: actor,
-          item: { name: 'unpublishedItem' },
-        });
-
-        const initialCount = await testUtils.rawItemRepository.count();
-        const copy = await app.inject({
-          method: HttpMethod.Post,
-          url: '/items/copy',
-          query: { id: unpublishedItem.id },
-          payload: {
-            parentId: publishedFolder.id,
-          },
-        });
-
-        expect(copy.statusCode).toBe(StatusCodes.ACCEPTED);
-
-        await waitForExpect(async () => {
-          const newCount = await testUtils.rawItemRepository.count();
-          expect(newCount).toEqual(initialCount + 1);
-        }, 1000);
-
-        expect(indexSpy).toHaveBeenCalledTimes(1);
-        // Topmost published at destination is reindexed
-        expect(indexSpy.mock.calls[0][0].id).not.toEqual(unpublishedItem.id);
-        expect(indexSpy.mock.calls[0][0].name).toEqual('unpublishedItem');
-      });
     });
   });
 

--- a/src/services/item/plugins/publication/published/plugins/search/service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.ts
@@ -168,22 +168,6 @@ export class SearchService {
       }
     });
 
-    itemService.hooks.setPostHook('copy', async (member, repositories, { copy: item }) => {
-      try {
-        // Check if the item is published (or has published parent)
-        const published = await repositories.itemPublishedRepository.getForItem(item);
-
-        if (!published) {
-          return;
-        }
-
-        // update index
-        await this.meilisearchClient.indexOne(item, repositories);
-      } catch (e) {
-        this.logger.error('Error during indexation, Meilisearch may be down');
-      }
-    });
-
     itemService.hooks.setPostHook('update', async (member, repositories, { item }) => {
       try {
         // Check if the item is published (or has published parent)


### PR DESCRIPTION
Move hooks in item service directly.
- Index copied items if they are copied in a published item
- Copy hidden tags
ref #1635