### PR TITLE
fix: replace non breaking spaces from link metadata title

### DIFF
--- a/src/services/item/plugins/embeddedLink/service.test.ts
+++ b/src/services/item/plugins/embeddedLink/service.test.ts
@@ -61,15 +61,16 @@ describe('Link Service', () => {
   });
 
   describe('getLinkMetadata', () => {
-    it('replace all non-breaking spaces by normal spaces', async () => {
+    it('replace all weird spaces by normal spaces', async () => {
       // ASSERTIONS
-      const title = 'ti\ntle\nwith special \t\t spaces';
+      const title = 'ti\ntle\nwith spec\r\nial \t\t spaces';
       // should have non breaking spaces
       expect(title).toContain(' ');
       // should have tab spaces
       expect(title).toContain('\t');
       // should have breaking spaces
       expect(title).toContain('\n');
+      expect(title).toContain('\r\n');
       // should not contain normal spaces
       expect(title).not.toContain(' ');
 
@@ -93,6 +94,7 @@ describe('Link Service', () => {
       expect(result.title).not.toContain('\t');
       // should not have breaking spaces
       expect(result.title).not.toContain('\n');
+      expect(result.title).not.toContain('\r\n');
       // should contain normal spaces
       expect(result.title).toContain(' ');
     });

--- a/src/services/item/plugins/embeddedLink/service.test.ts
+++ b/src/services/item/plugins/embeddedLink/service.test.ts
@@ -62,15 +62,26 @@ describe('Link Service', () => {
 
   describe('getLinkMetadata', () => {
     it('replace all non-breaking spaces by normal spaces', async () => {
+      // ASSERTIONS
+      const title = 'ti\ntle\nwith special \t\t spaces';
+      // should have non breaking spaces
+      expect(title).toContain(' ');
+      // should have tab spaces
+      expect(title).toContain('\t');
+      // should have breaking spaces
+      expect(title).toContain('\n');
+      // should not contain normal spaces
+      expect(title).not.toContain(' ');
+
       fetchMock = (fetch as jest.MockedFunction<typeof fetch>).mockImplementation(async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return {
           json: async () => ({
             meta: {
-              title: 'title with non breaking spaces',
+              title,
               description: 'description-patch',
             },
           }),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any;
       });
 
@@ -78,6 +89,10 @@ describe('Link Service', () => {
 
       // should not have non breaking spaces
       expect(result.title).not.toContain(' ');
+      // should not have tab spaces
+      expect(result.title).not.toContain('\t');
+      // should not have breaking spaces
+      expect(result.title).not.toContain('\n');
       // should contain normal spaces
       expect(result.title).toContain(' ');
     });

--- a/src/services/item/plugins/embeddedLink/service.test.ts
+++ b/src/services/item/plugins/embeddedLink/service.test.ts
@@ -60,6 +60,29 @@ describe('Link Service', () => {
     jest.clearAllMocks();
   });
 
+  describe('getLinkMetadata', () => {
+    it('replace all non-breaking spaces by normal spaces', async () => {
+      fetchMock = (fetch as jest.MockedFunction<typeof fetch>).mockImplementation(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return {
+          json: async () => ({
+            meta: {
+              title: 'title with non breaking spaces',
+              description: 'description-patch',
+            },
+          }),
+        } as any;
+      });
+
+      const result = await linkService.getLinkMetadata(MOCK_URL);
+
+      // should not have non breaking spaces
+      expect(result.title).not.toContain(' ');
+      // should contain normal spaces
+      expect(result.title).toContain(' ');
+    });
+  });
+
   describe('postWithOptions', () => {
     it('do not throw if iframely is unresponsive', async () => {
       fetchMock = (fetch as jest.MockedFunction<typeof fetch>).mockRejectedValue(new Error());

--- a/src/services/item/plugins/embeddedLink/service.ts
+++ b/src/services/item/plugins/embeddedLink/service.ts
@@ -92,7 +92,7 @@ export class EmbeddedLinkItemService extends ItemService {
 
       return {
         // fix non-breaking spaces
-        title: title?.trim()?.replaceAll(' ', ' '),
+        title: title?.trim()?.replace(/[ \n\t]/g, ' '),
         description: description?.trim(),
         html,
         thumbnails: links.filter(({ rel }) => hasThumbnailRel(rel)).map(({ href }) => href),

--- a/src/services/item/plugins/embeddedLink/service.ts
+++ b/src/services/item/plugins/embeddedLink/service.ts
@@ -94,7 +94,6 @@ export class EmbeddedLinkItemService extends ItemService {
       const r = new RegExp('[ \t\u{0000}-\u{001F}\u{007F}-\u{009F}]', 'gu');
 
       return {
-        // fix non-breaking spaces
         title: title?.trim()?.replaceAll(r, ' '),
         description: description?.trim(),
         html,

--- a/src/services/item/plugins/embeddedLink/service.ts
+++ b/src/services/item/plugins/embeddedLink/service.ts
@@ -90,9 +90,12 @@ export class EmbeddedLinkItemService extends ItemService {
       const { meta = {}, html, links = [] } = (await response.json()) as IframelyResponse;
       const { title, description } = meta;
 
+      // does not accept weird unicode characters, non-breaking spaces, tabs, breaking lines
+      const r = new RegExp('[ \t\u{0000}-\u{001F}\u{007F}-\u{009F}]', 'gu');
+
       return {
         // fix non-breaking spaces
-        title: title?.trim()?.replace(/[ \n\t]/g, ' '),
+        title: title?.trim()?.replaceAll(r, ' '),
         description: description?.trim(),
         html,
         thumbnails: links.filter(({ rel }) => hasThumbnailRel(rel)).map(({ href }) => href),

--- a/src/services/item/plugins/embeddedLink/service.ts
+++ b/src/services/item/plugins/embeddedLink/service.ts
@@ -79,7 +79,7 @@ export class EmbeddedLinkItemService extends ItemService {
     }
   }
 
-  async getLinkMetadata(url: string): Promise<LinkMetadata> {
+  public async getLinkMetadata(url: string): Promise<LinkMetadata> {
     this.assertUrlIsValid(url);
     try {
       const response = await fetch(
@@ -91,7 +91,8 @@ export class EmbeddedLinkItemService extends ItemService {
       const { title, description } = meta;
 
       return {
-        title: title?.trim(),
+        // fix non-breaking spaces
+        title: title?.trim()?.replaceAll(' ', ' '),
         description: description?.trim(),
         html,
         thumbnails: links.filter(({ rel }) => hasThumbnailRel(rel)).map(({ href }) => href),


### PR DESCRIPTION
Replace non classic spaces from link metadata:
-  non breaking spaces
- tab
- breaking spaces

close #1338
