### PR TITLE
fix: use an authenticatedUser that is minimal

### DIFF
--- a/src/@types/declarations.d.ts
+++ b/src/@types/declarations.d.ts
@@ -20,6 +20,7 @@ import { Item } from '../services/item/entities/Item';
 import { create, updateOne } from '../services/item/schema';
 import { Actor, Member } from '../services/member/entities/member';
 import { WebsocketService } from '../services/websockets/ws-service';
+import { AuthenticatedUser } from '../types';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -32,7 +33,7 @@ declare module 'fastify' {
   }
 
   interface PassportUser {
-    account?: Member | Guest;
+    account?: Actor;
     passwordResetRedisKey?: string; // Used for Password Reset
     emailChange?: {
       newEmail: string;

--- a/src/services/account/schemas.ts
+++ b/src/services/account/schemas.ts
@@ -1,8 +1,7 @@
 import { Type } from '@fastify/type-provider-typebox';
 
-import { AccountType } from '@graasp/sdk';
-
 import { customType, registerSchemaAsRef } from '../../plugins/typebox';
+import { AccountType } from '../../types';
 
 const accountSchema = customType.StrictObject(
   {

--- a/src/services/action/services/action.ts
+++ b/src/services/action/services/action.ts
@@ -26,12 +26,15 @@ export class ActionService {
   }
 
   async postMany(
-    member: Actor,
+    actor: Actor,
     repositories: Repositories,
     request: FastifyRequest,
     actions: (Partial<Action> & Pick<Action, 'type'>)[],
   ): Promise<void> {
     const { headers } = request;
+
+    // expand member to the full account
+    const member = actor ? await repositories.memberRepository.get(actor.id) : null;
 
     // prevent saving if member is defined and has disabled saveActions
     if (member && isMember(member) && member.enableSaveActions === false) {

--- a/src/services/action/utils/export.ts
+++ b/src/services/action/utils/export.ts
@@ -127,7 +127,7 @@ export const exportActionsInArchive = async (args: {
       fileFolderPath,
       buildActionFileName('members', archiveDate, format),
     );
-    writeFileForFormat(membersFilepath, format, baseAnalytics.members);
+    writeFileForFormat(membersFilepath, format, baseAnalytics.members ?? []);
 
     // create file for the memberships
     const iMembershipsPath = path.join(

--- a/src/services/auth/plugins/mobile/index.ts
+++ b/src/services/auth/plugins/mobile/index.ts
@@ -112,16 +112,21 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       preHandler: authenticateJWTChallengeVerifier,
     },
     async ({ user, authInfo }) => {
-      const member = asDefined(user?.account);
+      const account = asDefined(user?.account);
       await db.transaction(async (manager) => {
         const repositories = buildRepositories(manager);
-        await memberService.refreshLastAuthenticatedAt(member.id, repositories);
+        await memberService.refreshLastAuthenticatedAt(account.id, repositories);
         // on auth, if the user used the email sign in, its account gets validated
-        if (authInfo?.emailValidation && isMember(member) && !member.isValidated) {
-          await memberService.validate(member.id, repositories);
+        if (authInfo?.emailValidation && isMember(account)) {
+          // fetch complete member info from DB
+          const member = await repositories.memberRepository.get(account.id);
+          // if member is not validated, we validate them since they provided a proof of access to their email
+          if (!member.isValidated) {
+            await memberService.validate(account.id, repositories);
+          }
         }
       });
-      return generateAuthTokensPair(member.id);
+      return generateAuthTokensPair(account.id);
     },
   );
 

--- a/src/services/auth/plugins/passport/plugin.ts
+++ b/src/services/auth/plugins/passport/plugin.ts
@@ -3,6 +3,7 @@ import { fastifySecureSession } from '@fastify/secure-session';
 import { FastifyInstance, FastifyPluginAsync, PassportUser } from 'fastify';
 
 import { resolveDependency } from '../../../../di/utils';
+import { AuthenticatedUser } from '../../../../types';
 import { assertIsDefined } from '../../../../utils/assertions';
 import {
   AUTH_TOKEN_JWT_SECRET,
@@ -126,7 +127,8 @@ const plugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   });
   fastifyPassport.registerUserDeserializer(async (uuid: string, _req): Promise<PassportUser> => {
     return {
-      account: await accountRepository.get(uuid),
+      // HACK: We cast here, but in the future we should only retrieve the minimal info
+      account: (await accountRepository.get(uuid)) as AuthenticatedUser,
     };
   });
 };

--- a/src/services/auth/plugins/passport/strategies/jwt.ts
+++ b/src/services/auth/plugins/passport/strategies/jwt.ts
@@ -2,6 +2,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
+import { AuthenticatedUser } from '../../../../../types';
 import { MemberNotFound, UnauthorizedMember } from '../../../../../utils/errors';
 import { AccountRepository } from '../../../../account/repository';
 import { PassportStrategy } from '../strategies';
@@ -23,7 +24,8 @@ export default (
       },
       async ({ sub }, done: StrictVerifiedCallback) => {
         try {
-          const account = await accountRepository.get(sub);
+          // HACK: We cast here, but in the future we should only retrieve the minimal info
+          const account = (await accountRepository.get(sub)) as AuthenticatedUser;
           if (account) {
             // Token has been validated
             return done(null, { account });

--- a/src/services/auth/plugins/passport/strategies/jwtApps.ts
+++ b/src/services/auth/plugins/passport/strategies/jwtApps.ts
@@ -2,6 +2,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
+import { AuthenticatedUser } from '../../../../../types';
 import { APPS_JWT_SECRET } from '../../../../../utils/config';
 import { UnauthorizedMember } from '../../../../../utils/errors';
 import { AccountRepository } from '../../../../account/repository';
@@ -34,7 +35,8 @@ export default (
         }
 
         // Fetch Member datas
-        const account = await accountRepository.get(accountId);
+        // HACK: We cast here, but in the future we should only retrieve the minimal info
+        const account = (await accountRepository.get(accountId)) as AuthenticatedUser;
         // Member can be undefined if authorized.
         if (strict && !account) {
           return done(new UnauthorizedMember(), false);

--- a/src/services/auth/plugins/passport/strategies/jwtChallengeVerifier.ts
+++ b/src/services/auth/plugins/passport/strategies/jwtChallengeVerifier.ts
@@ -3,6 +3,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
+import { AuthenticatedUser } from '../../../../../types';
 import { JWT_SECRET } from '../../../../../utils/config';
 import { ChallengeFailed, MemberNotFound, UnauthorizedMember } from '../../../../../utils/errors';
 import { AccountRepository } from '../../../../account/repository';
@@ -44,7 +45,8 @@ export default (
 
         //-- Fetch Member Data --//
         try {
-          const account = await accountRepository.get(sub);
+          // HACK: We cast here, but in the future we should only retrieve the minimal info
+          const account = (await accountRepository.get(sub)) as AuthenticatedUser;
           if (account) {
             // Token has been validated
             return done(null, { account }, { emailValidation });

--- a/src/services/auth/plugins/password/service.ts
+++ b/src/services/auth/plugins/password/service.ts
@@ -9,6 +9,7 @@ import { TRANSLATIONS } from '../../../../langs/constants';
 import { BaseLogger } from '../../../../logger';
 import { MailBuilder } from '../../../../plugins/mailer/builder';
 import { MailerService } from '../../../../plugins/mailer/service';
+import { AuthenticatedUser } from '../../../../types';
 import {
   JWT_SECRET,
   PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES,
@@ -16,7 +17,6 @@ import {
 } from '../../../../utils/config';
 import { MemberNotSignedUp, MemberWithoutPassword } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
-import { Account } from '../../../account/entities/account';
 import { Member } from '../../../member/entities/member';
 import { SHORT_TOKEN_PARAM } from '../passport';
 import { PasswordConflict } from './errors';
@@ -57,7 +57,7 @@ export class MemberPasswordService {
     });
   }
 
-  async post(actor: Account, repositories: Repositories, newPassword: string) {
+  async post(actor: AuthenticatedUser, repositories: Repositories, newPassword: string) {
     const { memberPasswordRepository } = repositories;
     // verify that input current password is the same as the stored one
     const currentPassword = await memberPasswordRepository.getForMemberId(actor.id);
@@ -71,7 +71,7 @@ export class MemberPasswordService {
   }
 
   async patch(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     newPassword: string,
     currentPassword: string,

--- a/src/services/authorization.test.ts
+++ b/src/services/authorization.test.ts
@@ -11,10 +11,10 @@ import {
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../test/app';
 import { ItemMembershipRepository } from '../services/itemMembership/repository';
+import { AuthenticatedUser } from '../types';
 import { asDefined } from '../utils/assertions';
 import { MemberCannotAccess, MemberCannotAdminItem, MemberCannotWriteItem } from '../utils/errors';
 import { type Repositories } from '../utils/repositories';
-import { Account } from './account/entities/account';
 import { isAuthenticated } from './auth/plugins/passport';
 import {
   filterOutPackedDescendants,
@@ -32,8 +32,18 @@ import { Member } from './member/entities/member';
 import { validatedMemberAccountRole } from './member/strategies/validatedMemberAccountRole';
 import { saveMember } from './member/test/fixtures/members';
 
-const OWNER = { id: 'owner', name: 'owner' } as Account;
-const SHARED_MEMBER = { id: 'shared', name: 'shared' } as Account;
+const OWNER = {
+  id: 'owner',
+  name: 'owner',
+  type: 'individual',
+  isValidated: true,
+} satisfies AuthenticatedUser;
+const SHARED_MEMBER = {
+  id: 'shared',
+  name: 'shared',
+  type: 'individual',
+  isValidated: true,
+} satisfies AuthenticatedUser;
 const OTHER_MEMBER = { id: 'other', name: 'other' } as Member;
 const ITEM = { id: 'item' } as Item;
 const ownerMembership = { account: OWNER, permission: PermissionLevel.Admin } as ItemMembership;

--- a/src/services/chat/repository.ts
+++ b/src/services/chat/repository.ts
@@ -6,15 +6,13 @@ import { MutableRepository } from '../../repositories/MutableRepository';
 import { DEFAULT_PRIMARY_KEY } from '../../repositories/const';
 import { DeleteException, EntryNotFoundBeforeDeleteException } from '../../repositories/errors';
 import { assertIsError } from '../../utils/assertions';
-import { Guest } from '../itemLogin/entities/guest';
-import { Member } from '../member/entities/member';
 import { messageSchema } from '../member/plugins/export-data/schemas/schemas';
 import { schemaToSelectMapper } from '../member/plugins/export-data/utils/selection.utils';
 import { mapById } from '../utils';
 import { ChatMessage } from './chatMessage';
 
 type ChatMessageUpdateBody = Partial<ChatMessage>;
-type ChatMessageCreateBody = { itemId: string; creator: Guest | Member; body: string };
+type ChatMessageCreateBody = { itemId: string; creatorId: string; body: string };
 
 export class ChatMessageRepository extends MutableRepository<ChatMessage, ChatMessageUpdateBody> {
   constructor(manager?: EntityManager) {
@@ -83,7 +81,11 @@ export class ChatMessageRepository extends MutableRepository<ChatMessage, ChatMe
    * @param message Message
    */
   async addOne(message: ChatMessageCreateBody): Promise<ChatMessage> {
-    return await super.insert({ ...message, item: { id: message.itemId } });
+    return await super.insert({
+      ...message,
+      item: { id: message.itemId },
+      creator: { id: message.creatorId },
+    });
   }
 
   /**

--- a/src/services/chat/service.ts
+++ b/src/services/chat/service.ts
@@ -2,12 +2,11 @@ import { singleton } from 'tsyringe';
 
 import { PermissionLevel } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../types';
 import HookManager from '../../utils/hook';
 import { Repositories } from '../../utils/repositories';
-import { Account } from '../account/entities/account';
 import { ItemService } from '../item/service';
-import { Guest } from '../itemLogin/entities/guest';
-import { Actor, Member } from '../member/entities/member';
+import { Actor } from '../member/entities/member';
 import { ChatMessage } from './chatMessage';
 import { MemberCannotDeleteMessage, MemberCannotEditMessage } from './errors';
 import { MentionService } from './plugins/mentions/service';
@@ -37,7 +36,7 @@ export class ChatMessageService {
   }
 
   async postOne(
-    actor: Guest | Member,
+    actor: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     data: { body: string; mentions?: string[] },
@@ -49,7 +48,7 @@ export class ChatMessageService {
 
     const message = await chatMessageRepository.addOne({
       itemId,
-      creator: actor,
+      creatorId: actor.id,
       body: data.body,
     });
 
@@ -64,7 +63,7 @@ export class ChatMessageService {
   }
 
   async patchOne(
-    actor: Account,
+    actor: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     messageId: string,
@@ -89,7 +88,12 @@ export class ChatMessageService {
     return updatedMessage;
   }
 
-  async deleteOne(actor: Account, repositories: Repositories, itemId: string, messageId: string) {
+  async deleteOne(
+    actor: AuthenticatedUser,
+    repositories: Repositories,
+    itemId: string,
+    messageId: string,
+  ) {
     const { chatMessageRepository } = repositories;
 
     // check permission
@@ -111,7 +115,7 @@ export class ChatMessageService {
     return messageContent;
   }
 
-  async clear(actor: Account, repositories: Repositories, itemId: string) {
+  async clear(actor: AuthenticatedUser, repositories: Repositories, itemId: string) {
     const { chatMessageRepository } = repositories;
 
     // check rights for accessing the chat and sufficient right to clear the conversation

--- a/src/services/file/service.ts
+++ b/src/services/file/service.ts
@@ -1,8 +1,9 @@
 import { Readable } from 'stream';
 
-import { Account, Member } from '@graasp/sdk';
+import { Account } from '@graasp/sdk';
 
 import { BaseLogger } from '../../logger';
+import { AuthenticatedUser } from '../../types';
 import { CachingService } from '../caching/service';
 import { Actor } from '../member/entities/member';
 import { LocalFileConfiguration, S3FileConfiguration } from './interfaces/configuration';
@@ -135,7 +136,7 @@ class FileService {
   }
 
   async copy(
-    member: Member,
+    member: AuthenticatedUser,
     data: {
       newId?: string;
       newFilePath: string;

--- a/src/services/item/plugins/action/base-analytics.test.ts
+++ b/src/services/item/plugins/action/base-analytics.test.ts
@@ -81,7 +81,7 @@ describe('Base Analytics', () => {
     });
 
     for (const m of members) {
-      const member = analytics.members.find((me) => me.name === m.name) as Member | undefined;
+      const member = analytics.members?.find((me) => me.name === m.name) as Member | undefined;
       // lang exists
       if (m?.extra?.lang) {
         expect(member?.extra.lang).toBeTruthy();

--- a/src/services/item/plugins/action/base-analytics.ts
+++ b/src/services/item/plugins/action/base-analytics.ts
@@ -23,7 +23,7 @@ const memberSchema = {
 
 export class BaseAnalytics {
   readonly actions: Action[];
-  readonly members: { id: string; name: string }[];
+  readonly members: { id: string; name: string }[] | undefined;
   readonly itemMemberships: ItemMembership[];
   readonly descendants: Item[];
   readonly item: Item;
@@ -44,7 +44,7 @@ export class BaseAnalytics {
     item: Item;
     descendants: Item[];
     actions: Action[];
-    members: Account[];
+    members: Account[] | undefined;
     itemMemberships: ItemMembership[];
     chatMessages: ChatMessage[];
     apps: {

--- a/src/services/item/plugins/action/index.ts
+++ b/src/services/item/plugins/action/index.ts
@@ -47,9 +47,10 @@ const plugin: FastifyPluginAsyncTypebox<GraaspActionsOptions> = async (fastify) 
       preHandler: isAuthenticated,
     },
     async ({ user, params: { id }, query }) => {
+      const account = asDefined(user?.account);
       // remove itemMemberships from return
       const { itemMemberships: _, ...result } = await actionItemService.getBaseAnalyticsForItem(
-        user?.account,
+        account,
         buildRepositories(),
         {
           sampleSize: query.requestedSampleSize,

--- a/src/services/item/plugins/action/schemas.ts
+++ b/src/services/item/plugins/action/schemas.ts
@@ -61,7 +61,7 @@ export const getItemActions = {
   response: {
     [StatusCodes.OK]: customType.StrictObject({
       actions: Type.Array(actionSchema),
-      members: Type.Array(accountSchemaRef),
+      members: Type.Optional(Type.Array(accountSchemaRef)),
       descendants: Type.Array(itemSchemaRef),
       item: itemSchemaRef,
       apps: Type.Record(

--- a/src/services/item/plugins/action/service.ts
+++ b/src/services/item/plugins/action/service.ts
@@ -14,6 +14,7 @@ import {
   UUID,
 } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../types';
 import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
 import {
@@ -132,7 +133,7 @@ export class ActionItemService {
   }
 
   async getBaseAnalyticsForItem(
-    actor: Actor,
+    actor: AuthenticatedUser,
     repositories: Repositories,
     payload: {
       itemId: string;
@@ -180,7 +181,9 @@ export class ActionItemService {
     const allMemberships = [...inheritedMemberships, ...itemMemberships];
     // get members
     const members =
-      permission === PermissionLevel.Admin ? allMemberships.map(({ account }) => account) : [actor];
+      permission === PermissionLevel.Admin
+        ? allMemberships.map(({ account }) => account)
+        : undefined;
 
     // get descendants items
     const descendants = await this.itemService.getFilteredDescendants(

--- a/src/services/item/plugins/app/appAction/service.ts
+++ b/src/services/item/plugins/app/appAction/service.ts
@@ -1,8 +1,8 @@
 import { PermissionLevel } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../../types';
 import HookManager from '../../../../../utils/hook';
 import { Repositories } from '../../../../../utils/repositories';
-import { Account } from '../../../../account/entities/account';
 import { validatePermission } from '../../../../authorization';
 import { ManyItemsGetFilter, SingleItemGetFilter } from '../interfaces/request';
 import { AppAction } from './appAction';
@@ -17,7 +17,7 @@ export class AppActionService {
     };
   }>();
   async post(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     body: Partial<InputAppAction>,
@@ -45,7 +45,7 @@ export class AppActionService {
   }
 
   async getForItem(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     filters: SingleItemGetFilter,
@@ -78,7 +78,7 @@ export class AppActionService {
   }
 
   async getForManyItems(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     itemIds: string[],
     filters: ManyItemsGetFilter,

--- a/src/services/item/plugins/app/appData/plugins/file/service.ts
+++ b/src/services/item/plugins/app/appData/plugins/file/service.ts
@@ -6,8 +6,8 @@ import { MultipartFile } from '@fastify/multipart';
 
 import { AppDataVisibility, FileItemProperties, UUID } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../../../../types';
 import { Repositories } from '../../../../../../../utils/repositories';
-import { Account } from '../../../../../../account/entities/account';
 import FileService from '../../../../../../file/service';
 import { Item } from '../../../../../entities/Item';
 import { APP_DATA_TYPE_FILE } from '../../../constants';
@@ -29,7 +29,12 @@ class AppDataFileService {
     this.fileService = fileService;
   }
 
-  async upload(account: Account, repositories: Repositories, file: MultipartFile, item: Item) {
+  async upload(
+    account: AuthenticatedUser,
+    repositories: Repositories,
+    file: MultipartFile,
+    item: Item,
+  ) {
     const { filename, mimetype, file: stream } = file;
     const appDataId = v4();
     const filepath = this.buildFilePath(item.id, appDataId); // parentId, filename
@@ -80,7 +85,7 @@ class AppDataFileService {
   }
 
   async download(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     { item, appDataId }: { item: Item; appDataId: UUID },
   ) {

--- a/src/services/item/plugins/app/appData/service.ts
+++ b/src/services/item/plugins/app/appData/service.ts
@@ -3,9 +3,9 @@ import { inject, singleton } from 'tsyringe';
 import { AppDataVisibility, FileItemType, PermissionLevel, UUID } from '@graasp/sdk';
 
 import { FILE_ITEM_TYPE_DI_KEY } from '../../../../../di/constants';
+import { AuthenticatedUser } from '../../../../../types';
 import HookManager from '../../../../../utils/hook';
 import { Repositories } from '../../../../../utils/repositories';
-import { Account } from '../../../../account/entities/account';
 import { validatePermission } from '../../../../authorization';
 import { ItemMembership } from '../../../../itemMembership/entities/ItemMembership';
 import { Actor } from '../../../../member/entities/member';
@@ -79,7 +79,7 @@ export class AppDataService {
   }
 
   async post(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     body: Partial<InputAppData>,
@@ -117,7 +117,7 @@ export class AppDataService {
   }
 
   async patch(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     appDataId: string,
@@ -172,7 +172,12 @@ export class AppDataService {
     return appData;
   }
 
-  async deleteOne(account: Account, repositories: Repositories, itemId: string, appDataId: string) {
+  async deleteOne(
+    account: AuthenticatedUser,
+    repositories: Repositories,
+    itemId: string,
+    appDataId: string,
+  ) {
     const { appDataRepository, itemRepository } = repositories;
 
     // check item exists? let post fail?
@@ -210,7 +215,7 @@ export class AppDataService {
     return result;
   }
 
-  async get(account: Account, repositories: Repositories, item: Item, appDataId: UUID) {
+  async get(account: AuthenticatedUser, repositories: Repositories, item: Item, appDataId: UUID) {
     const { appDataRepository } = repositories;
 
     const { itemMembership } = await validatePermission(
@@ -241,7 +246,12 @@ export class AppDataService {
     return appData;
   }
 
-  async getForItem(account: Account, repositories: Repositories, itemId: string, type?: string) {
+  async getForItem(
+    account: AuthenticatedUser,
+    repositories: Repositories,
+    itemId: string,
+    type?: string,
+  ) {
     const { appDataRepository, itemRepository } = repositories;
 
     // check item exists? let post fail?

--- a/src/services/item/plugins/app/appSetting/plugins/file/service.ts
+++ b/src/services/item/plugins/app/appSetting/plugins/file/service.ts
@@ -6,8 +6,8 @@ import { MultipartFile } from '@fastify/multipart';
 
 import { FileItemProperties, MAX_ITEM_NAME_LENGTH, UUID } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../../../../types';
 import { Repositories } from '../../../../../../../utils/repositories';
-import { Account } from '../../../../../../account/entities/account';
 import FileService from '../../../../../../file/service';
 import { Actor, Member } from '../../../../../../member/entities/member';
 import { Item } from '../../../../../entities/Item';
@@ -42,7 +42,12 @@ class AppSettingFileService {
     this.itemService = itemService;
   }
 
-  async upload(member: Account, repositories: Repositories, file: MultipartFile, item: Item) {
+  async upload(
+    member: AuthenticatedUser,
+    repositories: Repositories,
+    file: MultipartFile,
+    item: Item,
+  ) {
     const { filename, mimetype, fields, file: stream } = file;
     const appSettingId = v4();
     const filepath = this.buildFilePath(item.id, appSettingId); // parentId, filename
@@ -88,7 +93,7 @@ class AppSettingFileService {
   }
 
   async download(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     { item, appSettingId }: { item: Item; appSettingId: UUID },
   ) {

--- a/src/services/item/plugins/app/chatBot/service.ts
+++ b/src/services/item/plugins/app/chatBot/service.ts
@@ -1,13 +1,13 @@
 import { ChatBotMessage, GPTVersion, PermissionLevel } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../../types';
 import { Repositories } from '../../../../../utils/repositories';
-import { Account } from '../../../../account/entities/account';
 import { validatePermission } from '../../../../authorization';
 import { fetchOpenAI } from './utils';
 
 export class ChatBotService {
   async post(
-    account: Account,
+    account: AuthenticatedUser,
     repositories: Repositories,
     itemId: string,
     body: Array<ChatBotMessage>,

--- a/src/services/item/plugins/app/service.ts
+++ b/src/services/item/plugins/app/service.ts
@@ -3,9 +3,9 @@ import uniqBy from 'lodash.uniqby';
 
 import { AuthTokenSubject, ItemType, PermissionLevel } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../types';
 import { APPS_JWT_SECRET } from '../../../../utils/config';
 import { Repositories } from '../../../../utils/repositories';
-import { Account } from '../../../account/entities/account';
 import { validatePermission } from '../../../authorization';
 import { Actor, Member } from '../../../member/entities/member';
 import { Item, isItemType } from '../../entities/Item';
@@ -29,7 +29,7 @@ export class AppService {
     return repositories.appRepository.getAll(publisherId);
   }
 
-  async getMostUsedApps(account: Account, repositories: Repositories) {
+  async getMostUsedApps(account: AuthenticatedUser, repositories: Repositories) {
     return repositories.appRepository.getMostUsedApps(account.id);
   }
 
@@ -85,14 +85,14 @@ export class AppService {
     // return member data only if authenticated
     let members: Member[] = [];
     if (account) {
-      members = await this.getTreeMembers(account, repositories, item);
+      members = await this.getTreeMembers(repositories, item);
     }
 
     return { item, members };
   }
 
   // used in apps: get members from tree
-  async getTreeMembers(actor: Actor, repositories: Repositories, item: Item): Promise<Member[]> {
+  async getTreeMembers(repositories: Repositories, item: Item): Promise<Member[]> {
     const memberships = await repositories.itemMembershipRepository.getForManyItems([item]);
     // get members only without duplicate
     return uniqBy(

--- a/src/services/item/plugins/etherpad/service.ts
+++ b/src/services/item/plugins/etherpad/service.ts
@@ -7,9 +7,9 @@ import { EtherpadItemExtra, ItemType, PermissionLevel } from '@graasp/sdk';
 
 import { ETHERPAD_NAME_FACTORY_DI_KEY } from '../../../../di/constants';
 import { BaseLogger } from '../../../../logger';
+import { AuthenticatedUser } from '../../../../types';
 import { MemberCannotWriteItem } from '../../../../utils/errors';
 import { Repositories, buildRepositories } from '../../../../utils/repositories';
-import { Account } from '../../../account/entities/account';
 import { Member } from '../../../member/entities/member';
 import { EtherpadItem, Item, isItemType } from '../../entities/Item';
 import { WrongItemTypeError } from '../../errors';
@@ -150,7 +150,7 @@ export class EtherpadItemService {
   private async checkMode(
     repositories: Repositories,
     requestedMode: 'read' | 'write',
-    account: Account,
+    account: AuthenticatedUser,
     item: EtherpadItem,
   ): Promise<'read' | 'write'> {
     // no specific check if read mode was requested
@@ -190,7 +190,11 @@ export class EtherpadItemService {
    * Retrieves the Etherpad service URL of the requested pad for a given item and a cookie
    * containing all valid sessions for pads for a given member (including the requested pad)
    */
-  public async getEtherpadFromItem(account: Account, itemId: string, mode: 'read' | 'write') {
+  public async getEtherpadFromItem(
+    account: AuthenticatedUser,
+    itemId: string,
+    mode: 'read' | 'write',
+  ) {
     const repos = buildRepositories();
     const item = await this.itemService.get(account, repos, itemId);
 
@@ -333,7 +337,10 @@ export class EtherpadItemService {
    * @param {string} itemId item to retrieve the content of
    * @returns {string} html content of the etherpad
    */
-  public async getEtherpadContentFromItem(account: Account, itemId: string): Promise<string> {
+  public async getEtherpadContentFromItem(
+    account: AuthenticatedUser,
+    itemId: string,
+  ): Promise<string> {
     const repos = buildRepositories();
     const item = await this.itemService.get(account, repos, itemId);
 

--- a/src/services/item/plugins/file/service.ts
+++ b/src/services/item/plugins/file/service.ts
@@ -15,6 +15,7 @@ import {
   getFileExtension,
 } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../types';
 import { asDefined } from '../../../../utils/assertions';
 import { Repositories } from '../../../../utils/repositories';
 import { validatePermission } from '../../../authorization';
@@ -204,7 +205,7 @@ class FileItemService {
     return result;
   }
 
-  async copy(member: Member, repositories: Repositories, { copy }: { original; copy }) {
+  async copy(member: AuthenticatedUser, repositories: Repositories, { copy }: { original; copy }) {
     const { id, extra } = copy; // full copy with new `id`
     const { path: originalPath, mimetype } = extra[this.fileService.fileType];
     // filenames are not used

--- a/src/services/item/plugins/geolocation/repository.test.ts
+++ b/src/services/item/plugins/geolocation/repository.test.ts
@@ -179,7 +179,7 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(actor, { lat1: 0, lat2: 4, lng1: 0, lng2: 4 });
+      const res = await repository.getItemsIn({ lat1: 0, lat2: 4, lng1: 0, lng2: 4 });
       expect(res).toHaveLength(2);
       expectItemGeolocations(res, [geoloc, geolocParent]);
     });
@@ -195,7 +195,7 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(actor, { lat1: 0, lat2: 0.5, lng1: 0, lng2: 0.5 });
+      const res = await repository.getItemsIn({ lat1: 0, lat2: 0.5, lng1: 0, lng2: 0.5 });
       expect(res).toHaveLength(0);
     });
 
@@ -213,7 +213,7 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(actor, { lat1: 0, lat2: 4, lng1: 0, lng2: 4 });
+      const res = await repository.getItemsIn({ lat1: 0, lat2: 4, lng1: 0, lng2: 4 });
       expect(res).toHaveLength(2);
       expectItemGeolocations(res, [geoloc, geolocParent]);
     });
@@ -240,16 +240,13 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(
-        { ...actor, lang: 'fr' },
-        {
-          lat1: 0,
-          lat2: 4,
-          lng1: 0,
-          lng2: 4,
-          keywords: ['chats'],
-        },
-      );
+      const res = await repository.getItemsIn({
+        lat1: 0,
+        lat2: 4,
+        lng1: 0,
+        lng2: 4,
+        keywords: ['chats'],
+      });
       expect(res).toHaveLength(1);
       expectItemGeolocations(res, [geolocParent]);
     });
@@ -276,17 +273,14 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res1 = await repository.getItemsIn(
-        { ...actor, lang: 'fr' },
-        {
-          lat1: 0,
-          lat2: 4,
-          lng1: 0,
-          lng2: 4,
-          // this checked the search_document stemmed correctly gatos
-          keywords: ['gato'],
-        },
-      );
+      const res1 = await repository.getItemsIn({
+        lat1: 0,
+        lat2: 4,
+        lng1: 0,
+        lng2: 4,
+        // this checked the search_document stemmed correctly gatos
+        keywords: ['gato'],
+      });
       expect(res1).toHaveLength(1);
       expectItemGeolocations(res1, [geolocParent]);
     });
@@ -312,7 +306,7 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -344,7 +338,7 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -376,7 +370,7 @@ describe('ItemGeolocationRepository', () => {
       // noise
       await testUtils.saveItemAndMembership({ member: actor, parentItem });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -430,7 +424,7 @@ describe('ItemGeolocationRepository', () => {
       });
       await rawRepository.save({ lat: 1, lng: 2, item: item2, country: 'de' });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -483,7 +477,7 @@ describe('ItemGeolocationRepository', () => {
       });
       await rawRepository.save({ lat: 1, lng: 2, item: item2, country: 'de' });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -535,7 +529,7 @@ describe('ItemGeolocationRepository', () => {
       });
       await rawRepository.save({ lat: 1, lng: 2, item: item2, country: 'de' });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -567,7 +561,7 @@ describe('ItemGeolocationRepository', () => {
       });
       const geoloc2 = await rawRepository.save({ lat: 1, lng: 2, item: item2, country: 'de' });
 
-      const res = await repository.getItemsIn(actor, {
+      const res = await repository.getItemsIn({
         lat1: 0,
         lat2: 4,
         lng1: 0,
@@ -603,7 +597,6 @@ describe('ItemGeolocationRepository', () => {
       await rawRepository.save({ lat: 1, lng: 2, item: item2, country: 'de' });
 
       const res = await repository.getItemsIn(
-        actor,
         {
           lat1: 0,
           lat2: 4,
@@ -641,7 +634,7 @@ describe('ItemGeolocationRepository', () => {
       });
       await rawRepository.save({ lat: 1, lng: 2, item: item2, country: 'de' });
 
-      const res = await repository.getItemsIn(actor, {}, parentItem);
+      const res = await repository.getItemsIn({}, parentItem);
       expect(res).toHaveLength(1);
       expectItemGeolocations(res, [geoloc]);
     });

--- a/src/services/item/plugins/geolocation/repository.test.ts
+++ b/src/services/item/plugins/geolocation/repository.test.ts
@@ -641,7 +641,7 @@ describe('ItemGeolocationRepository', () => {
 
     it('throw if does not provide parent item or lat lng', async () => {
       repository
-        .getItemsIn(actor, {
+        .getItemsIn({
           lat1: null,
           lat2: null,
           lng1: null,
@@ -653,7 +653,7 @@ describe('ItemGeolocationRepository', () => {
         });
 
       repository
-        .getItemsIn(actor, {
+        .getItemsIn({
           lat1: 1,
           lat2: 2,
           lng1: 1,
@@ -664,7 +664,7 @@ describe('ItemGeolocationRepository', () => {
           expect(e).toMatchObject(new MissingGeolocationSearchParams(expect.anything()));
         });
       repository
-        .getItemsIn(actor, {
+        .getItemsIn({
           lat1: 1,
           lat2: 2,
           lng1: 1,

--- a/src/services/item/plugins/geolocation/repository.ts
+++ b/src/services/item/plugins/geolocation/repository.ts
@@ -9,7 +9,6 @@ import { DEFAULT_LANG } from '@graasp/translations';
 
 import { AbstractRepository } from '../../../../repositories/AbstractRepository';
 import { ALLOWED_SEARCH_LANGS, GEOLOCATION_API_HOST } from '../../../../utils/config';
-import { Actor, isMember } from '../../../member/entities/member';
 import { Item } from '../../entities/Item';
 import { ItemGeolocation } from './ItemGeolocation';
 import { MissingGeolocationSearchParams, PartialItemGeolocation } from './errors';
@@ -57,7 +56,6 @@ export class ItemGeolocationRepository extends AbstractRepository<ItemGeolocatio
    * @returns item geolocations within bounding box. Does not include inheritance.
    */
   async getItemsIn(
-    actor: Actor,
     {
       lat1,
       lat2,
@@ -72,6 +70,7 @@ export class ItemGeolocationRepository extends AbstractRepository<ItemGeolocatio
       keywords?: string[];
     },
     parentItem?: Item,
+    memberLang?: string,
   ): Promise<ItemGeolocation[]> {
     // should include at least parentItem or all lat/lng
     if (
@@ -112,7 +111,6 @@ export class ItemGeolocationRepository extends AbstractRepository<ItemGeolocatio
     const allKeywords = keywords?.filter((s) => s && s.length);
     if (allKeywords?.length) {
       const keywordsString = allKeywords.join(' ');
-      const memberLang = actor && isMember(actor) ? actor?.lang : DEFAULT_LANG;
       query.andWhere(
         new Brackets((q) => {
           // search in english by default

--- a/src/services/item/plugins/html/h5p/service.ts
+++ b/src/services/item/plugins/html/h5p/service.ts
@@ -8,6 +8,7 @@ import { FastifyBaseLogger } from 'fastify';
 import { H5PItemExtra, ItemType } from '@graasp/sdk';
 
 import { BaseLogger } from '../../../../../logger';
+import { AuthenticatedUser } from '../../../../../types';
 import {
   H5P_FILE_STORAGE_CONFIG,
   H5P_FILE_STORAGE_TYPE,
@@ -74,7 +75,7 @@ export class H5PService extends HtmlService {
   }
 
   async copy(
-    member: Member,
+    member: AuthenticatedUser,
     repositories: Repositories,
     {
       original: item,

--- a/src/services/item/plugins/itemFlag/repository.ts
+++ b/src/services/item/plugins/itemFlag/repository.ts
@@ -4,12 +4,11 @@ import { FlagType } from '@graasp/sdk';
 
 import { ImmutableRepository } from '../../../../repositories/ImmutableRepository';
 import { DEFAULT_PRIMARY_KEY } from '../../../../repositories/const';
-import { Account } from '../../../account/entities/account';
 import { ItemFlag } from './itemFlag';
 
 type CreateItemFlagBody = {
   flagType: FlagType;
-  creator: Account;
+  creatorId: string;
   itemId: string;
 };
 
@@ -25,7 +24,7 @@ export class ItemFlagRepository extends ImmutableRepository<ItemFlag> {
     return await super.findOne(id, { relations: { creator: true, item: true }, ...options });
   }
 
-  async addOne({ flagType, creator, itemId }: CreateItemFlagBody): Promise<ItemFlag> {
-    return await super.insert({ type: flagType, creator, item: { id: itemId } });
+  async addOne({ flagType, creatorId, itemId }: CreateItemFlagBody): Promise<ItemFlag> {
+    return await super.insert({ type: flagType, creator: { id: creatorId }, item: { id: itemId } });
   }
 }

--- a/src/services/item/plugins/itemFlag/service.ts
+++ b/src/services/item/plugins/itemFlag/service.ts
@@ -2,8 +2,8 @@ import { singleton } from 'tsyringe';
 
 import { FlagType } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../types';
 import { Repositories } from '../../../../utils/repositories';
-import { Account } from '../../../account/entities/account';
 import { ItemService } from '../../service';
 
 @singleton()
@@ -18,12 +18,17 @@ export class ItemFlagService {
     return Object.values(FlagType);
   }
 
-  async post(account: Account, repositories: Repositories, itemId: string, flagType: FlagType) {
+  async post(
+    account: AuthenticatedUser,
+    repositories: Repositories,
+    itemId: string,
+    flagType: FlagType,
+  ) {
     const { itemFlagRepository } = repositories;
 
     // only register member can report
     await this.itemService.get(account, repositories, itemId);
 
-    return itemFlagRepository.addOne({ flagType, creator: account, itemId });
+    return itemFlagRepository.addOne({ flagType, creatorId: account.id, itemId });
   }
 }

--- a/src/services/item/plugins/publication/publicationState/service.ts
+++ b/src/services/item/plugins/publication/publicationState/service.ts
@@ -1,7 +1,7 @@
 import { ItemVisibilityType, PermissionLevel } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../../types';
 import { Repositories } from '../../../../../utils/repositories';
-import { Account } from '../../../../account/entities/account';
 import { ItemWrapper } from '../../../ItemWrapper';
 import { ItemService } from '../../../service';
 import { ItemVisibilityRepository } from '../../itemVisibility/repository';
@@ -31,7 +31,11 @@ export class PublicationService {
     this.validationQueue = validationQueue;
   }
 
-  public async computeStateForItem(member: Account, repositores: Repositories, itemId: string) {
+  public async computeStateForItem(
+    member: AuthenticatedUser,
+    repositores: Repositories,
+    itemId: string,
+  ) {
     const item = await this.itemService.get(member, repositores, itemId, PermissionLevel.Admin);
     const publicVisibility = await this.itemVisibilityRepository.getType(
       item.path,

--- a/src/services/item/plugins/shortLink/service.ts
+++ b/src/services/item/plugins/shortLink/service.ts
@@ -10,10 +10,10 @@ import {
   UpdateShortLink,
 } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../types';
 import { ITEMS_ROUTE_PREFIX } from '../../../../utils/config';
 import { UnauthorizedMember } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
-import { Account } from '../../../account/entities/account';
 import { ItemService } from '../../../item/service';
 import { Member } from '../../../member/entities/member';
 import { ItemPublishedNotFound } from '../publication/published/errors';
@@ -63,7 +63,7 @@ export class ShortLinkService {
     return ShortLinkDTO.from(shortLink);
   }
 
-  async getAllForItem(account: Account, repositories: Repositories, itemId: string) {
+  async getAllForItem(account: AuthenticatedUser, repositories: Repositories, itemId: string) {
     const { shortLinkRepository } = repositories;
 
     if (!account) throw new UnauthorizedMember();

--- a/src/services/item/repository.ts
+++ b/src/services/item/repository.ts
@@ -35,7 +35,7 @@ import {
   FILE_METADATA_MAX_PAGE_SIZE,
   FILE_METADATA_MIN_PAGE,
 } from '../member/constants';
-import { Actor, Member, isMember } from '../member/entities/member';
+import { Actor, Member } from '../member/entities/member';
 import { itemSchema } from '../member/plugins/export-data/schemas/schemas';
 import { schemaToSelectMapper } from '../member/plugins/export-data/utils/selection.utils';
 import { fileItemMetadata } from '../member/schemas';
@@ -183,7 +183,7 @@ export class ItemRepository extends MutableRepository<Item, UpdateItemBody> {
   }
 
   async getChildren(
-    actor: Actor,
+    memberLang: string | undefined,
     parent: Item,
     params?: ItemChildrenParams,
     options: { withOrder?: boolean } = {},
@@ -225,7 +225,6 @@ export class ItemRepository extends MutableRepository<Item, UpdateItemBody> {
           });
 
           // search by member lang
-          const memberLang = actor && isMember(actor) ? actor?.lang : DEFAULT_LANG;
           if (memberLang && ALLOWED_SEARCH_LANGS[memberLang]) {
             q.orWhere('item.search_document @@ plainto_tsquery(:lang, :keywords)', {
               keywords: keywordsString,
@@ -878,7 +877,7 @@ export class ItemRepository extends MutableRepository<Item, UpdateItemBody> {
 
   async rescaleOrder(actor: Actor, parentItem: Item) {
     const children = await this.getChildren(
-      actor,
+      undefined,
       parentItem,
       { ordered: true },
       { withOrder: true },

--- a/src/services/item/service.test.ts
+++ b/src/services/item/service.test.ts
@@ -109,7 +109,7 @@ describe('Item Service', () => {
       });
 
       const itemsInDB = await testUtils.itemRepository.getChildren(
-        actor,
+        actor.lang,
         parentItem,
         { ordered: true },
         { withOrder: true },
@@ -139,7 +139,7 @@ describe('Item Service', () => {
       });
 
       const itemsInDB = await testUtils.itemRepository.getChildren(
-        actor,
+        actor.lang,
         parentItem,
         { ordered: true },
         { withOrder: true },
@@ -179,7 +179,7 @@ describe('Item Service', () => {
       });
 
       const itemsInDB = await testUtils.itemRepository.getChildren(
-        actor,
+        actor.lang,
         parentItem,
         { ordered: true },
         { withOrder: true },

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -268,7 +268,7 @@ export class ItemService {
     itemRepository.checkHierarchyDepth(parentItem);
 
     // check if there's too many children under the same parent
-    const descendants = await itemRepository.getChildren(member, parentItem);
+    const descendants = await itemRepository.getChildren(member.lang, parentItem);
     if (descendants.length + items.length > MAX_NUMBER_OF_CHILDREN) {
       throw new TooManyChildren();
     }

--- a/src/services/item/service.ts
+++ b/src/services/item/service.ts
@@ -22,6 +22,7 @@ import {
 } from '@graasp/sdk';
 
 import { BaseLogger } from '../../logger';
+import { AuthenticatedUser } from '../../types';
 import {
   CannotReorderRootItem,
   InvalidMembership,
@@ -33,7 +34,6 @@ import {
 } from '../../utils/errors';
 import HookManager from '../../utils/hook';
 import { Repositories } from '../../utils/repositories';
-import { Account } from '../account/entities/account';
 import {
   filterOutItems,
   filterOutPackedDescendants,
@@ -584,16 +584,11 @@ export class ItemService {
     const { itemRepository } = repositories;
     const item = await this.get(actor, repositories, itemId);
 
-    return itemRepository.getChildren(actor, item, params);
+    return itemRepository.getChildren(actor?.lang, item, params);
   }
 
-  async getChildren(
-    actor: Actor,
-    repositories: Repositories,
-    itemId: string,
-    params?: ItemChildrenParams,
-  ) {
-    const children = await this._getChildren(actor, repositories, itemId, params);
+  async getChildren(actor: Actor, repositories: Repositories, itemId: string) {
+    const children = await this._getChildren(actor, repositories, itemId);
     // TODO optimize?
     return filterOutItems(actor, repositories, children);
   }
@@ -627,7 +622,11 @@ export class ItemService {
     return { item, descendants: await itemRepository.getDescendants(item, options) };
   }
 
-  async getFilteredDescendants(account: Account, repositories: Repositories, itemId: UUID) {
+  async getFilteredDescendants(
+    account: AuthenticatedUser,
+    repositories: Repositories,
+    itemId: UUID,
+  ) {
     const { descendants } = await this.getDescendants(account, repositories, itemId);
     if (!descendants.length) {
       return [];

--- a/src/services/itemLogin/entities/guest.ts
+++ b/src/services/itemLogin/entities/guest.ts
@@ -2,7 +2,8 @@ import { ChildEntity, Column, JoinColumn, ManyToOne, Unique } from 'typeorm';
 
 import { AccountType, CompleteMember } from '@graasp/sdk';
 
-import { Account, is } from '../../account/entities/account';
+import { AuthenticatedUser } from '../../../types';
+import { Account } from '../../account/entities/account';
 import { ItemLoginSchema } from './itemLoginSchema';
 
 const TYPE = AccountType.Guest;
@@ -25,6 +26,6 @@ export class Guest extends Account {
   type: AccountType.Guest;
 }
 
-export function isGuest(account: Account): account is Guest {
-  return is<Guest>(account, TYPE);
+export function isGuest(account: AuthenticatedUser): account is Guest {
+  return account.type === TYPE;
 }

--- a/src/services/itemMembership/repository.ts
+++ b/src/services/itemMembership/repository.ts
@@ -28,7 +28,6 @@ import { ITEMS_PAGE_SIZE_MAX } from '../item/constants';
 import { Item } from '../item/entities/Item';
 import { ItemSearchParams, Ordering, SortBy, orderingToUpperCase } from '../item/types';
 import { MemberIdentifierNotFound } from '../itemLogin/errors';
-import { isMember } from '../member/entities/member';
 import { itemMembershipSchema } from '../member/plugins/export-data/schemas/schemas';
 import { schemaToSelectMapper } from '../member/plugins/export-data/utils/selection.utils';
 import { mapById } from '../utils';
@@ -218,6 +217,7 @@ export class ItemMembershipRepository extends MutableRepository<
       types,
     }: ItemSearchParams,
     pagination: Pagination,
+    memberLang?: string,
   ): Promise<Paginated<ItemMembership>> {
     const { page, pageSize } = pagination;
     const limit = Math.min(pageSize, ITEMS_PAGE_SIZE_MAX);
@@ -268,7 +268,6 @@ export class ItemMembershipRepository extends MutableRepository<
           });
 
           // search by member lang
-          const memberLang = isMember(account) ? account.lang : DEFAULT_LANG;
           const memberLangKey = memberLang as keyof typeof ALLOWED_SEARCH_LANGS;
           if (memberLang != DEFAULT_LANG && ALLOWED_SEARCH_LANGS[memberLangKey]) {
             q.orWhere('item.search_document @@ plainto_tsquery(:lang, :keywords)', {

--- a/src/services/member/entities/member.ts
+++ b/src/services/member/entities/member.ts
@@ -4,7 +4,9 @@ import { Check, ChildEntity, Column, Unique } from 'typeorm';
 import { AccountType, CompleteMember } from '@graasp/sdk';
 import { DEFAULT_LANG } from '@graasp/translations';
 
-import { Account, is } from '../../account/entities/account';
+import { AuthenticatedUser, MinimalMember } from '../../../types';
+import { assertIsDefined } from '../../../utils/assertions';
+import { Account } from '../../account/entities/account';
 import { NotMember } from '../error';
 
 const TYPE = AccountType.Individual;
@@ -56,17 +58,18 @@ export class Member extends Account {
   }
 }
 
-export type Actor = Account | undefined;
+export type Actor = AuthenticatedUser | undefined;
 
-export function isMember(account: Account): account is Member {
-  return is<Member>(account, TYPE);
+export function isMember(account: AuthenticatedUser | Member): account is MinimalMember {
+  return account.type === TYPE;
 }
 
 export function assertIsMember<Err extends Error, Args extends unknown[]>(
-  account: Account,
+  account: Actor,
   error?: new (...args: Args) => Err,
   ...args: Args
 ): asserts account is Member {
+  assertIsDefined(account);
   if (!isMember(account)) {
     if (error) {
       throw new error(...args);

--- a/src/services/member/plugins/action/service.ts
+++ b/src/services/member/plugins/action/service.ts
@@ -3,9 +3,9 @@ import { singleton } from 'tsyringe';
 
 import { ActionTriggers, PermissionLevel } from '@graasp/sdk';
 
+import { AuthenticatedUser } from '../../../../types';
 import { CannotModifyOtherMembers } from '../../../../utils/errors';
 import { Repositories } from '../../../../utils/repositories';
-import { Account } from '../../../account/entities/account';
 import { ActionService } from '../../../action/services/action';
 import { validatePermissionMany } from '../../../authorization';
 import { Item, ItemExtraMap } from '../../../item/entities/Item';
@@ -35,7 +35,7 @@ export class ActionMemberService {
   }
 
   async getFilteredActions(
-    actor: Account,
+    actor: AuthenticatedUser,
     repositories: Repositories,
     filters: { startDate?: string; endDate?: string },
   ) {
@@ -73,7 +73,7 @@ export class ActionMemberService {
   }
 
   async deleteAllForMember(
-    actor: Account,
+    actor: AuthenticatedUser,
     repositories: Repositories,
     memberId: string,
   ): Promise<void> {

--- a/src/services/member/plugins/thumbnail/index.ts
+++ b/src/services/member/plugins/thumbnail/index.ts
@@ -83,8 +83,8 @@ const plugin: FastifyPluginAsyncTypebox<GraaspThumbnailsOptions> = async (fastif
       schema: download,
       preHandler: optionalIsAuthenticated,
     },
-    async ({ user, params: { size, id: memberId } }, reply) => {
-      const url = await thumbnailService.getUrl(user?.account, buildRepositories(), {
+    async ({ params: { size, id: memberId } }, reply) => {
+      const url = await thumbnailService.getUrl(buildRepositories(), {
         memberId,
         size,
       });

--- a/src/services/member/plugins/thumbnail/service.ts
+++ b/src/services/member/plugins/thumbnail/service.ts
@@ -53,16 +53,18 @@ export class MemberThumbnailService {
 
   // get member's avatar
   async getUrl(repositories: Repositories, { size, memberId }: { memberId: string; size: string }) {
-    const member = await repositories.memberRepository.get(memberId);
+    const account = await repositories.accountRepository.get(memberId);
 
-    if (!member) {
+    if (!account) {
       throw new AccountNotFound(memberId);
     }
 
     // only members can upload an avatar
-    if (member.type !== AccountType.Individual) {
+    if (account.type !== AccountType.Individual) {
       return null;
     }
+    // HACK: this is safe as long as we keep the previous check
+    const member = account as Member;
     // member does not have avatar
     if (!member.extra.hasAvatar) {
       return null;

--- a/src/services/member/plugins/thumbnail/service.ts
+++ b/src/services/member/plugins/thumbnail/service.ts
@@ -10,7 +10,7 @@ import {
   ThumbnailService,
   ThumbnailServiceTransformer,
 } from '../../../thumbnail/service';
-import { Actor, Member, assertIsMember } from '../../entities/member';
+import { Actor, Member } from '../../entities/member';
 import { MemberService } from '../../service';
 
 @singleton()
@@ -52,25 +52,19 @@ export class MemberThumbnailService {
   }
 
   // get member's avatar
-  async getUrl(
-    actor: Actor,
-    repositories: Repositories,
-    { size, memberId }: { memberId: string; size: string },
-  ) {
-    const account = await repositories.accountRepository.get(memberId);
+  async getUrl(repositories: Repositories, { size, memberId }: { memberId: string; size: string }) {
+    const member = await repositories.memberRepository.get(memberId);
 
-    if (!account) {
+    if (!member) {
       throw new AccountNotFound(memberId);
     }
 
     // only members can upload an avatar
-    if (account.type !== AccountType.Individual) {
+    if (member.type !== AccountType.Individual) {
       return null;
     }
-
-    assertIsMember(account);
     // member does not have avatar
-    if (!account.extra.hasAvatar) {
+    if (!member.extra.hasAvatar) {
       return null;
     }
 

--- a/src/services/member/schemas.ts
+++ b/src/services/member/schemas.ts
@@ -77,7 +77,6 @@ const compositeCurrentGuestSchema = Type.Composite([
   customType.StrictObject(
     {
       type: accountTypeGuestRef,
-      extra: Type.Object({}, { additionalProperties: true }),
     },
     { description: 'Current guest information' },
   ),

--- a/src/services/websockets/ws-service.ts
+++ b/src/services/websockets/ws-service.ts
@@ -4,7 +4,7 @@ import { FastifyBaseLogger } from 'fastify';
 
 import { Websocket as GraaspWS } from '@graasp/sdk';
 
-import { Account } from '../account/entities/account';
+import { AuthenticatedUser } from '../../types';
 import { Actor } from '../member/entities/member';
 import {
   createServerErrorResponse,
@@ -22,7 +22,7 @@ export interface SubscriptionRequest {
   /**
    * Member requesting a subscription
    */
-  member: Account;
+  member: AuthenticatedUser;
 }
 
 type ValidationFn = (request: SubscriptionRequest) => Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { UnionOfConst } from '@graasp/sdk';
+
 export type IdParam = {
   id: string;
 };
@@ -13,3 +15,52 @@ export function isNonEmptyArray<T>(arr: T[]): arr is NonEmptyArray<T> {
 
 export type KeysWithValsOfType<T, V> = keyof { [P in keyof T as T[P] extends V ? P : never]: P };
 export type KeysOfString<T> = KeysWithValsOfType<T, string>;
+
+export const AccountType = {
+  Individual: 'individual',
+  Guest: 'guest',
+} as const;
+export type AccountTypeOptions = UnionOfConst<typeof AccountType>;
+
+/**
+ * A minimal user, only contains the id and name.
+ */
+type MinimalUser = {
+  id: string;
+  name: string;
+  lang?: string;
+};
+
+/**
+ * A minimal member as given by the authentication functions.
+ *
+ * This should be all that is needed to handle most member requests.
+ *
+ * In cases where further member info is required, the full member should be fetched from the database.
+ */
+export type MinimalMember = MinimalUser & {
+  type: typeof AccountType.Individual;
+  isValidated: boolean;
+};
+
+/**
+ * A minimal guest as given by the authentication functions.
+ *
+ * This should be all that is needed to handle guests in most cases.
+ *
+ * In cases where more information on the guest is needed, the full guest info should be queried from the database.
+ */
+export type MinimalGuest = MinimalUser & {
+  type: typeof AccountType.Guest;
+};
+
+/**
+ * The authenticated user as given by the authentication functions.
+ * Is can be a member (real account) or a guest (only has access to a single item)
+ */
+export type AuthenticatedUser = MinimalMember | MinimalGuest;
+
+/**
+ * Sometimes we do not care if the person making the request exists or not, so we can use `Actor` instead
+ */
+export type Actor = AuthenticatedUser | undefined;

--- a/src/utils/assertions.ts
+++ b/src/utils/assertions.ts
@@ -1,7 +1,7 @@
-import { Account } from '../services/account/entities/account';
 import { NotMemberOrGuest } from '../services/account/errors';
 import { Guest, isGuest } from '../services/itemLogin/entities/guest';
 import { Member, isMember } from '../services/member/entities/member';
+import { AuthenticatedUser } from '../types';
 import { UnexpectedError } from './errors';
 
 export type Nullable<T> = T | null | undefined;
@@ -49,7 +49,7 @@ export function assertIsDefined<T, Err extends Error, Args extends unknown[]>(
 }
 
 export function assertIsMemberOrGuest<Err extends Error, Args extends unknown[]>(
-  account: Account,
+  account: AuthenticatedUser,
   error?: new (...args: Args) => Err,
   ...args: Args
 ): asserts account is Member | Guest {

--- a/test/app.ts
+++ b/test/app.ts
@@ -10,10 +10,10 @@ import registerAppPlugins from '../src/app';
 import { resetDependencies } from '../src/di/utils';
 import { BaseLogger } from '../src/logger';
 import ajvFormats from '../src/schemas/ajvFormats';
-import { Account } from '../src/services/account/entities/account';
 import { PassportStrategy } from '../src/services/auth/plugins/passport';
 import { Member } from '../src/services/member/entities/member';
 import { saveMember } from '../src/services/member/test/fixtures/members';
+import { Actor } from '../src/types';
 import { DB_TEST_SCHEMA } from './constants';
 
 const originalSessionStrategy = fastifyPassport.strategy(PassportStrategy.Session)!;
@@ -23,7 +23,7 @@ let originalStrictSessionStrategy;
  * Override the session strategy to always validate the request. Set the given Account to request.user.member on authentications
  * @param account Account to set to request.user.member
  */
-export function mockAuthenticate(account: Account | undefined) {
+export function mockAuthenticate(account: Actor | undefined) {
   if (!originalStrictSessionStrategy) {
     originalStrictSessionStrategy = fastifyPassport.strategy(PassportStrategy.StrictSession);
   }


### PR DESCRIPTION
In this PR I tried to shrink the surface of the exposed data for the automatically inferred `member` that passport gives to all handlers.

The idea was to see where we would need more, as these places should potentially fetch the "more" info themselves.

In fine the idea is to maybe change the structure of the `account` table to be more minimal (id, name, type)  and to have dedicated member and guest tables for full info. 

