### PR TITLE
feat(etherpad): allow readerPermission on create, item props in update

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "github:graasp/graasp-sdk#etherpad-reader-permission-type",
+    "@graasp/sdk": "5.10.0",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "5.10.0",
+    "@graasp/sdk": "5.10.1",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "4.1.0",
     "@fastify/websocket": "7.2.0",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "5.9.1",
+    "@graasp/sdk": "github:graasp/graasp-sdk#etherpad-reader-permission-type",
     "@graasp/translations": "1.42.0",
     "@rapideditor/country-coder": "5.2.2",
     "@sentry/node": "7.119.2",

--- a/src/services/item/plugins/etherpad/controller.ts
+++ b/src/services/item/plugins/etherpad/controller.ts
@@ -32,8 +32,8 @@ const endpoints: FastifyPluginAsyncTypebox = async (fastify) => {
     async (request) => {
       const {
         user,
+        body,
         query: { parentId },
-        body: { name },
       } = request;
       const member = asDefined(user?.account);
       assertIsMember(member);
@@ -42,7 +42,7 @@ const endpoints: FastifyPluginAsyncTypebox = async (fastify) => {
         return await etherpadItemService.createEtherpadItem(
           member,
           buildRepositories(manager),
-          name,
+          body,
           parentId,
         );
       });
@@ -62,15 +62,18 @@ const endpoints: FastifyPluginAsyncTypebox = async (fastify) => {
       const {
         user,
         params: { id },
-        body: { readerPermission },
+        body,
       } = request;
       const member = asDefined(user?.account);
       assertIsMember(member);
 
       await db.transaction(async (manager) => {
-        return await etherpadItemService.patchWithOptions(member, buildRepositories(manager), id, {
-          readerPermission,
-        });
+        return await etherpadItemService.patchWithOptions(
+          member,
+          buildRepositories(manager),
+          id,
+          body,
+        );
       });
       reply.status(StatusCodes.NO_CONTENT);
     },

--- a/src/services/item/plugins/etherpad/schemas.ts
+++ b/src/services/item/plugins/etherpad/schemas.ts
@@ -3,15 +3,15 @@ import { StatusCodes } from 'http-status-codes';
 
 import { FastifySchema } from 'fastify';
 
-import { EtherpadReaderPermission } from '@graasp/sdk';
+import { EtherpadPermission } from '@graasp/sdk';
 
 import { customType } from '../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../schemas/global';
 import { itemSchema, itemSchemaRef } from '../../schemas';
 
 const readerPermissionType = Type.Union([
-  Type.Literal(EtherpadReaderPermission.Read),
-  Type.Literal(EtherpadReaderPermission.Write),
+  Type.Literal(EtherpadPermission.Read),
+  Type.Literal(EtherpadPermission.Write),
 ]);
 
 export const createEtherpad = {

--- a/src/services/item/plugins/etherpad/service.test.ts
+++ b/src/services/item/plugins/etherpad/service.test.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid';
 import Etherpad, { AuthorSession } from '@graasp/etherpad-api';
 import {
   EtherpadItemFactory,
-  EtherpadReaderPermission,
+  EtherpadPermission,
   FolderItemFactory,
   ItemType,
   PermissionLevel,
@@ -94,7 +94,7 @@ describe('Etherpad Service', () => {
           return MOCK_ITEM;
         });
 
-      const readerPermission = EtherpadReaderPermission.Write;
+      const readerPermission = EtherpadPermission.Write;
       await etherpadService.createEtherpadItem(MOCK_MEMBER, repositories, {
         name: 'newName',
         readerPermission,
@@ -134,7 +134,7 @@ describe('Etherpad Service', () => {
             [ItemType.ETHERPAD]: {
               groupID: expect.anything(),
               padID: expect.anything(),
-              readerPermission: EtherpadReaderPermission.Read,
+              readerPermission: EtherpadPermission.Read,
             },
           },
         },
@@ -157,7 +157,7 @@ describe('Etherpad Service', () => {
             } as unknown as ItemRepository,
           } as repositoriesUtils.Repositories,
           FOLDER_ITEM.id,
-          { readerPermission: EtherpadReaderPermission.Write },
+          { readerPermission: EtherpadPermission.Write },
         ),
       ).rejects.toBeInstanceOf(WrongItemTypeError);
     });

--- a/src/services/item/plugins/etherpad/service.test.ts
+++ b/src/services/item/plugins/etherpad/service.test.ts
@@ -180,6 +180,8 @@ describe('Etherpad Service', () => {
         extra: {
           [ItemType.ETHERPAD]: {
             readerPermission: PermissionLevel.Write,
+            padID: MOCK_ITEM.extra.etherpad.padID,
+            groupID: MOCK_ITEM.extra.etherpad.groupID,
           },
         },
       });

--- a/src/services/item/plugins/etherpad/service.ts
+++ b/src/services/item/plugins/etherpad/service.ts
@@ -5,8 +5,8 @@ import { v4 } from 'uuid';
 import Etherpad, { AuthorSession } from '@graasp/etherpad-api';
 import {
   EtherpadItemExtra,
-  EtherpadReaderPermission,
-  EtherpadReaderPermissionType,
+  EtherpadPermission,
+  EtherpadPermissionType,
   ItemType,
   PermissionLevel,
 } from '@graasp/sdk';
@@ -100,7 +100,7 @@ export class EtherpadItemService {
   public async createEtherpadItem(
     member: Member,
     repositories: Repositories,
-    args: { readerPermission?: EtherpadReaderPermissionType; name: string },
+    args: { readerPermission?: EtherpadPermissionType; name: string },
     parentId?: string,
     initHtml?: string,
   ) {
@@ -114,7 +114,7 @@ export class EtherpadItemService {
           extra: this.buildEtherpadExtra({
             groupID,
             padName,
-            readerPermission: args.readerPermission ?? EtherpadReaderPermission.Read,
+            readerPermission: args.readerPermission ?? EtherpadPermission.Read,
           }),
         },
         parentId,
@@ -139,7 +139,7 @@ export class EtherpadItemService {
     repositories: Repositories,
     itemId: Item['id'],
     body: Partial<Pick<Item, 'settings' | 'name' | 'lang'>> & {
-      readerPermission?: EtherpadReaderPermissionType;
+      readerPermission?: EtherpadPermissionType;
     },
   ) {
     const { itemRepository } = repositories;
@@ -163,7 +163,7 @@ export class EtherpadItemService {
           readerPermission:
             newReaderPermissionValue ??
             item.extra.etherpad.readerPermission ??
-            EtherpadReaderPermission.Read,
+            EtherpadPermission.Read,
         },
       };
     }
@@ -439,11 +439,11 @@ export class EtherpadItemService {
   static buildEtherpadExtra({
     groupID,
     padName,
-    readerPermission = EtherpadReaderPermission.Read,
+    readerPermission = EtherpadPermission.Read,
   }: {
     groupID: string;
     padName: string;
-    readerPermission?: EtherpadReaderPermissionType;
+    readerPermission?: EtherpadPermissionType;
   }): EtherpadItemExtra {
     return {
       etherpad: {

--- a/src/services/item/plugins/etherpad/test/index.test.ts
+++ b/src/services/item/plugins/etherpad/test/index.test.ts
@@ -9,7 +9,7 @@ import { FastifyInstance } from 'fastify';
 
 import {
   EtherpadItemType,
-  EtherpadReaderPermission,
+  EtherpadPermission,
   HttpMethod,
   ItemType,
   PermissionLevel,
@@ -115,7 +115,7 @@ describe('Etherpad service API', () => {
         url: 'items/etherpad/create',
         payload: {
           name: 'test-item-name',
-          readerPermission: EtherpadReaderPermission.Write,
+          readerPermission: EtherpadPermission.Write,
         },
       });
 
@@ -131,7 +131,7 @@ describe('Etherpad service API', () => {
           etherpad: {
             padID: `${MOCK_GROUP_ID}$${createGroupPad?.get('padName')}`,
             groupID: MOCK_GROUP_ID,
-            readerPermission: EtherpadReaderPermission.Write,
+            readerPermission: EtherpadPermission.Write,
           },
         },
       });
@@ -864,7 +864,7 @@ describe('Etherpad service API', () => {
         url: `items/etherpad/${item.id}`,
         payload: {
           name: 'new-name',
-          readerPermission: EtherpadReaderPermission.Write,
+          readerPermission: EtherpadPermission.Write,
         },
       });
 

--- a/src/services/item/plugins/etherpad/test/index.test.ts
+++ b/src/services/item/plugins/etherpad/test/index.test.ts
@@ -2,14 +2,21 @@ import { add, isAfter, isBefore, sub } from 'date-fns';
 import { StatusCodes } from 'http-status-codes';
 import { cleanAll } from 'nock';
 import { And, Not } from 'typeorm';
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4, v4 } from 'uuid';
 import waitForExpect from 'wait-for-expect';
 
 import { FastifyInstance } from 'fastify';
 
-import { EtherpadItemType, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import {
+  EtherpadItemType,
+  EtherpadReaderPermission,
+  HttpMethod,
+  ItemType,
+  PermissionLevel,
+} from '@graasp/sdk';
 
-import build, { clearDatabase } from '../../../../../../test/app';
+import build, { clearDatabase, mockAuthenticate } from '../../../../../../test/app';
+import { seedFromJson } from '../../../../../../test/mocks/seed';
 import { resolveDependency } from '../../../../../di/utils';
 import { ETHERPAD_PUBLIC_URL } from '../../../../../utils/config';
 import { ItemNotFound, MemberCannotAccess } from '../../../../../utils/errors';
@@ -90,6 +97,41 @@ describe('Etherpad service API', () => {
           etherpad: {
             padID: `${MOCK_GROUP_ID}$${createGroupPad?.get('padName')}`,
             groupID: MOCK_GROUP_ID,
+          },
+        },
+      });
+    });
+
+    it('creates a pad with reader permission = write', async () => {
+      const reqsParams = setUpApi({
+        createGroupIfNotExistsFor: [
+          StatusCodes.OK,
+          { code: 0, message: 'ok', data: { groupID: MOCK_GROUP_ID } },
+        ],
+        createGroupPad: [StatusCodes.OK, { code: 0, message: 'ok', data: null }],
+      });
+      const res = await app.inject({
+        method: HttpMethod.Post,
+        url: 'items/etherpad/create',
+        payload: {
+          name: 'test-item-name',
+          readerPermission: EtherpadReaderPermission.Write,
+        },
+      });
+
+      const { createGroupIfNotExistsFor, createGroupPad } = await reqsParams;
+      expect(createGroupPad?.get('groupID')).toEqual(MOCK_GROUP_ID);
+      // groupMapper sent to etherpad is equal to the generated padID
+      expect(createGroupIfNotExistsFor?.get('groupMapper')).toEqual(createGroupPad?.get('padName'));
+
+      expect(res.statusCode).toEqual(StatusCodes.OK);
+      expect(res.json()).toMatchObject({
+        name: 'test-item-name',
+        extra: {
+          etherpad: {
+            padID: `${MOCK_GROUP_ID}$${createGroupPad?.get('padName')}`,
+            groupID: MOCK_GROUP_ID,
+            readerPermission: EtherpadReaderPermission.Write,
           },
         },
       });
@@ -763,6 +805,82 @@ describe('Etherpad service API', () => {
       });
 
       expect(res.statusCode).not.toEqual(StatusCodes.OK);
+    });
+  });
+  describe('update a pad', () => {
+    it('update a pad should return no content', async () => {
+      setUpApi({
+        createGroupIfNotExistsFor: [
+          StatusCodes.OK,
+          { code: 0, message: 'ok', data: { groupID: MOCK_GROUP_ID } },
+        ],
+        createGroupPad: [StatusCodes.OK, { code: 0, message: 'ok', data: null }],
+      });
+      const {
+        actor,
+        items: [item],
+      } = await seedFromJson({
+        items: [
+          {
+            type: ItemType.ETHERPAD,
+            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+          },
+        ],
+      });
+      mockAuthenticate(actor);
+      const res = await app.inject({
+        method: HttpMethod.Patch,
+        url: `items/etherpad/${item.id}`,
+        payload: {
+          name: 'new-name',
+        },
+      });
+
+      expect(res.statusCode).toEqual(StatusCodes.NO_CONTENT);
+    });
+
+    it('update a pad with reader permission = write should return no content', async () => {
+      setUpApi({
+        createGroupIfNotExistsFor: [
+          StatusCodes.OK,
+          { code: 0, message: 'ok', data: { groupID: MOCK_GROUP_ID } },
+        ],
+        createGroupPad: [StatusCodes.OK, { code: 0, message: 'ok', data: null }],
+      });
+      const {
+        actor,
+        items: [item],
+      } = await seedFromJson({
+        items: [
+          {
+            type: ItemType.ETHERPAD,
+            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+          },
+        ],
+      });
+      mockAuthenticate(actor);
+      const res = await app.inject({
+        method: HttpMethod.Patch,
+        url: `items/etherpad/${item.id}`,
+        payload: {
+          name: 'new-name',
+          readerPermission: EtherpadReaderPermission.Write,
+        },
+      });
+
+      expect(res.statusCode).toEqual(StatusCodes.NO_CONTENT);
+    });
+
+    it('update a pad without payload should throw', async () => {
+      const { actor } = await seedFromJson();
+      mockAuthenticate(actor);
+
+      const res = await app.inject({
+        method: HttpMethod.Patch,
+        url: `items/etherpad/${v4()}`,
+      });
+
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
   });
 });

--- a/src/services/item/plugins/etherpad/test/service.test.ts
+++ b/src/services/item/plugins/etherpad/test/service.test.ts
@@ -1,3 +1,5 @@
+import { EtherpadReaderPermission } from '@graasp/sdk';
+
 import { EtherpadItemService } from '../service';
 
 describe('Service helper methods', () => {
@@ -29,6 +31,7 @@ describe('Service helper methods', () => {
       etherpad: {
         padID: 'g.s8oes9dhwrvt0zif$test',
         groupID: 'g.s8oes9dhwrvt0zif',
+        readerPermission: EtherpadReaderPermission.Read,
       },
     });
   });

--- a/src/services/item/plugins/etherpad/test/service.test.ts
+++ b/src/services/item/plugins/etherpad/test/service.test.ts
@@ -1,4 +1,4 @@
-import { EtherpadReaderPermission } from '@graasp/sdk';
+import { EtherpadPermission } from '@graasp/sdk';
 
 import { EtherpadItemService } from '../service';
 
@@ -31,7 +31,7 @@ describe('Service helper methods', () => {
       etherpad: {
         padID: 'g.s8oes9dhwrvt0zif$test',
         groupID: 'g.s8oes9dhwrvt0zif',
-        readerPermission: EtherpadReaderPermission.Read,
+        readerPermission: EtherpadPermission.Read,
       },
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:5.9.1":
+"@graasp/sdk@github:graasp/graasp-sdk#etherpad-reader-permission-type":
   version: 5.9.1
-  resolution: "@graasp/sdk@npm:5.9.1"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=a3682a868638ba7d28ba23961edfaeeb976b9a4c"
   dependencies:
     "@faker-js/faker": "npm:9.5.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/4811a4033b75d09076c5749ce9137f48b017fe03fa8c4ff999f7f690d7ca0e1068e5ffd8bd9f91b21d92c81a41bdd5431b9d85a0304ba045fea5b69a0a1618ef
+  checksum: 10/38038267363ff6251162766ad8132d8fbba5acef20c0a8be49a3d033797ac9e81e53ddfc25fcf85d5d646f6bf168369b10823d685492db3714e061abae475e3b
   languageName: node
   linkType: hard
 
@@ -7468,7 +7468,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:5.9.1"
+    "@graasp/sdk": "github:graasp/graasp-sdk#etherpad-reader-permission-type"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#etherpad-reader-permission-type":
-  version: 5.9.1
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=a3682a868638ba7d28ba23961edfaeeb976b9a4c"
+"@graasp/sdk@npm:5.10.0":
+  version: 5.10.0
+  resolution: "@graasp/sdk@npm:5.10.0"
   dependencies:
     "@faker-js/faker": "npm:9.5.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/38038267363ff6251162766ad8132d8fbba5acef20c0a8be49a3d033797ac9e81e53ddfc25fcf85d5d646f6bf168369b10823d685492db3714e061abae475e3b
+  checksum: 10/8e8d4fa29a84f741982217b1086cc3b98933a3b8eb255f020522f7c61ad6f4e4b0cca4cd35dd013aa01bd76303d958b04de3f3ffe7d2d9088dd9b081baee5d5e
   languageName: node
   linkType: hard
 
@@ -7468,7 +7468,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "github:graasp/graasp-sdk#etherpad-reader-permission-type"
+    "@graasp/sdk": "npm:5.10.0"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:5.10.0":
-  version: 5.10.0
-  resolution: "@graasp/sdk@npm:5.10.0"
+"@graasp/sdk@npm:5.10.1":
+  version: 5.10.1
+  resolution: "@graasp/sdk@npm:5.10.1"
   dependencies:
     "@faker-js/faker": "npm:9.5.0"
     filesize: "npm:10.1.6"
@@ -2104,7 +2104,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/8e8d4fa29a84f741982217b1086cc3b98933a3b8eb255f020522f7c61ad6f4e4b0cca4cd35dd013aa01bd76303d958b04de3f3ffe7d2d9088dd9b081baee5d5e
+  checksum: 10/ccc9f9bf0301447c61e3025062252575f11890dfe7b75dfd1feb6fcee41a5f57a094b0931c10041eb0eb87236051d29c0122258bf82dc9ae602c9999572bfa19
   languageName: node
   linkType: hard
 
@@ -7468,7 +7468,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:4.1.0"
     "@fastify/websocket": "npm:7.2.0"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:5.10.0"
+    "@graasp/sdk": "npm:5.10.1"
     "@graasp/translations": "npm:1.42.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.13.6"


### PR DESCRIPTION
- POST /etherpad: allow to set `readerPermission`
- PATCH /etherpad/id: allow to set item's props (name, settings, lang)

close #1779 