### PR TITLE
fix: return 200 and null for empty member profile

### DIFF
--- a/src/services/member/plugins/profile/controller.ts
+++ b/src/services/member/plugins/profile/controller.ts
@@ -17,29 +17,23 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
 
   const memberProfileService = new MemberProfileService();
 
-  fastify.get(
-    '/own',
-    { schema: getOwnProfile, preHandler: isAuthenticated },
-    async ({ user }, reply) => {
-      const member = asDefined(user?.account);
-      assertIsMember(member);
-      const profile = await memberProfileService.getOwn(member, buildRepositories());
-      if (!profile) {
-        reply.status(StatusCodes.NO_CONTENT);
-        return;
-      }
-      return profile;
-    },
-  );
+  fastify.get('/own', { schema: getOwnProfile, preHandler: isAuthenticated }, async ({ user }) => {
+    const member = asDefined(user?.account);
+    assertIsMember(member);
+    const profile = await memberProfileService.getOwn(member, buildRepositories());
+    if (!profile) {
+      return null;
+    }
+    return profile;
+  });
 
   fastify.get(
     '/:memberId',
     { schema: getProfileForMember, preHandler: optionalIsAuthenticated },
-    async ({ params: { memberId } }, reply) => {
+    async ({ params: { memberId } }) => {
       const profile = await memberProfileService.get(buildRepositories(), memberId);
       if (!profile) {
-        reply.status(StatusCodes.NO_CONTENT);
-        return;
+        return null;
       }
       return profile;
     },

--- a/src/services/member/plugins/profile/schemas.ts
+++ b/src/services/member/plugins/profile/schemas.ts
@@ -14,20 +14,33 @@ const inputPublicProfileMemberSchema = customType.StrictObject({
   visibility: Type.Boolean(),
 });
 
+const profileMemberSchemaForIntersect = [
+  inputPublicProfileMemberSchema,
+  customType.StrictObject({
+    id: customType.UUID(),
+    createdAt: customType.DateTime(),
+    updatedAt: customType.DateTime(),
+  }),
+];
+
 export const profileMemberSchemaRef = registerSchemaAsRef(
   'profile',
   'Profile',
-  Type.Intersect(
-    [
-      inputPublicProfileMemberSchema,
-      customType.StrictObject({
-        id: customType.UUID(),
-        createdAt: customType.DateTime(),
-        updatedAt: customType.DateTime(),
-      }),
-    ],
-    { description: 'Profile of a member', additionalProperties: false },
-  ),
+  Type.Intersect(profileMemberSchemaForIntersect, {
+    description: 'Profile of a member',
+    additionalProperties: false,
+    nullable: true,
+  }),
+);
+
+export const nullableProfileMemberSchemaRef = registerSchemaAsRef(
+  'nullableProfile',
+  'Nullable Profile',
+  Type.Intersect(profileMemberSchemaForIntersect, {
+    description: 'Profile of a member, null if it does not exist',
+    additionalProperties: false,
+    nullable: true,
+  }),
 );
 
 export const createOwnProfile = {
@@ -52,9 +65,7 @@ export const getProfileForMember = {
 
   params: customType.StrictObject({ memberId: customType.UUID() }),
   response: {
-    [StatusCodes.OK]: profileMemberSchemaRef,
-    // Status NO CONTENT is used instead of NOT FOUND, so it doesn't trigger an error in the Frontend
-    [StatusCodes.NO_CONTENT]: Type.Null(),
+    [StatusCodes.OK]: nullableProfileMemberSchemaRef,
     [StatusCodes.UNAUTHORIZED]: errorSchemaRef,
     '4xx': errorSchemaRef,
   },
@@ -67,9 +78,7 @@ export const getOwnProfile = {
   description: 'Get profile of current member',
 
   response: {
-    [StatusCodes.OK]: profileMemberSchemaRef,
-    // Status NO CONTENT is used instead of NOT FOUND, so it doesn't trigger an error in the Frontend
-    [StatusCodes.NO_CONTENT]: Type.Null(),
+    [StatusCodes.OK]: nullableProfileMemberSchemaRef,
     [StatusCodes.UNAUTHORIZED]: errorSchemaRef,
     '4xx': errorSchemaRef,
   },

--- a/src/services/member/plugins/profile/schemas.ts
+++ b/src/services/member/plugins/profile/schemas.ts
@@ -29,7 +29,6 @@ export const profileMemberSchemaRef = registerSchemaAsRef(
   Type.Intersect(profileMemberSchemaForIntersect, {
     description: 'Profile of a member',
     additionalProperties: false,
-    nullable: true,
   }),
 );
 


### PR DESCRIPTION
Return 200 instead of 204 in order to return `null` for the frontend.

- Complete `seedFromJson` with `memberProfile`
- Use `seedFromJson` in `controller.test.ts` of member profile