### PR TITLE
fix(export-actions): use timestamp for filenames, infer zip

### DIFF
--- a/src/services/action/utils/export.ts
+++ b/src/services/action/utils/export.ts
@@ -1,4 +1,5 @@
 import archiver from 'archiver';
+import { format as formatDate } from 'date-fns';
 import fs, { mkdirSync } from 'fs';
 import { unparse } from 'papaparse';
 import path from 'path';
@@ -12,7 +13,7 @@ import { CannotWriteFileError } from './errors';
 export const buildItemTmpFolder = (itemId: string): string =>
   path.join(TMP_FOLDER, 'export', itemId);
 export const buildActionFileName = (name: string, datetime: string, format: string): string =>
-  `${name}_${datetime}.${format}`;
+  `${name}_${formatDate(datetime, 't')}.${format}`;
 
 export const buildActionFilePath = ({
   itemId,
@@ -23,7 +24,7 @@ export const buildActionFilePath = ({
   datetime: string;
   format: ExportActionsFormatting;
 }): string => {
-  return `actions/${itemId}/${format}/${datetime}`;
+  return `actions/${itemId}/${format}/${formatDate(datetime, 't')}`;
 };
 
 export const buildArchiveDateAsName = (timestamp: Date): string => timestamp.toISOString();

--- a/src/services/item/plugins/action/requestExport/service.ts
+++ b/src/services/item/plugins/action/requestExport/service.ts
@@ -1,3 +1,4 @@
+import { format as formatDate } from 'date-fns';
 import fs from 'fs';
 import { singleton } from 'tsyringe';
 
@@ -144,7 +145,7 @@ export class ActionRequestExportService {
     const link = await this.fileService.getUrl({
       path: filepath,
       expiration: EXPORT_FILE_EXPIRATION,
-      downloadName: `${item.name}_${format}_actions_${archiveDate}`,
+      downloadName: `${item.name}_${format}_actions_${formatDate(archiveDate, 't')}.zip`,
     });
     const mail = new MailBuilder({
       subject: {


### PR DESCRIPTION
Remove strange slashes in the filename by using timestamp of the date.

Adds '.zip' format to download name.

fix #1823
