### PR TITLE
refactor: remove reply url from get item content and thumbnail

### DIFF
--- a/src/services/file/service.ts
+++ b/src/services/file/service.ts
@@ -1,8 +1,4 @@
-import contentDisposition from 'content-disposition';
-import { StatusCodes } from 'http-status-codes';
 import { Readable } from 'stream';
-
-import { FastifyReply } from 'fastify';
 
 import { Account, Member } from '@graasp/sdk';
 
@@ -179,35 +175,6 @@ class FileService {
       originalFolderPath,
       newFolderPath,
     });
-  }
-  // should this be here?
-  setHeaders({
-    reply,
-    id,
-    replyUrl,
-    url,
-  }: {
-    id: string;
-    url: string;
-    reply: FastifyReply;
-    replyUrl?: boolean;
-  }) {
-    if (replyUrl) {
-      // const replyUrlExpiration = S3_PRESIGNED_EXPIRATION;
-      // reply.header('Cache-Control', `max-age=${replyUrlExpiration}`);
-      reply.status(StatusCodes.OK).send(url);
-    } else {
-      // this header will make the browser download the file with 'name'
-      // instead of simply opening it and showing it
-      reply.header('Content-Disposition', contentDisposition(id));
-      // TODO: necessary for localfiles ?
-      // reply.type(mimetype);
-      // It is necessary to add the header manually, because the redirect sends the request and
-      // when the fastify-cors plugin try to add the header it's already sent and can't add it.
-      // So we add it because otherwise the browser won't send the cookie
-      reply.header('Access-Control-Allow-Credentials', 'true');
-      reply.redirect(StatusCodes.MOVED_TEMPORARILY, url);
-    }
   }
 }
 

--- a/src/services/item/plugins/file/index.ts
+++ b/src/services/item/plugins/file/index.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from 'http-status-codes';
-
 import { fastifyMultipart } from '@fastify/multipart';
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
@@ -193,7 +191,7 @@ const basePlugin: FastifyPluginAsyncTypebox<GraaspPluginFileOptions> = async (fa
       schema: download,
       preHandler: optionalIsAuthenticated,
     },
-    async (request, reply) => {
+    async (request) => {
       const {
         user,
         params: { id: itemId },
@@ -203,7 +201,7 @@ const basePlugin: FastifyPluginAsyncTypebox<GraaspPluginFileOptions> = async (fa
         itemId,
       });
 
-      reply.status(StatusCodes.OK).send(url);
+      return url;
     },
   );
 };

--- a/src/services/item/plugins/file/index.ts
+++ b/src/services/item/plugins/file/index.ts
@@ -1,3 +1,5 @@
+import { StatusCodes } from 'http-status-codes';
+
 import { fastifyMultipart } from '@fastify/multipart';
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
@@ -195,13 +197,13 @@ const basePlugin: FastifyPluginAsyncTypebox<GraaspPluginFileOptions> = async (fa
       const {
         user,
         params: { id: itemId },
-        query: { replyUrl },
       } = request;
 
       const url = await fileItemService.getUrl(user?.account, buildRepositories(), {
         itemId,
       });
-      fileService.setHeaders({ url, reply, replyUrl, id: itemId });
+
+      reply.status(StatusCodes.OK).send(url);
     },
   );
 };

--- a/src/services/item/plugins/file/schema.ts
+++ b/src/services/item/plugins/file/schema.ts
@@ -39,7 +39,9 @@ export const download = {
   params: customType.StrictObject({
     id: customType.UUID(),
   }),
-  querystring: customType.StrictObject({ replyUrl: Type.Boolean({ default: false }) }),
+  querystring: customType.StrictObject({
+    replyUrl: Type.Boolean({ default: true, deprecated: true }),
+  }),
   response: {
     [StatusCodes.OK]: Type.String({ format: 'uri' }),
     '4xx': errorSchemaRef,

--- a/src/services/item/plugins/file/schema.ts
+++ b/src/services/item/plugins/file/schema.ts
@@ -40,6 +40,9 @@ export const download = {
     id: customType.UUID(),
   }),
   querystring: customType.StrictObject({
+    /**
+     * @deprecated we don't use this parameter anymore. This should be removed in a March 2025.
+     */
     replyUrl: Type.Boolean({ default: true, deprecated: true }),
   }),
   response: {

--- a/src/services/item/plugins/file/schema.ts
+++ b/src/services/item/plugins/file/schema.ts
@@ -41,7 +41,7 @@ export const download = {
   }),
   querystring: customType.StrictObject({
     /**
-     * @deprecated we don't use this parameter anymore. This should be removed in a March 2025.
+     * @deprecated we don't use this parameter anymore. This should be removed app once the mobile is deprecated.
      */
     replyUrl: Type.Boolean({ default: true, deprecated: true }),
   }),

--- a/src/services/item/plugins/file/test/index.test.ts
+++ b/src/services/item/plugins/file/test/index.test.ts
@@ -451,8 +451,8 @@ describe('File Item routes tests', () => {
           url: `${ITEMS_ROUTE_PREFIX}/${item.id}/download`,
         });
 
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.headers.location).toBe(MOCK_SIGNED_URL);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        expect(response.body).toBe(MOCK_SIGNED_URL);
       });
     });
 
@@ -468,20 +468,10 @@ describe('File Item routes tests', () => {
         }));
       });
       describe('Without error', () => {
-        it('Redirect to file item', async () => {
-          const response = await app.inject({
-            method: HttpMethod.Get,
-            url: `${ITEMS_ROUTE_PREFIX}/${item.id}/download`,
-          });
-
-          expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-          expect(response.headers.location).toBe(MOCK_SIGNED_URL);
-        });
-
         it('Return file url of item', async () => {
           const response = await app.inject({
             method: HttpMethod.Get,
-            url: `${ITEMS_ROUTE_PREFIX}/${item.id}/download?replyUrl=true`,
+            url: `${ITEMS_ROUTE_PREFIX}/${item.id}/download`,
           });
 
           expect(response.statusCode).toBe(StatusCodes.OK);

--- a/src/services/item/plugins/thumbnail/index.ts
+++ b/src/services/item/plugins/thumbnail/index.ts
@@ -9,7 +9,6 @@ import { THUMBNAILS_ROUTE_PREFIX } from '../../../../utils/config';
 import { buildRepositories } from '../../../../utils/repositories';
 import { isAuthenticated, optionalIsAuthenticated } from '../../../auth/plugins/passport';
 import { matchOne } from '../../../authorization';
-import FileService from '../../../file/service';
 import { UploadFileUnexpectedError } from '../../../file/utils/errors';
 import { assertIsMember } from '../../../member/entities/member';
 import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
@@ -27,7 +26,6 @@ const plugin: FastifyPluginAsyncTypebox<GraaspThumbnailsOptions> = async (fastif
   const { maxFileSize = DEFAULT_MAX_FILE_SIZE } = options;
   const { db } = fastify;
 
-  const fileService = resolveDependency(FileService);
   const itemThumbnailService = resolveDependency(ItemThumbnailService);
 
   fastify.register(fastifyMultipart, {
@@ -98,7 +96,7 @@ const plugin: FastifyPluginAsyncTypebox<GraaspThumbnailsOptions> = async (fastif
       if (!url) {
         return null;
       } else {
-        fileService.setHeaders({ reply, url, id: itemId, replyUrl: true });
+        reply.status(StatusCodes.OK).send(url);
       }
     },
   );

--- a/src/services/member/plugins/thumbnail/index.ts
+++ b/src/services/member/plugins/thumbnail/index.ts
@@ -10,7 +10,6 @@ import { asDefined } from '../../../../utils/assertions';
 import { buildRepositories } from '../../../../utils/repositories';
 import { isAuthenticated, optionalIsAuthenticated } from '../../../auth/plugins/passport';
 import { matchOne } from '../../../authorization';
-import FileService from '../../../file/service';
 import { UploadEmptyFileError, UploadFileUnexpectedError } from '../../../file/utils/errors';
 import { assertIsMember } from '../../entities/member';
 import { validatedMemberAccountRole } from '../../strategies/validatedMemberAccountRole';
@@ -26,7 +25,6 @@ type GraaspThumbnailsOptions = {
 const plugin: FastifyPluginAsyncTypebox<GraaspThumbnailsOptions> = async (fastify, options) => {
   const { maxFileSize = MAX_THUMBNAIL_SIZE } = options;
   const { db } = fastify;
-  const fileService = resolveDependency(FileService);
   const thumbnailService = resolveDependency(MemberThumbnailService);
 
   fastify.register(fastifyMultipart, {
@@ -85,7 +83,7 @@ const plugin: FastifyPluginAsyncTypebox<GraaspThumbnailsOptions> = async (fastif
       schema: download,
       preHandler: optionalIsAuthenticated,
     },
-    async ({ user, params: { size, id: memberId }, query: { replyUrl } }, reply) => {
+    async ({ user, params: { size, id: memberId } }, reply) => {
       const url = await thumbnailService.getUrl(user?.account, buildRepositories(), {
         memberId,
         size,
@@ -94,7 +92,7 @@ const plugin: FastifyPluginAsyncTypebox<GraaspThumbnailsOptions> = async (fastif
       if (!url) {
         reply.status(StatusCodes.NO_CONTENT);
       } else {
-        fileService.setHeaders({ reply, replyUrl, url, id: memberId });
+        reply.status(StatusCodes.OK).send(url);
       }
     },
   );

--- a/src/services/member/plugins/thumbnail/schemas.ts
+++ b/src/services/member/plugins/thumbnail/schemas.ts
@@ -25,7 +25,7 @@ export const download = {
   }),
   querystring: customType.StrictObject({
     /**
-     * @deprecated we don't use this parameter anymore. This should be removed in a March 2025.
+     * @deprecated we don't use this parameter anymore. This should be removed once the mobile app is deprecated.
      */
     replyUrl: Type.Boolean({ default: true, deprecated: true }),
   }),

--- a/src/services/member/plugins/thumbnail/schemas.ts
+++ b/src/services/member/plugins/thumbnail/schemas.ts
@@ -24,6 +24,9 @@ export const download = {
     size: Type.Enum(ThumbnailSize, { default: ThumbnailSize.Medium }),
   }),
   querystring: customType.StrictObject({
+    /**
+     * @deprecated we don't use this parameter anymore. This should be removed in a March 2025.
+     */
     replyUrl: Type.Boolean({ default: true, deprecated: true }),
   }),
   response: {

--- a/src/services/member/plugins/thumbnail/schemas.ts
+++ b/src/services/member/plugins/thumbnail/schemas.ts
@@ -24,10 +24,10 @@ export const download = {
     size: Type.Enum(ThumbnailSize, { default: ThumbnailSize.Medium }),
   }),
   querystring: customType.StrictObject({
-    replyUrl: Type.Boolean({ default: false }),
+    replyUrl: Type.Boolean({ default: true, deprecated: true }),
   }),
   response: {
-    [StatusCodes.OK]: Type.String({ description: 'Url string of the avatar if replyUrl is true' }),
+    [StatusCodes.OK]: Type.String({ description: 'Url string of the avatar' }),
     [StatusCodes.NO_CONTENT]: Type.Null({ description: 'No avatar' }),
     '4xx': errorSchemaRef,
     [StatusCodes.INTERNAL_SERVER_ERROR]: errorSchemaRef,

--- a/src/services/member/plugins/thumbnail/test/index.test.ts
+++ b/src/services/member/plugins/thumbnail/test/index.test.ts
@@ -75,8 +75,8 @@ describe('Thumbnail Plugin Tests', () => {
         method: HttpMethod.Get,
         url: `members/${member.id}/avatar/${ThumbnailSize.Small}`,
       });
-      expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(response.headers.location).toBe(MOCK_SIGNED_URL);
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expect(response.body).toBe(MOCK_SIGNED_URL);
     });
 
     it('Successfully redirect to thumbnails of all different sizes', async () => {
@@ -86,8 +86,8 @@ describe('Thumbnail Plugin Tests', () => {
           method: HttpMethod.Get,
           url: `members/${member.id}/avatar/${size}`,
         });
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.headers.location).toBe(MOCK_SIGNED_URL);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        expect(response.body).toBe(MOCK_SIGNED_URL);
       }
     });
 
@@ -98,8 +98,8 @@ describe('Thumbnail Plugin Tests', () => {
           method: HttpMethod.Get,
           url: `members/${member.id}/avatar/${size}`,
         });
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.headers.location).toBe(MOCK_SIGNED_URL);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        expect(response.body).toBe(MOCK_SIGNED_URL);
       }
     });
 
@@ -110,8 +110,8 @@ describe('Thumbnail Plugin Tests', () => {
           method: HttpMethod.Get,
           url: `members/${member.id}/avatar/${size}`,
         });
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.headers.location).toBe(MOCK_SIGNED_URL);
+        expect(response.statusCode).toBe(StatusCodes.OK);
+        expect(response.body).toBe(MOCK_SIGNED_URL);
       }
     });
 
@@ -120,7 +120,7 @@ describe('Thumbnail Plugin Tests', () => {
       for (const size of Object.values(ThumbnailSize)) {
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `members/${member.id}/avatar/${size}?replyUrl=true`,
+          url: `members/${member.id}/avatar/${size}`,
         });
 
         expect(response.statusCode).toBe(StatusCodes.OK);
@@ -133,7 +133,7 @@ describe('Thumbnail Plugin Tests', () => {
       for (const size of Object.values(ThumbnailSize)) {
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `members/${member.id}/avatar/${size}?replyUrl=true`,
+          url: `members/${member.id}/avatar/${size}`,
         });
 
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -149,7 +149,7 @@ describe('Thumbnail Plugin Tests', () => {
       for (const size of Object.values(ThumbnailSize)) {
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `members/${guest!.id}/avatar/${size}?replyUrl=true`,
+          url: `members/${guest!.id}/avatar/${size}`,
         });
 
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -160,7 +160,7 @@ describe('Thumbnail Plugin Tests', () => {
       for (const size of Object.values(ThumbnailSize)) {
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `members/${v4()}/avatar/${size}?replyUrl=true`,
+          url: `members/${v4()}/avatar/${size}`,
         });
 
         expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
@@ -177,7 +177,7 @@ describe('Thumbnail Plugin Tests', () => {
       for (const size of Object.values(ThumbnailSize)) {
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `members/${member.id}/avatar/${size}?replyUrl=true`,
+          url: `members/${member.id}/avatar/${size}`,
         });
 
         expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Remove `replyUrl` for
- GET items/thumbnails
- GET members/avatar
- GET item/download (item file)

We still keep the query param to prevent schema error, but it does nothing. 
The only and default behavior is to return a string which is the url of the file (s3 url).

close #1758 
close #1683 