### PR TITLE
ci: include source maps on build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     "strictNullChecks": true,
     "strictPropertyInitialization": false, // disable because of entities,
-    "typeRoots": ["./node_modules/@types", "./src/@types/*"]
+    "typeRoots": ["./node_modules/@types", "./src/@types/*"],
+    "sourceMap": true
   },
   "include": ["src/**/*", "test"]
 }


### PR DESCRIPTION
Enable source maps in tsconfig. It allows the debugger to work!