### PR TITLE
refactor: use seed in membership tests

### DIFF
--- a/src/services/itemMembership/test/index.test.ts
+++ b/src/services/itemMembership/test/index.test.ts
@@ -179,6 +179,7 @@ describe('Membership routes tests', () => {
                 },
               ],
             },
+            // actor cannot access
             { name: '2', memberships: [{ account: { name: 'bob' } }] },
           ],
         });
@@ -188,7 +189,6 @@ describe('Membership routes tests', () => {
         const memberships1 = [im1, im2];
         const memberships2 = [im3];
         const memberships3 = [im4, im5];
-
         const response = await app.inject({
           method: HttpMethod.Get,
           url: `/item-memberships?itemId=${item2.id}&itemId=${itemB.id}&itemId=${itemD.id}&itemId=${itemE.id}`,

--- a/src/services/member/test/index.test.ts
+++ b/src/services/member/test/index.test.ts
@@ -3,9 +3,10 @@ import { v4 } from 'uuid';
 
 import { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, MAX_USERNAME_LENGTH, MemberFactory } from '@graasp/sdk';
+import { HttpMethod, ItemType, MAX_USERNAME_LENGTH } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../../test/app';
+import { MemberFactory } from '../../../../test/factories/member.factory';
 import { seedFromJson } from '../../../../test/mocks/seed';
 import { AppDataSource } from '../../../plugins/datasource';
 import { DEFAULT_MAX_STORAGE } from '../../../services/item/plugins/file/utils/constants';
@@ -40,7 +41,7 @@ describe('Member routes tests', () => {
       const { actor } = await seedFromJson({
         actor: MemberFactory({
           isValidated: false,
-          lastAuthenticatedAt: new Date().toISOString(),
+          lastAuthenticatedAt: new Date(),
         }),
       });
 

--- a/test/factories/member.factory.ts
+++ b/test/factories/member.factory.ts
@@ -19,20 +19,22 @@ function BaseAccountFactory<T extends AccountType>(baseAccount: Partial<Account>
   };
 }
 
-export const MemberFactory = (m: Partial<Member> = {}): Member =>
-  ({
+export const MemberFactory = (m: Partial<Member> = {}): Member => {
+  const isValidated = m.isValidated ?? true;
+  return {
     email: faker.internet.email().toLowerCase(),
     extra: faker.helpers.arrayElement([
       { lang: faker.helpers.arrayElement(['en', 'fr', 'de']) },
       {},
     ]),
     enableSaveActions: m.enableSaveActions ?? true,
-    isValidated: m.isValidated ?? true,
-    lastAuthenticatedAt: m.lastAuthenticatedAt ?? faker.date.anytime(),
+    isValidated,
+    lastAuthenticatedAt: isValidated ? (m.lastAuthenticatedAt ?? faker.date.anytime()) : null,
     userAgreementsDate: m.userAgreementsDate ?? faker.date.anytime(),
     ...BaseAccountFactory({ type: AccountType.Individual }),
     ...m,
-  }) as Member;
+  } as Member;
+};
 
 export const GuestFactory = (g: Partial<Guest> & Pick<Guest, 'itemLoginSchema'>) => ({
   ...BaseAccountFactory({ type: AccountType.Guest }),

--- a/test/factories/member.factory.ts
+++ b/test/factories/member.factory.ts
@@ -33,7 +33,7 @@ export const MemberFactory = (m: Partial<Member> = {}): Member => {
     userAgreementsDate: m.userAgreementsDate ?? faker.date.anytime(),
     ...BaseAccountFactory({ type: AccountType.Individual }),
     ...m,
-  } as Member;
+  } as Member; // necessary cast because typeORM requires more properties
 };
 
 export const GuestFactory = (g: Partial<Guest> & Pick<Guest, 'itemLoginSchema'>) => ({

--- a/test/factories/member.factory.ts
+++ b/test/factories/member.factory.ts
@@ -19,14 +19,20 @@ function BaseAccountFactory<T extends AccountType>(baseAccount: Partial<Account>
   };
 }
 
-export const MemberFactory = (m: Partial<Member> = {}) => ({
-  email: faker.internet.email().toLowerCase(),
-  extra: faker.helpers.arrayElement([{ lang: faker.helpers.arrayElement(['en', 'fr', 'de']) }, {}]),
-  enableSaveActions: m.enableSaveActions ?? true,
-  isValidated: m.isValidated ?? true,
-  ...BaseAccountFactory({ type: AccountType.Individual }),
-  ...m,
-});
+export const MemberFactory = (m: Partial<Member> = {}): Member =>
+  ({
+    email: faker.internet.email().toLowerCase(),
+    extra: faker.helpers.arrayElement([
+      { lang: faker.helpers.arrayElement(['en', 'fr', 'de']) },
+      {},
+    ]),
+    enableSaveActions: m.enableSaveActions ?? true,
+    isValidated: m.isValidated ?? true,
+    lastAuthenticatedAt: m.lastAuthenticatedAt ?? faker.date.anytime(),
+    userAgreementsDate: m.userAgreementsDate ?? faker.date.anytime(),
+    ...BaseAccountFactory({ type: AccountType.Individual }),
+    ...m,
+  }) as Member;
 
 export const GuestFactory = (g: Partial<Guest> & Pick<Guest, 'itemLoginSchema'>) => ({
   ...BaseAccountFactory({ type: AccountType.Guest }),

--- a/test/mocks/seed.ts
+++ b/test/mocks/seed.ts
@@ -397,7 +397,7 @@ export async function seedFromJson(data: DataType = {}) {
  * @param member creator of the file
  * @returns file item structure
  */
-export function buildFile(member: SeedActor) {
+export function buildFile(member: ReferencedSeedActor) {
   return {
     type: ItemType.S3_FILE,
     extra: {

--- a/test/mocks/seed.ts
+++ b/test/mocks/seed.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { CompleteMember, ItemType, PermissionLevel, buildPathFromIds } from '@graasp/sdk';
 
 import { AppDataSource } from '../../src/plugins/datasource';
+import { Account } from '../../src/services/account/entities/account';
 import { MemberPassword } from '../../src/services/auth/plugins/password/entities/password';
 import { encryptPassword } from '../../src/services/auth/plugins/password/utils';
 import { Item } from '../../src/services/item/entities/Item';
@@ -64,33 +65,74 @@ export default async function seed(
 type SeedActor =
   | 'actor'
   | (Partial<CompleteMember> & { profile?: Partial<MemberProfile>; password?: string });
+type SeedMember = SeedActor | (Partial<Member> & { profile?: Partial<MemberProfile> });
+type SeedMembership =
+  | Partial<ItemMembership>
+  | {
+      account?: SeedMember;
+      creator?: SeedMember;
+      permission?: PermissionLevel;
+    };
+type SeedItem = (Partial<Item> | { creator: SeedActor }) & {
+  children?: SeedItem[];
+  memberships?: SeedMembership[];
+};
 type DataType = {
   actor?: SeedActor | null;
-  members?: (Partial<Member> & { profile?: Partial<MemberProfile> })[];
-  items?: ((Partial<Item> | { creator: SeedActor }) & {
-    children?: (Partial<Item> | { creator: SeedActor })[];
-    memberships?: (
-      | Partial<ItemMembership>
-      | { account?: SeedActor; creator?: SeedActor; permission?: PermissionLevel }
-    )[];
-  })[];
+  members?: SeedMember[];
+  items?: SeedItem[];
 };
 
-const replaceActorInItems = (createdActor?: Actor, items?: DataType['items']) => {
+const replaceActorInItems = (
+  nameString: string,
+  createdActor?: Actor,
+  items?: DataType['items'],
+) => {
   if (!items?.length) {
     return [];
   }
 
   return items.map((i) => ({
     ...i,
-    creator: i.creator === 'actor' ? createdActor : (i.creator ?? null),
+    creator: i.creator === nameString ? createdActor : (i.creator ?? null),
     memberships: i.memberships?.map((m) => ({
       ...m,
-      account: m.account === 'actor' ? createdActor : m.account,
-      creator: m.creator === 'actor' ? createdActor : m.creator,
+      account: m.account === nameString ? createdActor : m.account,
+      creator: m.creator === nameString ? createdActor : m.creator,
     })),
-    children: replaceActorInItems(createdActor, i.children),
+    children: replaceActorInItems(nameString, createdActor, i.children),
   }));
+};
+
+function getNameIfExists(i?: object | null | string) {
+  if (i && typeof i == 'object' && 'name' in i) {
+    return i.name;
+  }
+  return null;
+}
+
+const replaceAccountInItems = (createdAccount: Account, items?: DataType['items']) => {
+  if (!items?.length) {
+    return [];
+  }
+
+  return items.map((i) => {
+    const memberships = i.memberships?.map((m) => {
+      return {
+        ...m,
+        account: getNameIfExists(m.account) === createdAccount.name ? createdAccount : m.account,
+        creator: getNameIfExists(m.creator) === createdAccount.name ? createdAccount : m.creator,
+      };
+    });
+
+    return {
+      ...i,
+      creator:
+        getNameIfExists(i.creator) === createdAccount.name ? createdAccount : (i.creator ?? null),
+      memberships,
+      children: replaceAccountInItems(createdAccount, i.children),
+    };
+  });
 };
 
 /**
@@ -141,7 +183,7 @@ const processActor = async ({ actor, items, members }: DataType) => {
   }
 
   // replace 'actor' in entities
-  const processedItems = replaceActorInItems(createdActor, items);
+  const processedItems = replaceActorInItems('actor', createdActor, items);
 
   return { actor: createdActor, items: processedItems, members, actorProfile };
 };
@@ -163,7 +205,7 @@ const generateIdAndPathForItems = (
 
   return items.flatMap((i) => {
     const id = v4();
-    const path = buildPathFromIds(...([parent?.id, id].filter(Boolean) as string[]));
+    const path = (parent?.path ? parent?.path + '.' : '') + buildPathFromIds(id);
     const { children, ...allprops } = i;
 
     const fullParent = {
@@ -192,14 +234,74 @@ const processItemMemberships = (items: DataType['items'] = []) => {
 
 /**
  * Generate ids for members, necessary to further references (for example when creating profiles)
- * @param members
+ * Only unique accounts will be created based on their name
+ * @param members standalone members to be created
+ * @param items items whose creator and memberships' accounts should be created
  * @returns members' data with generated id
  */
-function generateIdForMembers(members?: DataType['members']) {
-  return members?.map((m) => {
-    const id = v4();
-    return { id, ...m, profile: { ...m.profile, member: { id } } };
+function generateIdForMembers({ members = [], items = [] }: any) {
+  // get all unique members
+  const allMembers = [
+    ...members,
+    ...items.flatMap((i) => [i.creator ?? null, ...(i.memberships ?? [])?.map((m) => m.account)]),
+  ].filter((m, index, array) => {
+    // return unique member by name
+    if (m && 'name' in m) {
+      return array.findIndex((a) => a && 'name' in a && a?.name === m.name) === index;
+    }
+    // member should be created
+    if (m) {
+      return true;
+    }
   });
+
+  const d = allMembers.map((m) => {
+    const id = v4();
+    return { id, ...m, profile: m.profile ? { ...m.profile, member: { id } } : undefined };
+  });
+  return d;
+}
+
+/**
+ * Given data, save needed and unique members and their related entities (eg. profile)
+ * @param members standalone members to be created
+ * @param items items whose creator and memberships' accounts should be created
+ * @returns members, memberProfiles and items filled with related account's data
+ */
+async function processMembers({
+  actor,
+  items = [],
+  members = [],
+}: {
+  actor?: Actor;
+  items?: Item[];
+  members?: SeedMember[];
+}) {
+  const membersWithIds = generateIdForMembers({ items, members })
+    // ignore actor if it is defined
+    .filter((m) => (actor ? m.id !== actor.id : true));
+
+  if (membersWithIds) {
+    const membersAndProfiles = await seed({
+      members: {
+        factory: MemberFactory,
+        constructor: Member,
+        entities: membersWithIds,
+      },
+      memberProfiles: {
+        constructor: MemberProfile,
+        entities: membersWithIds.map((m) => m.profile).filter(Boolean),
+      },
+    });
+    const resultMembers = membersAndProfiles.members as Member[];
+    const memberProfiles = membersAndProfiles.memberProfiles as MemberProfile[];
+    const processedItems = resultMembers.reduce(
+      (acc, m) => replaceAccountInItems(m, acc) as any,
+      items,
+    );
+    return { resultMembers, memberProfiles, items: processedItems };
+  }
+  return { resultMembers: [], memberProfiles: [], items: [] };
 }
 
 /**
@@ -225,30 +327,25 @@ export async function seedFromJson(data: DataType = {}) {
     memberProfiles: [],
   };
 
-  const { items, actor, members, actorProfile } = await processActor(data);
+  const { items: itemsWithActor, actor, members, actorProfile } = await processActor(data);
   result.actor = actor;
   result.memberProfiles = actorProfile ? [actorProfile] : [];
 
-  // save members
-  const membersEntities = generateIdForMembers(members);
-  if (membersEntities) {
-    const membersAndProfiles = await seed({
-      members: {
-        factory: MemberFactory,
-        constructor: Member,
-        entities: membersEntities,
-      },
-      memberProfiles: {
-        constructor: MemberProfile,
-        entities: membersEntities.map((m) => m.profile).filter(Boolean),
-      },
-    });
-    result.members = membersAndProfiles.members as Member[];
-    result.memberProfiles = membersAndProfiles.memberProfiles as MemberProfile[];
-  }
+  // save members and their relations
+  const {
+    resultMembers,
+    memberProfiles,
+    items: itemsWithAccounts,
+  } = await processMembers({
+    items: itemsWithActor,
+    members,
+    actor,
+  });
+  result.members = resultMembers;
+  result.memberProfiles = result.memberProfiles.concat(memberProfiles);
 
   // save items
-  const processedItems = generateIdAndPathForItems(items);
+  const processedItems = generateIdAndPathForItems(itemsWithAccounts);
   if (processedItems) {
     result.items = (
       await seed({
@@ -262,13 +359,13 @@ export async function seedFromJson(data: DataType = {}) {
   }
 
   // save item memberships
-  const itemMembershipsEntity = processItemMemberships(processedItems);
-  if (itemMembershipsEntity) {
+  const itemMembershipsEntities = processItemMemberships(processedItems);
+  if (itemMembershipsEntities) {
     result.itemMemberships = (
       await seed({
         itemMemberships: {
           constructor: ItemMembership,
-          entities: itemMembershipsEntity,
+          entities: itemMembershipsEntities,
         },
       })
     ).itemMemberships as ItemMembership[];

--- a/test/mocks/seed.ts
+++ b/test/mocks/seed.ts
@@ -63,9 +63,8 @@ export default async function seed(
 }
 
 const ACTOR_STRING = 'actor';
-type SeedActor =
-  | 'actor'
-  | (Partial<Member> & { profile?: Partial<MemberProfile>; password?: string });
+type SeedActor = Partial<Member> & { profile?: Partial<MemberProfile>; password?: string };
+type ReferencedSeedActor = 'actor' | SeedActor;
 type SeedMember = Partial<Member> & { profile?: Partial<MemberProfile> };
 type SeedMembership<M = SeedMember> = Partial<Omit<ItemMembership, 'creator' | 'account'>> & {
   account?: M;
@@ -79,7 +78,7 @@ type SeedItem<M = SeedMember> = (Partial<Omit<Item, 'creator'>> & { creator?: M 
 type DataType = {
   actor?: SeedActor | null;
   members?: SeedMember[];
-  items?: SeedItem<SeedActor | SeedMember>[];
+  items?: SeedItem<ReferencedSeedActor | SeedMember>[];
 };
 
 const replaceActorInItems = (createdActor?: Member, items?: DataType['items']): SeedItem[] => {
@@ -141,7 +140,7 @@ const processActor = async ({ actor, items, members }: DataType) => {
   let actorProfile;
   if (actor !== null) {
     // replace actor data with default values if actor is undefined or 'actor'
-    const actorData = typeof actor === 'string' || !actor ? {} : actor;
+    const actorData = !actor ? {} : actor;
     createdActor = (
       await seed({
         actor: {
@@ -153,7 +152,7 @@ const processActor = async ({ actor, items, members }: DataType) => {
     ).actor[0];
 
     // a profile is defined
-    if (actor && actor !== 'actor') {
+    if (actor) {
       if (actor.profile) {
         actorProfile = (
           await seed({


### PR DESCRIPTION
Adds membership management for `seedFromJson`.
You can specify an `account` with a name only for a membership, that will generate a member correctly from it. Account are distinct by their name, so you can reuse the same name across one seed. 
This management does not handle `guest` yet.