### PR TITLE
fix(file): keep extension on copy, remove content-disposition and cache control

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "bad-words": "3.0.4",
     "bcrypt": "5.1.1",
     "bullmq": "5.18.0",
-    "content-disposition": "0.5.4",
     "date-fns": "3.6.0",
     "dotenv": "16.4.7",
     "extract-zip": "2.0.1",

--- a/src/services/file/repositories/s3.ts
+++ b/src/services/file/repositories/s3.ts
@@ -7,7 +7,6 @@ import {
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import contentDisposition from 'content-disposition';
 import fs from 'fs';
 import { StatusCodes } from 'http-status-codes';
 import fetch from 'node-fetch';
@@ -69,7 +68,6 @@ export class S3FileRepository implements FileRepository {
     memberId,
     originalPath,
     newFilePath,
-    filename,
     mimetype,
   }: {
     newId?: UUID;
@@ -93,9 +91,7 @@ export class S3FileRepository implements FileRepository {
       Key: newFilePath,
       Metadata: metadata,
       MetadataDirective: 'REPLACE',
-      ContentDisposition: contentDisposition(filename),
       ContentType: mimetype,
-      CacheControl: 'no-cache', // TODO: improve?
     };
 
     // TODO: the Cache-Control policy metadata is lost. try to set a global policy for the bucket in aws.

--- a/src/services/item/plugins/file/service.ts
+++ b/src/services/item/plugins/file/service.ts
@@ -50,7 +50,7 @@ class FileItemService extends ItemService {
     this.storageService = storageService;
   }
 
-  public buildFilePath(extension?: string) {
+  public buildFilePath(extension: string = '') {
     // TODO: CHANGE ??
     const filepath = `${randomHexOf4()}/${randomHexOf4()}/${randomHexOf4()}-${Date.now()}${extension}`;
     return path.join('files', filepath);
@@ -209,9 +209,8 @@ class FileItemService extends ItemService {
 
   async copyFile(member: Member, repositories: Repositories, { copy }: { original; copy }) {
     const { id, extra } = copy; // full copy with new `id`
-    const { path: originalPath, mimetype } = extra[this.fileService.fileType];
-    // filenames are not used
-    const newFilePath = this.buildFilePath();
+    const { path: originalPath, mimetype, name } = extra[this.fileService.fileType];
+    const newFilePath = this.buildFilePath(getFileExtension(name));
 
     const data = {
       newId: id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5388,7 +5388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4, content-disposition@npm:^0.5.3":
+"content-disposition@npm:^0.5.3":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
@@ -7509,7 +7509,6 @@ __metadata:
     bullmq: "npm:5.18.0"
     checksum: "npm:1.0.0"
     concurrently: "npm:9.0.1"
-    content-disposition: "npm:0.5.4"
     date-fns: "npm:3.6.0"
     dir-compare: "npm:5.0.0"
     dotenv: "npm:16.4.7"


### PR DESCRIPTION
I think it never worked in the first place, but duplicating pdf would trigger a download of the file once displayed. The error only happens for pdf, probably because we use a viewer.

The solution was to remove the set content-disposition (attachment) in s3.

Alongside I removed the set cache control policy, and fixed the build path that was wrong on copy. It would result in `xxxundefined`. It doesn't impact anything tho (except the download name of the file).