### PR TITLE
feat(published-search): allow creator id filter

### DIFF
--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -164,6 +164,35 @@ describe('Collection Search endpoints', () => {
       expect(searchSpy).toHaveBeenCalledWith(expectedQuery);
     });
 
+    it('search with creator id', async () => {
+      actor = await saveMember();
+      mockAuthenticate(actor);
+
+      const searchSpy = jest.spyOn(MeiliSearchWrapper.prototype, 'search');
+      const creatorId = v4();
+      const expectedQuery: MultiSearchParams = {
+        queries: [
+          {
+            attributesToHighlight: ['*'],
+            q: 'random query',
+            filter: `isPublishedRoot = true AND creator.id = '${creatorId}' AND isHidden = false`,
+            indexUid: MOCK_INDEX,
+          },
+        ],
+      };
+
+      await app.inject({
+        method: HttpMethod.Post,
+        url: `${ITEMS_ROUTE_PREFIX}/collections/search`,
+        payload: {
+          query: 'random query',
+          creatorId,
+        },
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(expectedQuery);
+    });
+
     it('works with empty filters', async () => {
       actor = await saveMember();
       mockAuthenticate(actor);

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
@@ -65,6 +65,7 @@ const FILTERABLE_ATTRIBUTES: (keyof IndexItem)[] = [
   'isHidden',
   'lang',
   'likes',
+  'creator',
   ...Object.values(TagCategory),
 ];
 const TYPO_TOLERANCE: TypoTolerance = {

--- a/src/services/item/plugins/publication/published/plugins/search/schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/schemas.ts
@@ -80,6 +80,7 @@ export const search = {
       tags: Type.Partial(Type.Record(Type.Enum(TagCategory), Type.Array(Type.String()))),
       langs: Type.Array(Type.String()),
       isPublishedRoot: Type.Boolean(),
+      creatorId: customType.UUID(),
     }),
   ),
   response: {

--- a/src/services/item/plugins/publication/published/plugins/search/service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.test.ts
@@ -1,3 +1,5 @@
+import { v4 } from 'uuid';
+
 import { MOCK_LOGGER } from '../../../../../../../../test/app';
 import HookManager from '../../../../../../../utils/hook';
 import { ItemService } from '../../../../../service';
@@ -93,6 +95,21 @@ describe('search', () => {
 
     const { q } = spy.mock.calls[0][0].queries[0];
     expect(q).toEqual('hello');
+  });
+  it('filter by creator id', async () => {
+    const MOCK_RESULT = { hits: [] } as never;
+    const spy = jest
+      .spyOn(meilisearchClient, 'search')
+      .mockResolvedValue({ results: [MOCK_RESULT] });
+
+    const creatorId = v4();
+    const results = await searchService.search({
+      creatorId,
+    });
+    expect(results).toEqual(MOCK_RESULT);
+
+    const { filter } = spy.mock.calls[0][0].queries[0];
+    expect(filter).toContain(`creator.id = '${creatorId}'`);
   });
   it('apply sort', async () => {
     const MOCK_RESULT = { hits: [] } as never;

--- a/src/services/item/plugins/publication/published/schemas.ts
+++ b/src/services/item/plugins/publication/published/schemas.ts
@@ -46,7 +46,7 @@ export const getCollectionsForMember = {
   operationId: 'getCollectionsForMember',
   tags: ['collection'],
   summary: 'Get collections for member',
-  description: 'Get collections for member.',
+  description: 'Get packed collections for member, used in the builder view of the member.',
 
   params: customType.StrictObject({
     memberId: customType.UUID(),


### PR DESCRIPTION
Allow creator id in filter for search in meilisearch. The goal is to use this call in library.

I didn't remove the current `/collections/<memberId>` because it is used by builder (packed collections). Because it requires packed info, it won't be so easy to replace with the search call. So it will require some changes from the front first to remove the call definitely.

ref #1714