### PR TITLE
fix: remove default sorting for search

### DIFF
--- a/src/services/item/plugins/publication/published/plugins/search/index.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/index.test.ts
@@ -91,7 +91,6 @@ describe('Collection Search endpoints', () => {
             filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
             q: undefined,
-            sort: ['publicationUpdatedAt:desc'],
           },
         ],
       });
@@ -149,7 +148,6 @@ describe('Collection Search endpoints', () => {
             filter:
               "discipline IN ['random filter'] AND isPublishedRoot = true AND isHidden = false",
             indexUid: MOCK_INDEX,
-            sort: ['publicationUpdatedAt:desc'],
           },
         ],
       };
@@ -208,7 +206,6 @@ describe('Collection Search endpoints', () => {
             q: 'random query',
             filter: 'isPublishedRoot = true AND isHidden = false',
             indexUid: MOCK_INDEX,
-            sort: ['publicationUpdatedAt:desc'],
           },
         ],
       };

--- a/src/services/item/plugins/publication/published/plugins/search/service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.test.ts
@@ -146,6 +146,25 @@ describe('getMostLiked', () => {
   });
 });
 
+describe('getMostRecent', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('apply sort by publication updatedAt', async () => {
+    const MOCK_RESULT = { hits: [] } as never;
+    const spy = jest
+      .spyOn(meilisearchClient, 'search')
+      .mockResolvedValue({ results: [MOCK_RESULT] });
+
+    const results = await searchService.getMostRecent(4);
+    expect(results).toEqual(MOCK_RESULT);
+
+    const { sort, limit } = spy.mock.calls[0][0].queries[0];
+    expect(sort).toEqual(['publicationUpdatedAt:desc']);
+    expect(limit).toEqual(4);
+  });
+});
+
 describe('getFacets', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/services/item/plugins/publication/published/plugins/search/service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/service.ts
@@ -4,7 +4,10 @@ import { singleton } from 'tsyringe';
 import { TagCategory, UUID } from '@graasp/sdk';
 
 import { BaseLogger } from '../../../../../../../logger';
-import { GET_MOST_LIKED_ITEMS_MAXIMUM } from '../../../../../../../utils/config';
+import {
+  GET_MOST_LIKED_ITEMS_MAXIMUM,
+  GET_MOST_RECENT_ITEMS_MAXIMUM,
+} from '../../../../../../../utils/config';
 import { Tag } from '../../../../../../tag/Tag.entity';
 import { ItemService } from '../../../../../service';
 import { ItemPublishedService } from '../../service';
@@ -78,7 +81,7 @@ export class SearchService {
     return await this.search({ sort: ['likes:desc'], limit });
   }
 
-  async getMostRecent(limit: number = GET_MOST_LIKED_ITEMS_MAXIMUM) {
+  async getMostRecent(limit: number = GET_MOST_RECENT_ITEMS_MAXIMUM) {
     return await this.search({ sort: ['publicationUpdatedAt:desc'], limit });
   }
 
@@ -92,7 +95,6 @@ export class SearchService {
         {
           indexUid: this.meilisearchClient.getActiveIndexName(),
           attributesToHighlight: ['*'],
-          sort: ['publicationUpdatedAt:desc'],
           ...q,
           q: query,
           filter: filters,


### PR DESCRIPTION
Remove default sorting of `publicationUpdatedAt`, it will default again to relevancy.