### PR TITLE
feat: update recent endpoint to use meilisearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "github:graasp/graasp-sdk#published-props-index-item",
+    "@graasp/sdk": "5.7.0",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "5.6.0",
+    "@graasp/sdk": "github:graasp/graasp-sdk#published-props-index-item",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.2",

--- a/src/migrations/1736938402277-item-published-updated-at-.ts
+++ b/src/migrations/1736938402277-item-published-updated-at-.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1736938402277 implements MigrationInterface {
+  name = 'item-published-updated-at-1736938402277';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "item_published" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(`UPDATE "item_published" SET updated_at = created_at`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "item_published" DROP COLUMN "updated_at"`);
+  }
+}

--- a/src/services/item/plugins/itemLike/service.ts
+++ b/src/services/item/plugins/itemLike/service.ts
@@ -53,8 +53,8 @@ export class ItemLikeService {
     const result = await itemLikeRepository.deleteOneByCreatorAndItem(member.id, item.id);
 
     // update index if item is published
-    const isPublished = await itemPublishedRepository.getForItem(item);
-    if (isPublished) {
+    const publishedItem = await itemPublishedRepository.getForItem(item);
+    if (publishedItem) {
       const likes = await itemLikeRepository.getCountByItemId(item.id);
       await this.meilisearchClient.updateItem(item.id, { likes });
     }
@@ -70,8 +70,8 @@ export class ItemLikeService {
     const result = await itemLikeRepository.addOne({ creatorId: member.id, itemId: item.id });
 
     // update index if item is published
-    const isPublished = await itemPublishedRepository.getForItem(item);
-    if (isPublished) {
+    const publishedItem = await itemPublishedRepository.getForItem(item);
+    if (publishedItem) {
       const likes = await itemLikeRepository.getCountByItemId(item.id);
       await this.meilisearchClient.updateItem(item.id, { likes });
     }

--- a/src/services/item/plugins/publication/published/entities/itemPublished.ts
+++ b/src/services/item/plugins/publication/published/entities/itemPublished.ts
@@ -8,6 +8,7 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
   Unique,
+  UpdateDateColumn,
 } from 'typeorm';
 import { v4 } from 'uuid';
 
@@ -31,6 +32,9 @@ export class ItemPublished extends BaseEntity {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 
   @OneToOne(() => Item, (item) => item.path, {
     onUpdate: 'CASCADE',

--- a/src/services/item/plugins/publication/published/index.ts
+++ b/src/services/item/plugins/publication/published/index.ts
@@ -16,7 +16,6 @@ import {
   getCollectionsForMember,
   getInformations,
   getManyInformations,
-  getRecentCollections,
   publishItem,
   unpublishItem,
 } from './schemas';
@@ -100,17 +99,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       return db.transaction(async (manager) => {
         return itemPublishedService.delete(member, buildRepositories(manager), params.itemId);
       });
-    },
-  );
-
-  fastify.get(
-    '/collections/recent',
-    {
-      preHandler: optionalIsAuthenticated,
-      schema: getRecentCollections,
-    },
-    async ({ user, query: { limit } }) => {
-      return itemPublishedService.getRecentItems(user?.account, buildRepositories(), limit);
     },
   );
 };

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -91,7 +91,7 @@ describe('Collection Search endpoints', () => {
             filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
             q: undefined,
-            sort: ['publishedUpdatedAt:desc'],
+            sort: ['publicationUpdatedAt:desc'],
           },
         ],
       });
@@ -149,7 +149,7 @@ describe('Collection Search endpoints', () => {
             filter:
               "discipline IN ['random filter'] AND isPublishedRoot = true AND isHidden = false",
             indexUid: MOCK_INDEX,
-            sort: ['publishedUpdatedAt:desc'],
+            sort: ['publicationUpdatedAt:desc'],
           },
         ],
       };
@@ -208,7 +208,7 @@ describe('Collection Search endpoints', () => {
             q: 'random query',
             filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
-            sort: ['publishedUpdatedAt:desc'],
+            sort: ['publicationUpdatedAt:desc'],
           },
         ],
       };

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -476,6 +476,7 @@ describe('Collection Search endpoints', () => {
                 type: 'folder',
                 isPublishedRoot: true,
                 isHidden: false,
+                publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
                 createdAt: '2021-10-20T13:12:47.821Z',
                 updatedAt: '2021-10-23T09:25:39.798Z',
                 lang: 'en',
@@ -495,6 +496,7 @@ describe('Collection Search endpoints', () => {
                   type: 'folder',
                   isPublishedRoot: true,
                   isHidden: false,
+                  publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
                   createdAt: '2021-10-20T13:12:47.821Z',
                   updatedAt: '2021-10-23T09:25:39.798Z',
                   lang: 'en',
@@ -516,6 +518,7 @@ describe('Collection Search endpoints', () => {
                 type: 'folder',
                 isPublishedRoot: true,
                 isHidden: false,
+                publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
                 createdAt: '2021-10-20T13:03:42.712Z',
                 updatedAt: '2021-11-10T10:49:39.296Z',
                 lang: 'en',
@@ -535,6 +538,7 @@ describe('Collection Search endpoints', () => {
                   type: 'folder',
                   isPublishedRoot: true,
                   isHidden: false,
+                  publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
                   createdAt: '2021-10-20T13:03:42.712Z',
                   updatedAt: '2021-11-10T10:49:39.296Z',
                   lang: 'en',
@@ -558,6 +562,117 @@ describe('Collection Search endpoints', () => {
       // should return the likes property
       res.json().hits.forEach(({ likes }) => {
         expect(likes).toBeGreaterThanOrEqual(0);
+      });
+    });
+  });
+  describe('GET /collections/recent', () => {
+    describe('Signed Out', () => {
+      it('Get 2 most recent collections', async () => {
+        // Meilisearch is mocked so format of API doesn't matter, we just want it to proxy MultiSearchParams;
+        const fakeResponse = {
+          results: [
+            {
+              indexUid: 'index',
+              hits: [
+                {
+                  name: 'Geogebra',
+                  description: 'Interactive tools from geogebra for mathematics.',
+                  content: '',
+                  creator: {
+                    id: v4(),
+                    name: 'Graasper',
+                  },
+                  level: [],
+                  discipline: [],
+                  'resource-type': [],
+                  id: v4(),
+                  type: 'folder',
+                  isPublishedRoot: true,
+                  isHidden: false,
+                  publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                  createdAt: '2021-10-20T13:12:47.821Z',
+                  updatedAt: '2021-10-23T09:25:39.798Z',
+                  lang: 'en',
+                  likes: 9,
+                  _formatted: {
+                    name: 'Geogebra',
+                    description: 'Interactive tools from geogebra for mathematics.',
+                    content: '',
+                    creator: {
+                      id: v4(),
+                      name: 'Graasper',
+                    },
+                    level: [],
+                    discipline: [],
+                    'resource-type': [],
+                    id: v4(),
+                    type: 'folder',
+                    isPublishedRoot: true,
+                    isHidden: false,
+                    publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                    createdAt: '2021-10-20T13:12:47.821Z',
+                    updatedAt: '2021-10-23T09:25:39.798Z',
+                    lang: 'en',
+                    likes: 9,
+                  },
+                },
+                {
+                  name: 'PhET',
+                  content: '',
+                  description: '',
+                  creator: {
+                    id: v4(),
+                    name: 'Graasper',
+                  },
+                  level: [],
+                  discipline: [],
+                  'resource-type': [],
+                  id: v4(),
+                  type: 'folder',
+                  isPublishedRoot: true,
+                  isHidden: false,
+                  publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                  createdAt: '2021-10-20T13:03:42.712Z',
+                  updatedAt: '2021-11-10T10:49:39.296Z',
+                  lang: 'en',
+                  likes: 7,
+                  _formatted: {
+                    name: 'PhET',
+                    description: '',
+                    content: '',
+                    creator: {
+                      id: v4(),
+                      name: 'Graasper',
+                    },
+                    level: [],
+                    discipline: [],
+                    'resource-type': [],
+                    id: v4(),
+                    type: 'folder',
+                    isPublishedRoot: true,
+                    publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                    isHidden: false,
+                    createdAt: '2021-10-20T13:03:42.712Z',
+                    updatedAt: '2021-11-10T10:49:39.296Z',
+                    lang: 'en',
+                    likes: 7,
+                  },
+                },
+              ] as never[],
+              processingTimeMs: 123,
+              query: '',
+            },
+          ],
+        };
+        jest.spyOn(MeiliSearchWrapper.prototype, 'search').mockResolvedValue(fakeResponse);
+
+        const res = await app.inject({
+          method: HttpMethod.Get,
+          url: `${ITEMS_ROUTE_PREFIX}/collections/recent?limit=2`,
+        });
+        expect(res.statusCode).toBe(StatusCodes.OK);
+
+        expect(res.json().hits).toHaveLength(2);
       });
     });
   });

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -375,7 +375,7 @@ describe('Collection Search endpoints', () => {
           await waitForExpect(moveDone(unpublishedItem.id, unpublishedFolder), 300);
           expect(deleteSpy).toHaveBeenCalledTimes(1);
           // item is deleted from index
-          expect(deleteSpy.mock.calls[0][0].item.id).toEqual(unpublishedItem.id);
+          expect(deleteSpy.mock.calls[0][0].id).toEqual(unpublishedItem.id);
         });
       });
     });

--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -91,6 +91,7 @@ describe('Collection Search endpoints', () => {
             filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
             q: undefined,
+            sort: ['publishedUpdatedAt:desc'],
           },
         ],
       });
@@ -148,6 +149,7 @@ describe('Collection Search endpoints', () => {
             filter:
               "discipline IN ['random filter'] AND isPublishedRoot = true AND isHidden = false",
             indexUid: MOCK_INDEX,
+            sort: ['publishedUpdatedAt:desc'],
           },
         ],
       };
@@ -206,6 +208,7 @@ describe('Collection Search endpoints', () => {
             q: 'random query',
             filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
+            sort: ['publishedUpdatedAt:desc'],
           },
         ],
       };
@@ -274,7 +277,7 @@ describe('Collection Search endpoints', () => {
 
         expect(response.statusCode).toBe(StatusCodes.OK);
         expect(indexSpy).toHaveBeenCalledTimes(1);
-        expect(indexSpy.mock.calls[0][0]).toMatchObject(payload);
+        expect(indexSpy.mock.calls[0][0].item).toMatchObject(payload);
       });
 
       describe('Move', () => {
@@ -308,8 +311,10 @@ describe('Collection Search endpoints', () => {
           await waitForExpect(moveDone(item.id, unpublishedFolder), 300);
           expect(indexSpy).toHaveBeenCalledTimes(1);
           // Path update is sent to index
-          expect(indexSpy.mock.calls[0][0].id).toEqual(item.id);
-          expect(indexSpy.mock.calls[0][0].path.startsWith(unpublishedFolder.path)).toBeTruthy();
+          expect(indexSpy.mock.calls[0][0].item.id).toEqual(item.id);
+          expect(
+            indexSpy.mock.calls[0][0].item.path.startsWith(unpublishedFolder.path),
+          ).toBeTruthy();
         });
 
         it('Move published into published folder should be indexed', async () => {
@@ -327,7 +332,7 @@ describe('Collection Search endpoints', () => {
           await waitForExpect(moveDone(item.id, publishedFolder), 300);
           expect(indexSpy).toHaveBeenCalledTimes(1);
           // Closest published at destination is reindexed
-          expect(indexSpy.mock.calls[0][0].id).toEqual(item.id);
+          expect(indexSpy.mock.calls[0][0].item.id).toEqual(item.id);
         });
 
         it('Move unpublished into published folder should be indexed', async () => {
@@ -348,7 +353,7 @@ describe('Collection Search endpoints', () => {
           await waitForExpect(moveDone(unpublishedItem.id, publishedFolder), 300);
           expect(indexSpy).toHaveBeenCalledTimes(1);
           // Topmost published at destination is reindexed
-          expect(indexSpy.mock.calls[0][0].id).toEqual(publishedFolder.id);
+          expect(indexSpy.mock.calls[0][0].item.id).toEqual(publishedFolder.id);
         });
 
         it(' Move unpublished nested inside published into unpublished should be deleted from index', async () => {
@@ -370,7 +375,7 @@ describe('Collection Search endpoints', () => {
           await waitForExpect(moveDone(unpublishedItem.id, unpublishedFolder), 300);
           expect(deleteSpy).toHaveBeenCalledTimes(1);
           // item is deleted from index
-          expect(deleteSpy.mock.calls[0][0].id).toEqual(unpublishedItem.id);
+          expect(deleteSpy.mock.calls[0][0].item.id).toEqual(unpublishedItem.id);
         });
       });
     });

--- a/src/services/item/plugins/publication/published/plugins/search/index.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.ts
@@ -9,7 +9,7 @@ import { MEILISEARCH_REBUILD_SECRET } from '../../../../../../../utils/config';
 import { buildRepositories } from '../../../../../../../utils/repositories';
 import { ActionService } from '../../../../../../action/services/action';
 import { optionalIsAuthenticated } from '../../../../../../auth/plugins/passport';
-import { getFacets, getMostLiked, search } from './schemas';
+import { getFacets, getMostLiked, getMostRecent, search } from './schemas';
 import { SearchService } from './service';
 
 export type SearchFields = {
@@ -58,6 +58,15 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     { preHandler: optionalIsAuthenticated, schema: getMostLiked },
     async ({ query }) => {
       const searchResults = await searchService.getMostLiked(query.limit);
+      return searchResults;
+    },
+  );
+
+  fastify.get(
+    '/collections/recent',
+    { preHandler: optionalIsAuthenticated, schema: getMostRecent },
+    async ({ query }) => {
+      const searchResults = await searchService.getMostRecent(query.limit);
       return searchResults;
     },
   );

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
@@ -197,13 +197,9 @@ export class MeiliSearchWrapper {
       content: await this.getContent(item),
       isPublishedRoot: isPublishedRoot,
       isHidden: isHidden,
-      // todo: fix these types
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      createdAt: item.createdAt,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      updatedAt: item.updatedAt,
+      // todo: fix typings
+      createdAt: item.createdAt.toISOString(),
+      updatedAt: item.updatedAt.toISOString(),
       lang: item.lang,
       likes: likesCount,
       ...tagsByCategory,
@@ -245,7 +241,7 @@ export class MeiliSearchWrapper {
   }
 
   async index(
-    itemPublisheds: ItemPublished[],
+    manyItemPublished: ItemPublished[],
     repositories: Repositories,
     targetIndex: ALLOWED_INDICES = ACTIVE_INDEX,
   ): Promise<EnqueuedTask> {
@@ -256,7 +252,7 @@ export class MeiliSearchWrapper {
         publicationUpdatedAt: string;
         item: Item;
       }[] = [];
-      for (const p of itemPublisheds) {
+      for (const p of manyItemPublished) {
         const isHidden = await repositories.itemVisibilityRepository.getManyBelowAndSelf(p.item, [
           ItemVisibilityType.Hidden,
         ]);

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
@@ -49,7 +49,7 @@ const SORT_ATTRIBUTES: (keyof IndexItem)[] = [
   'name',
   'updatedAt',
   'createdAt',
-  'publishedUpdatedAt',
+  'publicationUpdatedAt',
   'likes',
 ];
 const DISPLAY_ATTRIBUTES: (keyof IndexItem)[] = [
@@ -61,8 +61,7 @@ const DISPLAY_ATTRIBUTES: (keyof IndexItem)[] = [
   'content',
   'createdAt',
   'updatedAt',
-  'publishedCreatedAt',
-  'publishedUpdatedAt',
+  'publicationUpdatedAt',
   'isPublishedRoot',
   'isHidden',
   'lang',
@@ -179,7 +178,7 @@ export class MeiliSearchWrapper {
     isPublishedRoot: boolean,
     isHidden: boolean,
     likesCount: number,
-  ): Promise<Omit<IndexItem, 'publishedCreatedAt' | 'publishedUpdatedAt'>> {
+  ): Promise<Omit<IndexItem, 'publicationUpdatedAt'>> {
     const tagsByCategory = Object.fromEntries(
       Object.values(TagCategory).map((c) => {
         return [c, tags.filter(({ category }) => category === c).map(({ name }) => name)];
@@ -254,8 +253,7 @@ export class MeiliSearchWrapper {
       // Get all descendants from the input items
       let itemsToIndex: {
         isHidden: boolean;
-        publishedCreatedAt: string;
-        publishedUpdatedAt: string;
+        publicationUpdatedAt: string;
         item: Item;
       }[] = [];
       for (const p of itemPublisheds) {
@@ -264,8 +262,7 @@ export class MeiliSearchWrapper {
         ]);
 
         itemsToIndex.push({
-          publishedCreatedAt: p.createdAt.toISOString(),
-          publishedUpdatedAt: p.updatedAt.toISOString(),
+          publicationUpdatedAt: p.updatedAt.toISOString(),
           item: p.item,
           isHidden: Boolean(isHidden.find((ih) => p.item.path.includes(ih.item.path))),
         });
@@ -277,8 +274,7 @@ export class MeiliSearchWrapper {
         itemsToIndex = itemsToIndex.concat(
           descendants.map((d) => ({
             item: d,
-            publishedCreatedAt: p.createdAt.toISOString(),
-            publishedUpdatedAt: p.updatedAt.toISOString(),
+            publicationUpdatedAt: p.updatedAt.toISOString(),
             isHidden: Boolean(isHidden.find((ih) => d.path.includes(ih.item.path))),
           })),
         );
@@ -287,7 +283,7 @@ export class MeiliSearchWrapper {
       // Parse all the item into indexable items (containing published state, visibility, content...)
 
       const documents: IndexItem[] = await Promise.all(
-        itemsToIndex.map(async ({ isHidden, publishedUpdatedAt, publishedCreatedAt, item: i }) => {
+        itemsToIndex.map(async ({ isHidden, publicationUpdatedAt, item: i }) => {
           // Publishing and categories are implicit/inherited on children, we are forced to query the database to check these
           // More efficient way to get this info? Do the db query for all item at once ?
           // This part might slow the app when we index many items or an item with many children.
@@ -308,8 +304,7 @@ export class MeiliSearchWrapper {
               isHidden,
               likesCount,
             )),
-            publishedCreatedAt,
-            publishedUpdatedAt,
+            publicationUpdatedAt,
           };
         }),
       );

--- a/src/services/item/plugins/publication/published/plugins/search/schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/schemas.ts
@@ -7,7 +7,10 @@ import { ItemType, TagCategory } from '@graasp/sdk';
 
 import { customType } from '../../../../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../../../../schemas/global';
-import { GET_MOST_LIKED_ITEMS_MAXIMUM } from '../../../../../../../utils/config';
+import {
+  GET_MOST_LIKED_ITEMS_MAXIMUM,
+  GET_MOST_RECENT_ITEMS_MAXIMUM,
+} from '../../../../../../../utils/config';
 
 const meilisearchSearchResponseSchema = customType.StrictObject({
   totalHits: Type.Optional(Type.Number()),
@@ -32,6 +35,8 @@ const meilisearchSearchResponseSchema = customType.StrictObject({
       isHidden: Type.Boolean(),
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
+      publishedCreatedAt: customType.DateTime(),
+      publishedUpdatedAt: customType.DateTime(),
       lang: Type.String(),
       likes: Type.Number(),
       _formatted: customType.StrictObject({
@@ -98,6 +103,23 @@ export const getMostLiked = {
   querystring: customType.StrictObject({
     limit: Type.Optional(
       Type.Number({ minimum: 1, maximum: GET_MOST_LIKED_ITEMS_MAXIMUM, default: 12 }),
+    ),
+  }),
+  response: {
+    [StatusCodes.OK]: meilisearchSearchResponseSchema,
+    '4xx': errorSchemaRef,
+  },
+} as const satisfies FastifySchema;
+
+export const getMostRecent = {
+  operationId: 'getMostRecentCollections',
+  tags: ['collection'],
+  summary: 'Get most recent collections',
+  description: 'Get most recently published and modified collections',
+
+  querystring: customType.StrictObject({
+    limit: Type.Optional(
+      Type.Number({ minimum: 1, maximum: GET_MOST_RECENT_ITEMS_MAXIMUM, default: 12 }),
     ),
   }),
   response: {

--- a/src/services/item/plugins/publication/published/plugins/search/schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/schemas.ts
@@ -35,8 +35,7 @@ const meilisearchSearchResponseSchema = customType.StrictObject({
       isHidden: Type.Boolean(),
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
-      publishedCreatedAt: customType.DateTime(),
-      publishedUpdatedAt: customType.DateTime(),
+      publicationUpdatedAt: customType.DateTime(),
       lang: Type.String(),
       likes: Type.Number(),
       _formatted: customType.StrictObject({
@@ -53,6 +52,7 @@ const meilisearchSearchResponseSchema = customType.StrictObject({
         id: customType.UUID(),
         type: Type.String(),
         isPublishedRoot: Type.Boolean(),
+        publicationUpdatedAt: customType.DateTime(),
         isHidden: Type.Boolean(),
         createdAt: customType.DateTime(),
         updatedAt: customType.DateTime(),

--- a/src/services/item/plugins/publication/published/plugins/search/service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.ts
@@ -79,7 +79,7 @@ export class SearchService {
   }
 
   async getMostRecent(limit: number = GET_MOST_LIKED_ITEMS_MAXIMUM) {
-    return await this.search({ sort: ['publishedUpdatedAt:desc'], limit });
+    return await this.search({ sort: ['publicationUpdatedAt:desc'], limit });
   }
 
   async search(body: Omit<MultiSearchQuery, 'filter' | 'indexUid' | 'q'> & SearchFilters) {
@@ -92,7 +92,7 @@ export class SearchService {
         {
           indexUid: this.meilisearchClient.getActiveIndexName(),
           attributesToHighlight: ['*'],
-          sort: ['publishedUpdatedAt:desc'],
+          sort: ['publicationUpdatedAt:desc'],
           ...q,
           q: query,
           filter: filters,

--- a/src/services/item/plugins/publication/published/plugins/search/service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.ts
@@ -78,6 +78,10 @@ export class SearchService {
     return await this.search({ sort: ['likes:desc'], limit });
   }
 
+  async getMostRecent(limit: number = GET_MOST_LIKED_ITEMS_MAXIMUM) {
+    return await this.search({ sort: ['publishedUpdatedAt:desc'], limit });
+  }
+
   async search(body: Omit<MultiSearchQuery, 'filter' | 'indexUid' | 'q'> & SearchFilters) {
     const { tags, langs, isPublishedRoot, query, creatorId, ...q } = body;
     const filters = this.buildFilters({ creatorId, tags, langs, isPublishedRoot });
@@ -88,6 +92,7 @@ export class SearchService {
         {
           indexUid: this.meilisearchClient.getActiveIndexName(),
           attributesToHighlight: ['*'],
+          sort: ['publishedUpdatedAt:desc'],
           ...q,
           q: query,
           filter: filters,
@@ -134,14 +139,6 @@ export class SearchService {
   ) {
     // Update index when itemPublished changes ------------------------------------------
 
-    itemPublishedService.hooks.setPostHook('create', async (member, repositories, { item }) => {
-      try {
-        await this.meilisearchClient.indexOne(item, repositories);
-      } catch {
-        this.logger.error('Error during indexation, Meilisearch may be down');
-      }
-    });
-
     itemPublishedService.hooks.setPostHook('delete', async (member, repositories, { item }) => {
       try {
         await this.meilisearchClient.deleteOne(item, repositories);
@@ -164,7 +161,7 @@ export class SearchService {
         }
 
         // update index
-        await this.meilisearchClient.indexOne(item, repositories);
+        await this.meilisearchClient.indexOne(published, repositories);
       } catch (e) {
         this.logger.error('Error during indexation, Meilisearch may be down');
       }
@@ -187,7 +184,7 @@ export class SearchService {
           return;
         }
         // update index
-        await this.meilisearchClient.indexOne(item, repositories);
+        await this.meilisearchClient.indexOne(published, repositories);
       } catch (e) {
         this.logger.error('Error during indexation, Meilisearch may be down');
       }
@@ -201,7 +198,7 @@ export class SearchService {
         if (published) {
           // destination or moved item is published, we must update the index
           // update index from published
-          await this.meilisearchClient.indexOne(published.item, repositories);
+          await this.meilisearchClient.indexOne(published, repositories);
         } else {
           // nothing published, we must delete if it exists in index
           await this.meilisearchClient.deleteOne(destination, repositories);

--- a/src/services/item/plugins/publication/published/repositories/itemPublished.test.ts
+++ b/src/services/item/plugins/publication/published/repositories/itemPublished.test.ts
@@ -1,36 +1,76 @@
-import { FastifyInstance } from 'fastify';
+import { DataSource, Repository } from 'typeorm';
 
-import build, { clearDatabase } from '../../../../../../../test/app';
-import { saveMember } from '../../../../../member/test/fixtures/members';
-import { ItemTestUtils, expectManyItems } from '../../../../test/fixtures/items';
+import { FolderItemFactory, MemberFactory, PermissionLevel } from '@graasp/sdk';
+
+import { AppDataSource } from '../../../../../../plugins/datasource';
+import { ItemMembership } from '../../../../../itemMembership/entities/ItemMembership';
+import { Member } from '../../../../../member/entities/member';
+import { Item } from '../../../../entities/Item';
+import { expectManyItems } from '../../../../test/fixtures/items';
+import { ItemPublished } from '../entities/itemPublished';
 import { ItemPublishedRepository } from './itemPublished';
 
-const itemPublishedRepository = new ItemPublishedRepository();
-const testUtils = new ItemTestUtils();
-
 describe('ItemPublishedRepository', () => {
-  let app: FastifyInstance;
-  let actor;
+  let db: DataSource;
+  let repository: ItemPublishedRepository;
+  let rawRepository: Repository<ItemPublished>;
+  let itemRawRepository: Repository<Item>;
+  let memberRawRepository: Repository<Member>;
+  let itemMembershipRawRepository: Repository<ItemMembership>;
 
-  beforeEach(async () => {
-    ({ app, actor } = await build());
+  beforeAll(async () => {
+    db = await AppDataSource.initialize();
+    await db.runMigrations();
+    repository = new ItemPublishedRepository(db.manager);
+    rawRepository = db.getRepository(ItemPublished);
+    itemRawRepository = db.getRepository(Item);
+    memberRawRepository = db.getRepository(Member);
+    itemMembershipRawRepository = db.getRepository(ItemMembership);
   });
-  afterEach(async () => {
-    jest.clearAllMocks();
-    await clearDatabase(app.db);
-    actor = null;
-    app.close();
+
+  afterAll(async () => {
+    await db.dropDatabase();
+    await db.destroy();
   });
 
   describe('getForMember', () => {
     it('get published items for member', async () => {
-      const { items } = await testUtils.saveCollections(actor);
-      // noise
-      const member = await saveMember();
-      await testUtils.saveCollections(member);
+      const creator = await memberRawRepository.save(MemberFactory());
+      const items = [
+        await itemRawRepository.save(FolderItemFactory({ creator })),
+        await itemRawRepository.save(FolderItemFactory({ creator })),
+        await itemRawRepository.save(FolderItemFactory({ creator })),
+      ];
+      for (const i of items) {
+        await itemMembershipRawRepository.save({
+          item: { path: i.path },
+          account: { id: creator.id },
+          permission: PermissionLevel.Admin,
+        });
+        await rawRepository.save({
+          item: { path: i.path },
+        });
+      }
 
-      const result = await itemPublishedRepository.getForMember(actor.id);
+      const result = await repository.getForMember(creator.id);
       expectManyItems(result, items);
+    });
+  });
+
+  describe('touchUpdatedAt', () => {
+    it('undefined path throws', async () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      await expect(() => repository.touchUpdatedAt(undefined)).rejects.toThrow();
+    });
+    it('update updatedAt on current time', async () => {
+      const updatedAt = new Date();
+      const creator = await memberRawRepository.save(MemberFactory());
+      const item = await itemRawRepository.save(FolderItemFactory({ creator }));
+
+      const result = await repository.touchUpdatedAt(item.path);
+
+      expect(new Date(result).getTime() - new Date(updatedAt).getTime()).toBeLessThanOrEqual(100);
     });
   });
 });

--- a/src/services/item/plugins/publication/published/repositories/itemPublished.test.ts
+++ b/src/services/item/plugins/publication/published/repositories/itemPublished.test.ts
@@ -70,7 +70,7 @@ describe('ItemPublishedRepository', () => {
 
       const result = await repository.touchUpdatedAt(item.path);
 
-      expect(new Date(result).getTime() - new Date(updatedAt).getTime()).toBeLessThanOrEqual(100);
+      expect(new Date(result).getTime() - new Date(updatedAt).getTime()).toBeLessThanOrEqual(200);
     });
   });
 });

--- a/src/services/item/plugins/publication/published/repositories/itemPublished.test.ts
+++ b/src/services/item/plugins/publication/published/repositories/itemPublished.test.ts
@@ -1,8 +1,10 @@
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
+
+import { FastifyInstance } from 'fastify';
 
 import { FolderItemFactory, MemberFactory, PermissionLevel } from '@graasp/sdk';
 
-import { AppDataSource } from '../../../../../../plugins/datasource';
+import build from '../../../../../../../test/app';
 import { ItemMembership } from '../../../../../itemMembership/entities/ItemMembership';
 import { Member } from '../../../../../member/entities/member';
 import { Item } from '../../../../entities/Item';
@@ -11,7 +13,7 @@ import { ItemPublished } from '../entities/itemPublished';
 import { ItemPublishedRepository } from './itemPublished';
 
 describe('ItemPublishedRepository', () => {
-  let db: DataSource;
+  let app: FastifyInstance;
   let repository: ItemPublishedRepository;
   let rawRepository: Repository<ItemPublished>;
   let itemRawRepository: Repository<Item>;
@@ -19,8 +21,10 @@ describe('ItemPublishedRepository', () => {
   let itemMembershipRawRepository: Repository<ItemMembership>;
 
   beforeAll(async () => {
-    db = await AppDataSource.initialize();
-    await db.runMigrations();
+    // bug: necessary for test to work
+    ({ app } = await build());
+    const { db } = app;
+
     repository = new ItemPublishedRepository(db.manager);
     rawRepository = db.getRepository(ItemPublished);
     itemRawRepository = db.getRepository(Item);
@@ -29,8 +33,7 @@ describe('ItemPublishedRepository', () => {
   });
 
   afterAll(async () => {
-    await db.dropDatabase();
-    await db.destroy();
+    await app.close();
   });
 
   describe('getForMember', () => {

--- a/src/services/item/plugins/publication/published/repositories/itemPublished.ts
+++ b/src/services/item/plugins/publication/published/repositories/itemPublished.ts
@@ -126,4 +126,10 @@ export class ItemPublishedRepository extends AbstractRepository<ItemPublished> {
 
     return publishedInfos.map(({ item }) => item);
   }
+
+  async touchUpdatedAt(path: Item['path']): Promise<string> {
+    const updatedAt = new Date().toISOString();
+    await this.repository.update({ item: { path } }, { updatedAt });
+    return updatedAt;
+  }
 }

--- a/src/services/item/plugins/publication/published/schemas.ts
+++ b/src/services/item/plugins/publication/published/schemas.ts
@@ -5,7 +5,6 @@ import { MAX_TARGETS_FOR_READ_REQUEST } from '@graasp/sdk';
 
 import { customType } from '../../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../../schemas/global';
-import { GET_MOST_RECENT_ITEMS_MAXIMUM } from '../../../../../utils/config';
 import { nullableMemberSchemaRef } from '../../../../member/schemas';
 import { itemSchemaRef } from '../../../schemas';
 import { packedItemSchemaRef } from '../../../schemas.packed';
@@ -21,26 +20,6 @@ const publishEntry = customType.StrictObject(
     description: 'Information of a published item',
   },
 );
-
-export const getRecentCollections = {
-  operationId: 'getRecentCollections',
-  tags: ['collection'],
-  summary: 'Get most recent published items',
-  description: 'Get most recently published items (collections)',
-
-  querystring: customType.StrictObject({
-    limit: Type.Number({
-      maximum: GET_MOST_RECENT_ITEMS_MAXIMUM,
-      minimum: 1,
-      default: 24,
-    }),
-  }),
-
-  response: {
-    [StatusCodes.OK]: Type.Array(itemSchemaRef),
-    '4xx': errorSchemaRef,
-  },
-};
 
 export const getCollectionsForMember = {
   operationId: 'getCollectionsForMember',

--- a/src/services/item/plugins/publication/published/service.test.ts
+++ b/src/services/item/plugins/publication/published/service.test.ts
@@ -1,0 +1,51 @@
+import { v4 } from 'uuid';
+
+import { buildPathFromIds } from '@graasp/sdk';
+
+import { MOCK_LOGGER } from '../../../../../../test/app';
+import { MailerService } from '../../../../../plugins/mailer/service';
+import { Repositories } from '../../../../../utils/repositories';
+import { ItemService } from '../../../service';
+import { ItemThumbnailService } from '../../thumbnail/service';
+import { MeiliSearchWrapper } from './plugins/search/meilisearch';
+import { ItemPublishedService } from './service';
+
+const meiliSearchWrapper = {
+  updateItem: jest.fn(),
+} as unknown as MeiliSearchWrapper;
+
+const itemPublishedService = new ItemPublishedService(
+  {} as ItemService,
+  {} as ItemThumbnailService,
+  {} as MailerService,
+  meiliSearchWrapper,
+  MOCK_LOGGER,
+);
+
+const repositories = {
+  itemRepository: {
+    getPublishedItemsForMember: jest.fn(),
+  },
+  itemPublishedRepository: {
+    touchUpdatedAt: jest.fn(),
+  },
+} as unknown as Repositories;
+
+describe('ItemPublishedService - touchUpdatedAt', () => {
+  it('change updatedAt with current time', async () => {
+    // GIVEN
+    const id = v4();
+    const item = { id, path: buildPathFromIds(id) };
+    const updatedAt = new Date().toISOString();
+
+    // MOCK
+    const updateItemMock = jest.spyOn(meiliSearchWrapper, 'updateItem');
+    jest.spyOn(repositories.itemPublishedRepository, 'touchUpdatedAt').mockResolvedValue(updatedAt);
+
+    // WHEN
+    await itemPublishedService.touchUpdatedAt(repositories, item);
+
+    // EXPECT
+    expect(updateItemMock).toHaveBeenCalledWith(id, { updatedAt });
+  });
+});

--- a/src/services/item/plugins/publication/published/service.ts
+++ b/src/services/item/plugins/publication/published/service.ts
@@ -17,11 +17,13 @@ import { Item } from '../../../entities/Item';
 import { ItemService } from '../../../service';
 import { ItemThumbnailService } from '../../thumbnail/service';
 import { buildPublishedItemLink } from './constants';
+import { ItemPublished } from './entities/itemPublished';
 import {
   ItemIsNotValidated,
   ItemPublicationAlreadyExists,
   ItemTypeNotAllowedToPublish,
 } from './errors';
+import { MeiliSearchWrapper } from './plugins/search/meilisearch';
 
 interface ActionCount {
   actionCount: number;
@@ -32,10 +34,11 @@ export class ItemPublishedService {
   private readonly log: BaseLogger;
   private readonly itemService: ItemService;
   private readonly itemThumbnailService: ItemThumbnailService;
+  private readonly meilisearchWrapper: MeiliSearchWrapper;
   private readonly mailerService: MailerService;
 
   hooks = new HookManager<{
-    create: { pre: { item: Item }; post: { item: Item } };
+    create: { pre: { item: Item }; post: { published: ItemPublished; item: Item } };
     delete: { pre: { item: Item }; post: { item: Item } };
   }>();
 
@@ -43,11 +46,13 @@ export class ItemPublishedService {
     itemService: ItemService,
     itemThumbnailService: ItemThumbnailService,
     mailerService: MailerService,
+    meilisearchWrapper: MeiliSearchWrapper,
     log: BaseLogger,
   ) {
     this.log = log;
     this.itemService = itemService;
     this.itemThumbnailService = itemThumbnailService;
+    this.meilisearchWrapper = meilisearchWrapper;
     this.mailerService = mailerService;
   }
 
@@ -202,11 +207,10 @@ export class ItemPublishedService {
 
     // TODO: check validation is alright
 
-    await this.hooks.runPreHooks('create', member, repositories, { item });
-
     const published = await itemPublishedRepository.post(member, item);
 
-    await this.hooks.runPostHooks('create', member, repositories, { item });
+    await this.meilisearchWrapper.indexOne(published, repositories);
+
     //TODO: should we sent a publish hooks for all descendants? If yes take inspiration from delete method in ItemService
 
     this._notifyContributors(member, repositories, item);
@@ -226,6 +230,15 @@ export class ItemPublishedService {
     await this.hooks.runPostHooks('delete', member, repositories, { item });
 
     return result;
+  }
+
+  async touchUpdatedAt(repositories: Repositories, item: { id: Item['id']; path: Item['path'] }) {
+    const { itemPublishedRepository } = repositories;
+
+    const updatedAt = await itemPublishedRepository.touchUpdatedAt(item.path);
+
+    // change value in meilisearch index
+    await this.meilisearchWrapper.updateItem(item.id, { updatedAt });
   }
 
   async getItemsForMember(actor: Actor, repositories, memberId: UUID) {

--- a/src/services/item/plugins/publication/published/test/index.test.ts
+++ b/src/services/item/plugins/publication/published/test/index.test.ts
@@ -45,7 +45,6 @@ const expectPublishedEntry = (value, expectedValue) => {
 
 describe('Item Published', () => {
   let app: FastifyInstance;
-  let actor;
   const itemPublishedRawRepository = AppDataSource.getRepository(ItemPublished);
 
   beforeAll(async () => {
@@ -146,44 +145,6 @@ describe('Item Published', () => {
           query: { categoryId: 'invalid-id' },
         });
         expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
-      });
-    });
-  });
-
-  describe('GET /collections/recent', () => {
-    describe('Signed Out', () => {
-      let member;
-      let collections: Item[];
-
-      beforeEach(async () => {
-        member = await saveMember();
-        ({ items: collections } = await testUtils.saveCollections(member));
-      });
-
-      it('Get 2 most recent collections', async () => {
-        const res = await app.inject({
-          method: HttpMethod.Get,
-          url: `${ITEMS_ROUTE_PREFIX}/collections/recent`,
-          query: { limit: '2' },
-        });
-        expect(res.statusCode).toBe(StatusCodes.OK);
-
-        expect(res.json()).toHaveLength(2);
-      });
-
-      it('Get recent published collections without hidden', async () => {
-        const hiddenCollection = collections[0];
-        await rawRepository.save({
-          item: hiddenCollection,
-          creator: actor,
-          type: ItemVisibilityType.Hidden,
-        });
-        const res = await app.inject({
-          method: HttpMethod.Get,
-          url: `${ITEMS_ROUTE_PREFIX}/collections/recent`,
-        });
-        expect(res.statusCode).toBe(StatusCodes.OK);
-        expect(res.json().map(({ id }) => id)).not.toContain(hiddenCollection.id);
       });
     });
   });

--- a/src/services/item/plugins/publication/published/test/index.test.ts
+++ b/src/services/item/plugins/publication/published/test/index.test.ts
@@ -275,7 +275,7 @@ describe('Item Published', () => {
 
         // Publishing an item triggers an indexing
         expect(indexSpy).toHaveBeenCalledTimes(1);
-        expectItem(indexSpy.mock.calls[0][0], item);
+        expectItem(indexSpy.mock.calls[0][0].item, item);
       });
 
       it('Publish item with admin rights and send notification', async () => {

--- a/src/services/item/plugins/publication/published/test/index.test.ts
+++ b/src/services/item/plugins/publication/published/test/index.test.ts
@@ -58,7 +58,6 @@ describe('Item Published', () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
-    actor = null;
     unmockAuthenticate();
   });
 

--- a/src/services/item/plugins/publication/published/test/meilisearch.test.ts
+++ b/src/services/item/plugins/publication/published/test/meilisearch.test.ts
@@ -43,14 +43,14 @@ const mockItemPublished = ({ id, path }: { id: string; path: string }) => {
   return {
     item: {
       id,
-      createdAt: Date(),
-      updatedAt: Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
       type: ItemType.FOLDER,
       path,
     } as unknown as Item,
     createdAt: new Date(),
     updatedAt: new Date(),
-  } as ItemPublished;
+  } as unknown as ItemPublished;
 };
 
 describe('MeilisearchWrapper', () => {
@@ -489,32 +489,30 @@ describe('MeilisearchWrapper', () => {
   });
 
   describe('rebuilds index', () => {
-    // it('reindex all items', async () => {
-    //   const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
-    //     return mockItemPublished(index.toString());
-    //   });
-    //   jest.spyOn(repositoriesModule, 'buildRepositories').mockReturnValue(repositories);
-    //   // prevent finding any PDFs to store because this part is temporary
-    //   jest.spyOn(testUtils.itemRepository, 'findAndCount').mockResolvedValue([[], 0]);
-    //   // fake pagination
-    //   itemPublishedRepositoryMock.getPaginatedItems.mockImplementation((page, _) => {
-    //     if (page === 1) {
-    //       return Promise.resolve([publishedItemsInDb.slice(0, 10), publishedItemsInDb.length]);
-    //     } else if (page === 2) {
-    //       return Promise.resolve([publishedItemsInDb.slice(10), publishedItemsInDb.length]);
-    //     } else {
-    //       throw new Error();
-    //     }
-    //   });
-    //   const indexSpy = jest
-    //     .spyOn(MeiliSearchWrapper.prototype, 'index')
-    //     .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
-    //   await meilisearch.rebuildIndex(10);
-    //   expect(indexSpy).toHaveBeenCalledTimes(2);
-    //   expect(indexSpy.mock.calls[0][0]).toEqual(
-    //     publishedItemsInDb.slice(0, 10).map((pi) => pi.item),
-    //   );
-    //   expect(indexSpy.mock.calls[1][0]).toEqual(publishedItemsInDb.slice(10).map((pi) => pi.item));
-    // });
+    it('reindex all items', async () => {
+      const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
+        return mockItemPublished({ id: index.toString(), path: index.toString() });
+      });
+      jest.spyOn(repositoriesModule, 'buildRepositories').mockReturnValue(repositories);
+      // prevent finding any PDFs to store because this part is temporary
+      jest.spyOn(testUtils.itemRepository, 'findAndCount').mockResolvedValue([[], 0]);
+      // fake pagination
+      itemPublishedRepositoryMock.getPaginatedItems.mockImplementation((page, _) => {
+        if (page === 1) {
+          return Promise.resolve([publishedItemsInDb.slice(0, 10), publishedItemsInDb.length]);
+        } else if (page === 2) {
+          return Promise.resolve([publishedItemsInDb.slice(10), publishedItemsInDb.length]);
+        } else {
+          throw new Error();
+        }
+      });
+      const indexSpy = jest
+        .spyOn(MeiliSearchWrapper.prototype, 'index')
+        .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
+      await meilisearch.rebuildIndex(10);
+      expect(indexSpy).toHaveBeenCalledTimes(2);
+      expect(indexSpy.mock.calls[0][0]).toEqual(publishedItemsInDb.slice(0, 10));
+      expect(indexSpy.mock.calls[1][0]).toEqual(publishedItemsInDb.slice(10));
+    });
   });
 });

--- a/src/services/item/plugins/publication/published/test/meilisearch.test.ts
+++ b/src/services/item/plugins/publication/published/test/meilisearch.test.ts
@@ -11,7 +11,15 @@ import {
 import { DataSource, EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { IndexItem, ItemType, MimeTypes, S3FileItemExtra, TagCategory, UUID } from '@graasp/sdk';
+import {
+  IndexItem,
+  ItemType,
+  ItemVisibilityType,
+  MimeTypes,
+  S3FileItemExtra,
+  TagCategory,
+  UUID,
+} from '@graasp/sdk';
 
 import { BaseLogger } from '../../../../../../logger';
 import * as repositoriesModule from '../../../../../../utils/repositories';
@@ -21,6 +29,7 @@ import { Tag } from '../../../../../tag/Tag.entity';
 import { Item } from '../../../../entities/Item';
 import { ItemTestUtils } from '../../../../test/fixtures/items';
 import { ItemLikeRepository } from '../../../itemLike/repository';
+import { ItemVisibility } from '../../../itemVisibility/ItemVisibility';
 import { ItemTagRepository } from '../../../tag/ItemTag.repository';
 import { ItemPublished } from '../entities/itemPublished';
 import { MeiliSearchWrapper } from '../plugins/search/meilisearch';
@@ -29,6 +38,20 @@ import { ItemPublishedRepository } from '../repositories/itemPublished';
 jest.unmock('../plugins/search/meilisearch');
 
 const testUtils = new ItemTestUtils();
+
+const mockItemPublished = ({ id, path }: { id: string; path: string }) => {
+  return {
+    item: {
+      id,
+      createdAt: Date(),
+      updatedAt: Date(),
+      type: ItemType.FOLDER,
+      path,
+    } as unknown as Item,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as ItemPublished;
+};
 
 describe('MeilisearchWrapper', () => {
   afterEach(() => {
@@ -148,19 +171,16 @@ describe('MeilisearchWrapper', () => {
       const item = testUtils.createItem();
 
       // Given
-      jest.spyOn(testUtils.itemRepository, 'getManyDescendants').mockResolvedValue([]);
+      jest.spyOn(testUtils.itemRepository, 'getDescendants').mockResolvedValue([]);
       itemTagRepositoryMock.getByItemId.mockResolvedValue([]);
-      itemPublishedRepositoryMock.getForItem.mockResolvedValue({
-        item: { id: item.id } as Item,
-      } as ItemPublished);
-      jest
-        .spyOn(testUtils.itemVisibilityRepository, 'hasForMany')
-        .mockResolvedValue({ data: {}, errors: [] });
+      const itemPublished = mockItemPublished(item);
+      itemPublishedRepositoryMock.getForItem.mockResolvedValue(itemPublished);
+      jest.spyOn(testUtils.itemVisibilityRepository, 'getManyBelowAndSelf').mockResolvedValue([]);
 
       const addDocumentSpy = jest.spyOn(mockIndex, 'addDocuments');
 
       // When
-      await meilisearch.indexOne(item, repositories);
+      await meilisearch.indexOne(itemPublished, repositories);
 
       // Then
       expect(addDocumentSpy).toHaveBeenCalledTimes(1);
@@ -181,21 +201,22 @@ describe('MeilisearchWrapper', () => {
       const descendant2 = testUtils.createItem();
       // Given
       jest
-        .spyOn(testUtils.itemRepository, 'getManyDescendants')
+        .spyOn(testUtils.itemRepository, 'getDescendants')
         .mockResolvedValue([descendant, descendant2]);
       itemTagRepositoryMock.getByItemId.mockResolvedValue([]);
-      itemPublishedRepositoryMock.getForItem.mockResolvedValue({
-        item: { id: item.id } as Item,
-      } as ItemPublished);
-      jest.spyOn(testUtils.itemVisibilityRepository, 'hasForMany').mockResolvedValue({
-        data: { [descendant.id]: true },
-        errors: [],
-      });
+      const itemPublished = mockItemPublished(item);
+      itemPublishedRepositoryMock.getForItem.mockResolvedValue(itemPublished);
+      jest.spyOn(testUtils.itemVisibilityRepository, 'getManyBelowAndSelf').mockResolvedValue([
+        {
+          type: ItemVisibilityType.Hidden,
+          item: { id: descendant.id, path: descendant.path } as Item,
+        } as ItemVisibility,
+      ]);
 
       const addDocumentSpy = jest.spyOn(mockIndex, 'addDocuments');
 
       // When
-      await meilisearch.indexOne(item, repositories);
+      await meilisearch.indexOne(itemPublished, repositories);
 
       // Then
       expect(addDocumentSpy).toHaveBeenCalledTimes(1);
@@ -246,25 +267,20 @@ describe('MeilisearchWrapper', () => {
       } satisfies Record<string, Item[]>;
 
       // Given
-      jest.spyOn(testUtils.itemRepository, 'getManyDescendants').mockImplementation((items) => {
-        const result: Item[] = [];
-        for (const i of items) {
-          result.push(...descendants[i.id]);
-        }
-        return Promise.resolve(result);
-      });
-      itemTagRepositoryMock.getByItemId.mockResolvedValue([]);
-      itemPublishedRepositoryMock.getForItem.mockResolvedValue({
-        item: { id: item.id } as Item,
-      } as ItemPublished);
       jest
-        .spyOn(testUtils.itemVisibilityRepository, 'hasForMany')
-        .mockResolvedValue({ data: {}, errors: [] });
+        .spyOn(testUtils.itemRepository, 'getDescendants')
+        .mockImplementation(async (item) => descendants[item.id]);
+      itemTagRepositoryMock.getByItemId.mockResolvedValue([]);
+      const itemPublished1 = mockItemPublished(item);
+      itemPublishedRepositoryMock.getForItem.mockResolvedValue(itemPublished1);
+      const itemPublished2 = mockItemPublished(item2);
+      itemPublishedRepositoryMock.getForItem.mockResolvedValue(itemPublished2);
+      jest.spyOn(testUtils.itemVisibilityRepository, 'getManyBelowAndSelf').mockResolvedValue([]);
 
       const addDocumentSpy = jest.spyOn(mockIndex, 'addDocuments');
 
       // When
-      await meilisearch.index([item, item2], repositories);
+      await meilisearch.index([itemPublished1, itemPublished2], repositories);
 
       // Then
       expect(addDocumentSpy).toHaveBeenCalledTimes(1);
@@ -294,9 +310,6 @@ describe('MeilisearchWrapper', () => {
       const descendant = testUtils.createItem();
       const descendant2 = testUtils.createItem();
 
-      const mockItemPublished = (id) => {
-        return { item: { id: id } as Item } as ItemPublished;
-      };
       const tags = {
         [item.id]: [
           { name: 'tag1', id: v4(), category: TagCategory.Discipline },
@@ -308,13 +321,13 @@ describe('MeilisearchWrapper', () => {
       };
 
       const published = {
-        [item.id]: mockItemPublished(item.id),
-        [descendant.id]: mockItemPublished(item.id),
-        [descendant2.id]: mockItemPublished(descendant2.id),
+        [item.id]: mockItemPublished(item),
+        [descendant.id]: mockItemPublished(item),
+        [descendant2.id]: mockItemPublished(descendant2),
       } satisfies Record<string, ItemPublished>;
 
       jest
-        .spyOn(testUtils.itemRepository, 'getManyDescendants')
+        .spyOn(testUtils.itemRepository, 'getDescendants')
         .mockResolvedValue([descendant, descendant2]);
       itemTagRepositoryMock.getByItemId.mockImplementation(
         jest.fn(async (id: UUID) => tags[id] as Tag[]),
@@ -322,15 +335,17 @@ describe('MeilisearchWrapper', () => {
       itemPublishedRepositoryMock.getForItem.mockImplementation((i) =>
         Promise.resolve(published[i.id]),
       );
-      jest.spyOn(testUtils.itemVisibilityRepository, 'hasForMany').mockResolvedValue({
-        data: { [descendant.id]: true },
-        errors: [],
-      });
+      jest.spyOn(testUtils.itemVisibilityRepository, 'getManyBelowAndSelf').mockResolvedValue([
+        {
+          type: ItemVisibilityType.Hidden,
+          item: { id: descendant.id } as unknown as Item,
+        } as ItemVisibility,
+      ]);
 
       const addDocumentSpy = jest.spyOn(mockIndex, 'addDocuments');
 
       // When
-      await meilisearch.indexOne(item, repositories);
+      await meilisearch.indexOne(published[item.id], repositories);
 
       // Then
       expect(addDocumentSpy).toHaveBeenCalledTimes(1);
@@ -355,35 +370,33 @@ describe('MeilisearchWrapper', () => {
       const descendant = testUtils.createItem();
       const descendant2 = testUtils.createItem();
 
-      const mockItemPublished = (id) => {
-        return { item: { id: id } as Item } as ItemPublished;
-      };
-
       const published = {
-        [item.id]: mockItemPublished(item.id),
-        [descendant.id]: mockItemPublished(item.id),
-        [descendant2.id]: mockItemPublished(descendant2.id),
+        [item.id]: mockItemPublished(item),
+        [descendant.id]: mockItemPublished(item),
+        [descendant2.id]: mockItemPublished(descendant2),
       } satisfies Record<string, ItemPublished>;
 
       jest
-        .spyOn(testUtils.itemRepository, 'getManyDescendants')
+        .spyOn(testUtils.itemRepository, 'getDescendants')
         .mockResolvedValue([descendant, descendant2]);
       itemTagRepositoryMock.getByItemId.mockResolvedValue([]);
       itemPublishedRepositoryMock.getForItem.mockImplementation((i) =>
         Promise.resolve(published[i.id]),
       );
 
-      jest.spyOn(testUtils.itemVisibilityRepository, 'hasForMany').mockResolvedValue({
-        data: { [descendant.id]: true },
-        errors: [],
-      });
+      jest.spyOn(testUtils.itemVisibilityRepository, 'getManyBelowAndSelf').mockResolvedValue([
+        {
+          type: ItemVisibilityType.Hidden,
+          item: { id: descendant.id } as Item,
+        } as ItemVisibility,
+      ]);
 
       itemLikeRepositoryMock.getCountByItemId.mockResolvedValue(2);
 
       const addDocumentSpy = jest.spyOn(mockIndex, 'addDocuments');
 
       // When
-      await meilisearch.indexOne(item, repositories);
+      await meilisearch.indexOne(published[item.id], repositories);
 
       // Then
       expect(addDocumentSpy).toHaveBeenCalledTimes(1);
@@ -419,20 +432,17 @@ describe('MeilisearchWrapper', () => {
       // Given
 
       jest
-        .spyOn(testUtils.itemRepository, 'getManyDescendants')
+        .spyOn(testUtils.itemRepository, 'getDescendants')
         .mockResolvedValue([descendant, descendant2]);
       itemTagRepositoryMock.getByItemId.mockResolvedValue([]);
-      itemPublishedRepositoryMock.getForItem.mockResolvedValue({
-        item: { id: item.id } as Item,
-      } as ItemPublished);
-      jest
-        .spyOn(testUtils.itemVisibilityRepository, 'hasForMany')
-        .mockResolvedValue({ data: {}, errors: [] });
+      const itemPublished = mockItemPublished(item);
+      itemPublishedRepositoryMock.getForItem.mockResolvedValue(itemPublished);
+      jest.spyOn(testUtils.itemVisibilityRepository, 'getManyBelowAndSelf').mockResolvedValue([]);
 
       const addDocumentSpy = jest.spyOn(mockIndex, 'addDocuments');
 
       // When
-      await meilisearch.indexOne(item, repositories);
+      await meilisearch.indexOne(itemPublished, repositories);
 
       // Then
       expect(addDocumentSpy).toHaveBeenCalledTimes(1);
@@ -479,37 +489,32 @@ describe('MeilisearchWrapper', () => {
   });
 
   describe('rebuilds index', () => {
-    it('reindex all items', async () => {
-      const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
-        return { item: { id: index.toString() } as Item } as ItemPublished;
-      });
-
-      jest.spyOn(repositoriesModule, 'buildRepositories').mockReturnValue(repositories);
-
-      // prevent finding any PDFs to store because this part is temporary
-      jest.spyOn(testUtils.itemRepository, 'findAndCount').mockResolvedValue([[], 0]);
-
-      // fake pagination
-      itemPublishedRepositoryMock.getPaginatedItems.mockImplementation((page, _) => {
-        if (page === 1) {
-          return Promise.resolve([publishedItemsInDb.slice(0, 10), publishedItemsInDb.length]);
-        } else if (page === 2) {
-          return Promise.resolve([publishedItemsInDb.slice(10), publishedItemsInDb.length]);
-        } else {
-          throw new Error();
-        }
-      });
-      const indexSpy = jest
-        .spyOn(MeiliSearchWrapper.prototype, 'index')
-        .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
-
-      await meilisearch.rebuildIndex(10);
-
-      expect(indexSpy).toHaveBeenCalledTimes(2);
-      expect(indexSpy.mock.calls[0][0]).toEqual(
-        publishedItemsInDb.slice(0, 10).map((pi) => pi.item),
-      );
-      expect(indexSpy.mock.calls[1][0]).toEqual(publishedItemsInDb.slice(10).map((pi) => pi.item));
-    });
+    // it('reindex all items', async () => {
+    //   const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
+    //     return mockItemPublished(index.toString());
+    //   });
+    //   jest.spyOn(repositoriesModule, 'buildRepositories').mockReturnValue(repositories);
+    //   // prevent finding any PDFs to store because this part is temporary
+    //   jest.spyOn(testUtils.itemRepository, 'findAndCount').mockResolvedValue([[], 0]);
+    //   // fake pagination
+    //   itemPublishedRepositoryMock.getPaginatedItems.mockImplementation((page, _) => {
+    //     if (page === 1) {
+    //       return Promise.resolve([publishedItemsInDb.slice(0, 10), publishedItemsInDb.length]);
+    //     } else if (page === 2) {
+    //       return Promise.resolve([publishedItemsInDb.slice(10), publishedItemsInDb.length]);
+    //     } else {
+    //       throw new Error();
+    //     }
+    //   });
+    //   const indexSpy = jest
+    //     .spyOn(MeiliSearchWrapper.prototype, 'index')
+    //     .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
+    //   await meilisearch.rebuildIndex(10);
+    //   expect(indexSpy).toHaveBeenCalledTimes(2);
+    //   expect(indexSpy.mock.calls[0][0]).toEqual(
+    //     publishedItemsInDb.slice(0, 10).map((pi) => pi.item),
+    //   );
+    //   expect(indexSpy.mock.calls[1][0]).toEqual(publishedItemsInDb.slice(10).map((pi) => pi.item));
+    // });
   });
 });

--- a/src/services/item/plugins/tag/service.ts
+++ b/src/services/item/plugins/tag/service.ts
@@ -36,7 +36,7 @@ export class ItemTagService {
     // update index if item is published
     const isPublished = await itemPublishedRepository.getForItem(item);
     if (isPublished) {
-      await this.meilisearchClient.indexOne(item, repositories);
+      await this.meilisearchClient.indexOne(isPublished, repositories);
     }
 
     return result;
@@ -60,7 +60,7 @@ export class ItemTagService {
     // update index if item is published
     const isPublished = await itemPublishedRepository.getForItem(item);
     if (isPublished) {
-      await this.meilisearchClient.indexOne(item, repositories);
+      await this.meilisearchClient.indexOne(isPublished, repositories);
     }
 
     return await itemTagRepository.delete(itemId, tagId);

--- a/src/services/item/plugins/tag/service.ts
+++ b/src/services/item/plugins/tag/service.ts
@@ -34,9 +34,9 @@ export class ItemTagService {
     const result = await itemTagRepository.create(itemId, tag.id);
 
     // update index if item is published
-    const isPublished = await itemPublishedRepository.getForItem(item);
-    if (isPublished) {
-      await this.meilisearchClient.indexOne(isPublished, repositories);
+    const publishedItem = await itemPublishedRepository.getForItem(item);
+    if (publishedItem) {
+      await this.meilisearchClient.indexOne(publishedItem, repositories);
     }
 
     return result;
@@ -58,9 +58,9 @@ export class ItemTagService {
     const item = await this.itemService.get(actor, repositories, itemId, PermissionLevel.Admin);
 
     // update index if item is published
-    const isPublished = await itemPublishedRepository.getForItem(item);
-    if (isPublished) {
-      await this.meilisearchClient.indexOne(isPublished, repositories);
+    const publishedItem = await itemPublishedRepository.getForItem(item);
+    if (publishedItem) {
+      await this.meilisearchClient.indexOne(publishedItem, repositories);
     }
 
     return await itemTagRepository.delete(itemId, tagId);

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -749,7 +749,7 @@ export class ItemService {
     if (parentItem) {
       const published = await repositories.itemPublishedRepository.getForItem(parentItem);
       if (published) {
-        await this.meilisearchWrapper.indexOne(copyRoot, repositories);
+        await this.meilisearchWrapper.indexOne(published, repositories);
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#published-props-index-item":
-  version: 5.6.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=76fe6397f99c41dc8bd24ae28b6387f2be572140"
+"@graasp/sdk@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@graasp/sdk@npm:5.7.0"
   dependencies:
     "@faker-js/faker": "npm:9.2.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/2a1148c63187307e806f0ccc92c3e969d0bdcc3c47b2f8747cd7c8b33130b419d159b56c08c1a40f12b03094d65d222df9f586d08723107327c87a9074d15704
+  checksum: 10/080ab6fb6d290728cf8862759dc3f45cd38767e36454030ea9d6f65eed2789aefd3a7c7b528b08446da69e0e849326661df5ff34a76d4e04ceb946319b3a10c9
   languageName: node
   linkType: hard
 
@@ -7468,7 +7468,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "github:graasp/graasp-sdk#published-props-index-item"
+    "@graasp/sdk": "npm:5.7.0"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:5.6.0":
+"@graasp/sdk@github:graasp/graasp-sdk#published-props-index-item":
   version: 5.6.0
-  resolution: "@graasp/sdk@npm:5.6.0"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=76fe6397f99c41dc8bd24ae28b6387f2be572140"
   dependencies:
     "@faker-js/faker": "npm:9.2.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/212575ce29e97ce7772477c8bc55d315cbc1a1a50cbf0a184d356384f0d6ee5480750ad049afddbfc0d4fac5b0ce0913c02bf3c81e9c4dd4051e7914f9358d0d
+  checksum: 10/2a1148c63187307e806f0ccc92c3e969d0bdcc3c47b2f8747cd7c8b33130b419d159b56c08c1a40f12b03094d65d222df9f586d08723107327c87a9074d15704
   languageName: node
   linkType: hard
 
@@ -7468,7 +7468,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:5.6.0"
+    "@graasp/sdk": "github:graasp/graasp-sdk#published-props-index-item"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"


### PR DESCRIPTION
- add props `publicationUpdatedAt` to `meilisearch`
- add `updatedAt` to `ItemPublished`
- Move `/collections/recent` endpoint to search to use meilisearch's search 

TODO
- [x] write tests

close #1714 