### PR TITLE
refactor: remove usage of `throwOnForbiddenPermission` for item service get

### DIFF
--- a/src/services/item/service.test.ts
+++ b/src/services/item/service.test.ts
@@ -26,16 +26,20 @@ describe('Item Service', () => {
   let app: FastifyInstance;
   let actor;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     ({ app, actor } = await build());
   });
 
-  afterEach(async () => {
-    jest.clearAllMocks();
+  afterAll(async () => {
     await clearDatabase(app.db);
-    actor = null;
     app.close();
   });
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    actor = null;
+  });
+
   describe('get', () => {
     it('return item if exists and pass validation', async () => {
       const item = FolderItemFactory() as unknown as Item;

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -215,21 +215,16 @@ export class ItemService {
     repositories: Repositories,
     id: string,
     permission: PermissionLevel = PermissionLevel.Read,
-    throwOnForbiddenPermission: boolean = true,
   ) {
     const item = await repositories.itemRepository.getOneOrThrow(id);
 
-    if (throwOnForbiddenPermission) {
-      const { itemMembership, visibilities } = await validatePermission(
-        repositories,
-        permission,
-        actor,
-        item,
-      );
-      return { item, itemMembership, visibilities };
-    }
-
-    return { item, itemMembership: null, visibilities: [] };
+    const { itemMembership, visibilities } = await validatePermission(
+      repositories,
+      permission,
+      actor,
+      item,
+    );
+    return { item, itemMembership, visibilities };
   }
 
   /**
@@ -245,15 +240,8 @@ export class ItemService {
     repositories: Repositories,
     id: string,
     permission: PermissionLevel = PermissionLevel.Read,
-    throwOnForbiddenPermission?: boolean,
   ) {
-    const { item } = await this._get(
-      actor,
-      repositories,
-      id,
-      permission,
-      throwOnForbiddenPermission,
-    );
+    const { item } = await this._get(actor, repositories, id, permission);
 
     return item;
   }

--- a/src/services/itemLogin/index.ts
+++ b/src/services/itemLogin/index.ts
@@ -43,13 +43,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         const repositories = buildRepositories(manager);
 
         // Get item to have the path
-        const item = await itemService.get(
-          user?.account,
-          repositories,
-          itemId,
-          PermissionLevel.Read,
-          false,
-        );
+        const item = await repositories.itemRepository.getOneOrThrow(itemId);
 
         // If item is not visible, throw NOT_FOUND
         const isVisible = await isItemVisible(

--- a/src/services/itemMembership/plugins/MembershipRequest/index.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/index.ts
@@ -88,13 +88,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           return reply.send({ status: MembershipRequestStatus.Approved });
         }
 
-        const item = await itemService.get(
-          member,
-          repositories,
-          itemId,
-          PermissionLevel.Read,
-          false,
-        );
+        const item = await repositories.itemRepository.getOneOrThrow(itemId);
         if (item) {
           return reply.send({ status: MembershipRequestStatus.NotSubmittedOrDeleted });
         }
@@ -127,13 +121,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           throw new MembershipRequestAlreadyExists();
         }
 
-        const item = await itemService.get(
-          member,
-          repositories,
-          itemId,
-          PermissionLevel.Read,
-          false,
-        );
+        const item = await repositories.itemRepository.getOneOrThrow(itemId);
 
         const itemLoginSchema = await itemLoginService.getByItemPath(repositories, item.path);
         if (itemLoginSchema) {


### PR DESCRIPTION
Remove hacky `throwOnForbiddenPermission` prop to use the repository instead.

Added tests for `get`.