### PR TITLE
fix: convert timestamp columns to include timezone

### DIFF
--- a/src/drizzle/0003_use-timezone-in-items-account.sql
+++ b/src/drizzle/0003_use-timezone-in-items-account.sql
@@ -1,0 +1,22 @@
+-- Alter column types to use timestamp with timezone
+
+Alter table membership_request alter column created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+-- Need to drop the view before changing the column types
+DROP view item_view;--> statement-breakpoint
+Alter table item alter column created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+Alter table item alter column updated_at type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+Alter table item alter column deleted_at type timestamptz USING deleted_at AT TIME ZONE 'UTC';--> statement-breakpoint
+-- Re-create the item view after the column type change
+CREATE VIEW "public"."item_view" AS (select "id", "name", "type", "description", "path", "creator_id", "extra", "settings", "created_at", "updated_at", "lang", "order" from "item" where "item"."deleted_at" is null);--> statement-breakpoint
+
+-- Need to drop the guests and members view before changing the column types
+Drop view guests_view;--> statement-breakpoint
+Drop view members_view;--> statement-breakpoint
+Alter table account alter column created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+Alter table account alter column updated_at type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+Alter table account alter column user_agreements_date type timestamptz USING user_agreements_date AT TIME ZONE 'UTC';--> statement-breakpoint
+Alter table account alter column last_authenticated_at type timestamptz USING last_authenticated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+-- Re-create the guest and member views after the column type change
+CREATE VIEW "public"."guests_view" AS (select "id", "name", "extra", "type", "created_at", "updated_at", "last_authenticated_at", "is_validated", "item_login_schema_id" from "account" where ("account"."type" = 'guest' and "account"."item_login_schema_id" is not null));--> statement-breakpoint
+CREATE VIEW "public"."members_view" AS (select "id", "name", "email", "extra", "type", "created_at", "updated_at", "user_agreements_date", "enable_save_actions", "last_authenticated_at", "is_validated" from "account" where ("account"."type" = 'individual' and "account"."email" is not null));--> statement-breakpoint

--- a/src/drizzle/0003_use-timezone-in-items-account.sql
+++ b/src/drizzle/0003_use-timezone-in-items-account.sql
@@ -1,22 +1,89 @@
 -- Alter column types to use timestamp with timezone
 
-Alter table membership_request alter column created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE membership_request ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
 
 -- Need to drop the view before changing the column types
 DROP view item_view;--> statement-breakpoint
-Alter table item alter column created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
-Alter table item alter column updated_at type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
-Alter table item alter column deleted_at type timestamptz USING deleted_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE item ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE item ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE item ALTER COLUMN "deleted_at" type timestamptz USING deleted_at AT TIME ZONE 'UTC';--> statement-breakpoint
 -- Re-create the item view after the column type change
 CREATE VIEW "public"."item_view" AS (select "id", "name", "type", "description", "path", "creator_id", "extra", "settings", "created_at", "updated_at", "lang", "order" from "item" where "item"."deleted_at" is null);--> statement-breakpoint
 
 -- Need to drop the guests and members view before changing the column types
 Drop view guests_view;--> statement-breakpoint
 Drop view members_view;--> statement-breakpoint
-Alter table account alter column created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
-Alter table account alter column updated_at type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
-Alter table account alter column user_agreements_date type timestamptz USING user_agreements_date AT TIME ZONE 'UTC';--> statement-breakpoint
-Alter table account alter column last_authenticated_at type timestamptz USING last_authenticated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE account ALTER COLUMN created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE account ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE account ALTER COLUMN user_agreements_date type timestamptz USING user_agreements_date AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE account ALTER COLUMN last_authenticated_at type timestamptz USING last_authenticated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "action_request_export" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "action" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "app_action" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "app_data" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "app_data" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "app_setting" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "app_setting" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "app" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "app" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "chat_mention" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "chat_mention" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "chat_message" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "chat_message" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "guest_password" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "guest_password" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "invitation" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "invitation" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_favorite" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_category" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_flag" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_geolocation" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_geolocation" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_like" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_login_schema" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_login_schema" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_membership" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_membership" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_validation_group" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_validation_review" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_validation_review" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_validation" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_validation" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_visibility" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "member_password" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "member_password" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "member_profile" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "member_profile" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "item_published" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "item_published" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "publisher" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+ALTER TABLE "publisher" ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "recycled_item_data" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+ALTER TABLE "short_link" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
+
+
 -- Re-create the guest and member views after the column type change
 CREATE VIEW "public"."guests_view" AS (select "id", "name", "extra", "type", "created_at", "updated_at", "last_authenticated_at", "is_validated", "item_login_schema_id" from "account" where ("account"."type" = 'guest' and "account"."item_login_schema_id" is not null));--> statement-breakpoint
 CREATE VIEW "public"."members_view" AS (select "id", "name", "email", "extra", "type", "created_at", "updated_at", "user_agreements_date", "enable_save_actions", "last_authenticated_at", "is_validated" from "account" where ("account"."type" = 'individual' and "account"."email" is not null));--> statement-breakpoint
+

--- a/src/drizzle/0003_use-timezone-in-items-account.sql
+++ b/src/drizzle/0003_use-timezone-in-items-account.sql
@@ -1,18 +1,15 @@
--- Alter column types to use timestamp with timezone
+-- Need to drop the views before changing the column types 
+DROP view item_view;--> statement-breakpoint
+DROP view guests_view;--> statement-breakpoint
+DROP view members_view;--> statement-breakpoint
 
+-- Alter column types to use timestamp with timezone
 ALTER TABLE membership_request ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
 
--- Need to drop the view before changing the column types
-DROP view item_view;--> statement-breakpoint
 ALTER TABLE item ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
 ALTER TABLE item ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
 ALTER TABLE item ALTER COLUMN "deleted_at" type timestamptz USING deleted_at AT TIME ZONE 'UTC';--> statement-breakpoint
--- Re-create the item view after the column type change
-CREATE VIEW "public"."item_view" AS (select "id", "name", "type", "description", "path", "creator_id", "extra", "settings", "created_at", "updated_at", "lang", "order" from "item" where "item"."deleted_at" is null);--> statement-breakpoint
 
--- Need to drop the guests and members view before changing the column types
-Drop view guests_view;--> statement-breakpoint
-Drop view members_view;--> statement-breakpoint
 ALTER TABLE account ALTER COLUMN created_at type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
 ALTER TABLE account ALTER COLUMN "updated_at" type timestamptz USING updated_at AT TIME ZONE 'UTC';--> statement-breakpoint
 ALTER TABLE account ALTER COLUMN user_agreements_date type timestamptz USING user_agreements_date AT TIME ZONE 'UTC';--> statement-breakpoint
@@ -83,7 +80,8 @@ ALTER TABLE "recycled_item_data" ALTER COLUMN "created_at" type timestamptz USIN
 ALTER TABLE "short_link" ALTER COLUMN "created_at" type timestamptz USING created_at AT TIME ZONE 'UTC';--> statement-breakpoint
 
 
--- Re-create the guest and member views after the column type change
+-- Re-create the views after the column type change
+CREATE VIEW "public"."item_view" AS (select "id", "name", "type", "description", "path", "creator_id", "extra", "settings", "created_at", "updated_at", "lang", "order" from "item" where "item"."deleted_at" is null);--> statement-breakpoint
 CREATE VIEW "public"."guests_view" AS (select "id", "name", "extra", "type", "created_at", "updated_at", "last_authenticated_at", "is_validated", "item_login_schema_id" from "account" where ("account"."type" = 'guest' and "account"."item_login_schema_id" is not null));--> statement-breakpoint
 CREATE VIEW "public"."members_view" AS (select "id", "name", "email", "extra", "type", "created_at", "updated_at", "user_agreements_date", "enable_save_actions", "last_authenticated_at", "is_validated" from "account" where ("account"."type" = 'individual' and "account"."email" is not null));--> statement-breakpoint
 

--- a/src/drizzle/meta/0003_snapshot.json
+++ b/src/drizzle/meta/0003_snapshot.json
@@ -112,12 +112,8 @@
           "name": "account_item_login_schema_id_item_login_schema_id_fk",
           "tableFrom": "account",
           "tableTo": "item_login_schema",
-          "columnsFrom": [
-            "item_login_schema_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_login_schema_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -127,17 +123,12 @@
         "UQ_account_name_item_login_schema_id": {
           "name": "UQ_account_name_item_login_schema_id",
           "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "item_login_schema_id"
-          ]
+          "columns": ["name", "item_login_schema_id"]
         },
         "member_email_key1": {
           "name": "member_email_key1",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -174,7 +165,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -206,12 +197,8 @@
           "name": "FK_fea823c4374f507a68cf8f926a4",
           "tableFrom": "action_request_export",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -219,12 +206,8 @@
           "name": "FK_bc85ef3298df8c7974b33081b47",
           "tableFrom": "action_request_export",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -275,7 +258,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -332,12 +315,8 @@
           "name": "FK_1214f6f4d832c402751617361c0",
           "tableFrom": "action",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -345,12 +324,8 @@
           "name": "FK_action_account_id",
           "tableFrom": "action",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -399,7 +374,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -411,12 +386,8 @@
           "name": "FK_c415fc186dda51fa260d338d776",
           "tableFrom": "app_action",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -424,12 +395,8 @@
           "name": "FK_app_action_account_id",
           "tableFrom": "app_action",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -490,14 +457,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -526,12 +493,8 @@
           "name": "FK_8c3e2463c67d9865658941c9e2d",
           "tableFrom": "app_data",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -539,12 +502,8 @@
           "name": "FK_27cb180cb3f372e4cf55302644a",
           "tableFrom": "app_data",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -552,12 +511,8 @@
           "name": "FK_app_data_account_id",
           "tableFrom": "app_data",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -606,14 +561,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -649,12 +604,8 @@
           "name": "FK_f5922b885e2680beab8add96008",
           "tableFrom": "app_setting",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -662,12 +613,8 @@
           "name": "FK_22d3d051ee6f94932c1373a3d09",
           "tableFrom": "app_setting",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -722,14 +669,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -748,12 +695,8 @@
           "name": "FK_37eb7baab82e11150157ec0b5a6",
           "tableFrom": "app",
           "tableTo": "publisher",
-          "columnsFrom": [
-            "publisher_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["publisher_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -763,23 +706,17 @@
         "app_key_key": {
           "name": "app_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "key"
-          ]
+          "columns": ["key"]
         },
         "UQ_f36adbb7b096ceeb6f3e80ad14c": {
           "name": "UQ_f36adbb7b096ceeb6f3e80ad14c",
           "nullsNotDistinct": false,
-          "columns": [
-            "name"
-          ]
+          "columns": ["name"]
         },
         "app_url_key": {
           "name": "app_url_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "url"
-          ]
+          "columns": ["url"]
         }
       },
       "policies": {},
@@ -817,10 +754,7 @@
         "category-name-type": {
           "name": "category-name-type",
           "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "type"
-          ]
+          "columns": ["name", "type"]
         }
       },
       "policies": {},
@@ -852,14 +786,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -879,12 +813,8 @@
           "name": "chat_mention_message_id_chat_message_id_fk",
           "tableFrom": "chat_mention",
           "tableTo": "chat_message",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -892,12 +822,8 @@
           "name": "chat_mention_account_id_account_id_fk",
           "tableFrom": "chat_mention",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -905,12 +831,8 @@
           "name": "FK_e5199951167b722215127651e7c",
           "tableFrom": "chat_mention",
           "tableTo": "chat_message",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -918,12 +840,8 @@
           "name": "FK_chat_mention_account_id",
           "tableFrom": "chat_mention",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -959,14 +877,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -984,12 +902,8 @@
           "name": "FK_b31e627ea7a4787672e265a1579",
           "tableFrom": "chat_message",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -997,12 +911,8 @@
           "name": "FK_71fdcb9038eca1b903102bdfd17",
           "tableFrom": "chat_message",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1032,14 +942,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1057,12 +967,8 @@
           "name": "FK_guest_password_guest_id",
           "tableFrom": "guest_password",
           "tableTo": "account",
-          "columnsFrom": [
-            "guest_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1072,9 +978,7 @@
         "UQ_guest_password_guest_id": {
           "name": "UQ_guest_password_guest_id",
           "nullsNotDistinct": false,
-          "columns": [
-            "guest_id"
-          ]
+          "columns": ["guest_id"]
         }
       },
       "policies": {},
@@ -1126,14 +1030,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1145,12 +1049,8 @@
           "name": "invitation_creator_id_account_id_fk",
           "tableFrom": "invitation",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1158,12 +1058,8 @@
           "name": "invitation_item_path_item_path_fk",
           "tableFrom": "invitation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1171,12 +1067,8 @@
           "name": "FK_7ad4a490d5b9f79a677827b641c",
           "tableFrom": "invitation",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1184,12 +1076,8 @@
           "name": "FK_dc1d92accde1c2fbb7e729e4dcc",
           "tableFrom": "invitation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1199,10 +1087,7 @@
         "item-email": {
           "name": "item-email",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path",
-            "email"
-          ]
+          "columns": ["item_path", "email"]
         }
       },
       "policies": {},
@@ -1222,7 +1107,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1246,12 +1131,8 @@
           "name": "FK_a169d350392956511697f7e7d38",
           "tableFrom": "item_favorite",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1259,12 +1140,8 @@
           "name": "FK_10ea93bde287762010695378f94",
           "tableFrom": "item_favorite",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1274,10 +1151,7 @@
         "favorite_key": {
           "name": "favorite_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id",
-            "item_id"
-          ]
+          "columns": ["member_id", "item_id"]
         }
       },
       "policies": {},
@@ -1315,7 +1189,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1327,12 +1201,8 @@
           "name": "FK_638552fc7d9a2035c2b53182d8a",
           "tableFrom": "item_category",
           "tableTo": "category",
-          "columnsFrom": [
-            "category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1340,12 +1210,8 @@
           "name": "FK_9a34a079b5b24f4396462546d26",
           "tableFrom": "item_category",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1353,12 +1219,8 @@
           "name": "FK_5681d1785eea699e9cae8818fe0",
           "tableFrom": "item_category",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1368,10 +1230,7 @@
         "category-item": {
           "name": "category-item",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path",
-            "category_id"
-          ]
+          "columns": ["item_path", "category_id"]
         }
       },
       "policies": {},
@@ -1409,7 +1268,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1421,12 +1280,8 @@
           "name": "FK_b04d0adf4b73d82537c92fa55ea",
           "tableFrom": "item_flag",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1434,12 +1289,8 @@
           "name": "FK_bde9b9ab1da1483a71c9b916dd2",
           "tableFrom": "item_flag",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1449,11 +1300,7 @@
         "item-flag-creator": {
           "name": "item-flag-creator",
           "nullsNotDistinct": false,
-          "columns": [
-            "type",
-            "creator_id",
-            "item_id"
-          ]
+          "columns": ["type", "creator_id", "item_id"]
         }
       },
       "policies": {},
@@ -1491,14 +1338,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1528,12 +1375,8 @@
           "name": "FK_66d4b13df4e7765068c8268d719",
           "tableFrom": "item_geolocation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1543,9 +1386,7 @@
         "item_geolocation_unique_item": {
           "name": "item_geolocation_unique_item",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -1565,7 +1406,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1606,12 +1447,8 @@
           "name": "FK_4a56eba1ce30dc93f118a51ff26",
           "tableFrom": "item_like",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1619,12 +1456,8 @@
           "name": "FK_159827eb667d019dc71372d7463",
           "tableFrom": "item_like",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1634,10 +1467,7 @@
         "id": {
           "name": "id",
           "nullsNotDistinct": false,
-          "columns": [
-            "creator_id",
-            "item_id"
-          ]
+          "columns": ["creator_id", "item_id"]
         }
       },
       "policies": {},
@@ -1664,14 +1494,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1697,12 +1527,8 @@
           "name": "item_login_schema_item_path_item_path_fk",
           "tableFrom": "item_login_schema",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1712,9 +1538,7 @@
         "item-login-schema": {
           "name": "item-login-schema",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -1759,14 +1583,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1866,12 +1690,8 @@
           "name": "item_membership_item_path_item_path_fk",
           "tableFrom": "item_membership",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1879,12 +1699,8 @@
           "name": "item_membership_creator_id_account_id_fk",
           "tableFrom": "item_membership",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1892,12 +1708,8 @@
           "name": "item_membership_account_id_account_id_fk",
           "tableFrom": "item_membership",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1907,10 +1719,7 @@
         "item_membership-item-member": {
           "name": "item_membership-item-member",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path",
-            "account_id"
-          ]
+          "columns": ["item_path", "account_id"]
         }
       },
       "policies": {},
@@ -1957,12 +1766,8 @@
           "name": "FK_16ab8afb42f763f7cbaa4bff66a",
           "tableFrom": "item_tag",
           "tableTo": "tag",
-          "columnsFrom": [
-            "tag_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1970,12 +1775,8 @@
           "name": "FK_39b492fda03c7ac846afe164b58",
           "tableFrom": "item_tag",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1983,20 +1784,14 @@
       "compositePrimaryKeys": {
         "PK_a04bb2298e37d95233a0c92347e": {
           "name": "PK_a04bb2298e37d95233a0c92347e",
-          "columns": [
-            "tag_id",
-            "item_id"
-          ]
+          "columns": ["tag_id", "item_id"]
         }
       },
       "uniqueConstraints": {
         "UQ_item_tag": {
           "name": "UQ_item_tag",
           "nullsNotDistinct": false,
-          "columns": [
-            "tag_id",
-            "item_id"
-          ]
+          "columns": ["tag_id", "item_id"]
         }
       },
       "policies": {},
@@ -2022,7 +1817,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2034,12 +1829,8 @@
           "name": "FK_a9e83cf5f53c026b774b53d3c60",
           "tableFrom": "item_validation_group",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2087,14 +1878,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2106,12 +1897,8 @@
           "name": "FK_59fd000835c70c728e525d82950",
           "tableFrom": "item_validation_review",
           "tableTo": "item_validation",
-          "columnsFrom": [
-            "item_validation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_validation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2119,12 +1906,8 @@
           "name": "FK_44bf14fee580ae08702d70e622e",
           "tableFrom": "item_validation_review",
           "tableTo": "account",
-          "columnsFrom": [
-            "reviewer_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["reviewer_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2180,14 +1963,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2199,12 +1982,8 @@
           "name": "FK_d60969d5e478e7c844532ac4e7f",
           "tableFrom": "item_validation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2212,12 +1991,8 @@
           "name": "FK_e92da280941f666acf87baedc65",
           "tableFrom": "item_validation",
           "tableTo": "item_validation_group",
-          "columnsFrom": [
-            "item_validation_group_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_validation_group_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2260,7 +2035,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2289,12 +2064,8 @@
           "name": "FK_item_visibility_creator",
           "tableFrom": "item_visibility",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -2302,12 +2073,8 @@
           "name": "FK_item_visibility_item",
           "tableFrom": "item_visibility",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2317,10 +2084,7 @@
         "UQ_item_visibility_item_type": {
           "name": "UQ_item_visibility_item_type",
           "nullsNotDistinct": false,
-          "columns": [
-            "type",
-            "item_path"
-          ]
+          "columns": ["type", "item_path"]
         }
       },
       "policies": {},
@@ -2472,12 +2236,8 @@
           "name": "FK_bdc46717fadc2f04f3093e51fd5",
           "tableFrom": "item",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2487,9 +2247,7 @@
         "item_path_key1": {
           "name": "item_path_key1",
           "nullsNotDistinct": false,
-          "columns": [
-            "path"
-          ]
+          "columns": ["path"]
         }
       },
       "policies": {},
@@ -2515,14 +2273,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2540,12 +2298,8 @@
           "name": "member_password_member_id_account_id_fk",
           "tableFrom": "member_password",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2555,9 +2309,7 @@
         "member-password": {
           "name": "member-password",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id"
-          ]
+          "columns": ["member_id"]
         }
       },
       "policies": {},
@@ -2608,14 +2360,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2650,12 +2402,8 @@
           "name": "member_profile_member_id_account_id_fk",
           "tableFrom": "member_profile",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2663,12 +2411,8 @@
           "name": "FK_91fa43bc5482dc6b00892baf016",
           "tableFrom": "member_profile",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2678,9 +2422,7 @@
         "member-profile": {
           "name": "member-profile",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id"
-          ]
+          "columns": ["member_id"]
         }
       },
       "policies": {},
@@ -2724,12 +2466,8 @@
           "name": "FK_membership_request_member_id",
           "tableFrom": "membership_request",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2737,12 +2475,8 @@
           "name": "FK_membership_request_item_id",
           "tableFrom": "membership_request",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2752,10 +2486,7 @@
         "UQ_membership_request_item-member": {
           "name": "UQ_membership_request_item-member",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id",
-            "item_id"
-          ]
+          "columns": ["member_id", "item_id"]
         }
       },
       "policies": {},
@@ -2775,7 +2506,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2794,7 +2525,7 @@
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2823,12 +2554,8 @@
           "name": "item_published_creator_id_account_id_fk",
           "tableFrom": "item_published",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -2836,12 +2563,8 @@
           "name": "item_published_item_path_item_path_fk",
           "tableFrom": "item_published",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2851,9 +2574,7 @@
         "published-item": {
           "name": "published-item",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -2885,14 +2606,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2905,9 +2626,7 @@
         "publisher_name_key": {
           "name": "publisher_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "name"
-          ]
+          "columns": ["name"]
         }
       },
       "policies": {},
@@ -2927,7 +2646,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -2951,12 +2670,8 @@
           "name": "FK_3e3650ebd5c49843013429d510a",
           "tableFrom": "recycled_item_data",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -2964,12 +2679,8 @@
           "name": "FK_f8a4db4476e3d81e18de5d63c42",
           "tableFrom": "recycled_item_data",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2979,9 +2690,7 @@
         "recycled-item-data": {
           "name": "recycled-item-data",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -3007,7 +2716,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -3042,12 +2751,8 @@
           "name": "FK_43c8a0471d5e58f99fc9c36b991",
           "tableFrom": "short_link",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -3057,10 +2762,7 @@
         "UQ_859a3384cadaa460b84e04e5375": {
           "name": "UQ_859a3384cadaa460b84e04e5375",
           "nullsNotDistinct": false,
-          "columns": [
-            "platform",
-            "item_id"
-          ]
+          "columns": ["platform", "item_id"]
         }
       },
       "policies": {},
@@ -3104,10 +2806,7 @@
         "UQ_tag_name_category": {
           "name": "UQ_tag_name_category",
           "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "category"
-          ]
+          "columns": ["name", "category"]
         }
       },
       "policies": {},
@@ -3119,111 +2818,62 @@
     "public.account_type_enum": {
       "name": "account_type_enum",
       "schema": "public",
-      "values": [
-        "individual",
-        "guest"
-      ]
+      "values": ["individual", "guest"]
     },
     "public.action_request_export_format_enum": {
       "name": "action_request_export_format_enum",
       "schema": "public",
-      "values": [
-        "json",
-        "csv"
-      ]
+      "values": ["json", "csv"]
     },
     "public.action_view_enum": {
       "name": "action_view_enum",
       "schema": "public",
-      "values": [
-        "builder",
-        "player",
-        "library",
-        "explorer",
-        "account",
-        "auth",
-        "unknown"
-      ]
+      "values": ["builder", "player", "library", "explorer", "account", "auth", "unknown"]
     },
     "public.chat_mention_status_enum": {
       "name": "chat_mention_status_enum",
       "schema": "public",
-      "values": [
-        "unread",
-        "read"
-      ]
+      "values": ["unread", "read"]
     },
     "public.item_login_schema_status": {
       "name": "item_login_schema_status",
       "schema": "public",
-      "values": [
-        "active",
-        "freeze",
-        "disabled"
-      ]
+      "values": ["active", "freeze", "disabled"]
     },
     "public.item_login_schema_type": {
       "name": "item_login_schema_type",
       "schema": "public",
-      "values": [
-        "username",
-        "username+password",
-        "anonymous",
-        "anonymous+password"
-      ]
+      "values": ["username", "username+password", "anonymous", "anonymous+password"]
     },
     "public.item_validation_process": {
       "name": "item_validation_process",
       "schema": "public",
-      "values": [
-        "bad-words-detection",
-        "image-classification"
-      ]
+      "values": ["bad-words-detection", "image-classification"]
     },
     "public.item_validation_status": {
       "name": "item_validation_status",
       "schema": "public",
-      "values": [
-        "success",
-        "failure",
-        "pending",
-        "pending-manual"
-      ]
+      "values": ["success", "failure", "pending", "pending-manual"]
     },
     "public.item_visibility_type": {
       "name": "item_visibility_type",
       "schema": "public",
-      "values": [
-        "public",
-        "hidden"
-      ]
+      "values": ["public", "hidden"]
     },
     "public.permission_enum": {
       "name": "permission_enum",
       "schema": "public",
-      "values": [
-        "read",
-        "write",
-        "admin"
-      ]
+      "values": ["read", "write", "admin"]
     },
     "public.short_link_platform_enum": {
       "name": "short_link_platform_enum",
       "schema": "public",
-      "values": [
-        "builder",
-        "player",
-        "library"
-      ]
+      "values": ["builder", "player", "library"]
     },
     "public.tag_category_enum": {
       "name": "tag_category_enum",
       "schema": "public",
-      "values": [
-        "level",
-        "discipline",
-        "resource-type"
-      ]
+      "values": ["level", "discipline", "resource-type"]
     }
   },
   "schemas": {},

--- a/src/drizzle/meta/0003_snapshot.json
+++ b/src/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,3480 @@
+{
+  "id": "445d3534-8fa9-4b2a-934f-6ac275378c42",
+  "prevId": "3475671e-a598-470b-a065-b6c87df8b6ce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agreements_date": {
+          "name": "user_agreements_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_save_actions": {
+          "name": "enable_save_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "item_login_schema_id": {
+          "name": "item_login_schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_account_type": {
+          "name": "IDX_account_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_item_login_schema_id_item_login_schema_id_fk": {
+          "name": "account_item_login_schema_id_item_login_schema_id_fk",
+          "tableFrom": "account",
+          "tableTo": "item_login_schema",
+          "columnsFrom": [
+            "item_login_schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_account_name_item_login_schema_id": {
+          "name": "UQ_account_name_item_login_schema_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "item_login_schema_id"
+          ]
+        },
+        "member_email_key1": {
+          "name": "member_email_key1",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "CHK_account_is_validated": {
+          "name": "CHK_account_is_validated",
+          "value": "(is_validated IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        },
+        "CHK_account_email": {
+          "name": "CHK_account_email",
+          "value": "(email IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        },
+        "CHK_account_extra": {
+          "name": "CHK_account_extra",
+          "value": "(extra IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        },
+        "CHK_account_enable_save_actions": {
+          "name": "CHK_account_enable_save_actions",
+          "value": "(enable_save_actions IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.action_request_export": {
+      "name": "action_request_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "action_request_export_format_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_fea823c4374f507a68cf8f926a4": {
+          "name": "FK_fea823c4374f507a68cf8f926a4",
+          "tableFrom": "action_request_export",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FK_bc85ef3298df8c7974b33081b47": {
+          "name": "FK_bc85ef3298df8c7974b33081b47",
+          "tableFrom": "action_request_export",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action": {
+      "name": "action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "view": {
+          "name": "view",
+          "type": "action_view_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "geolocation": {
+          "name": "geolocation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_1214f6f4d832c402751617361c": {
+          "name": "IDX_1214f6f4d832c402751617361c",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_action_account_id": {
+          "name": "IDX_action_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_1214f6f4d832c402751617361c0": {
+          "name": "FK_1214f6f4d832c402751617361c0",
+          "tableFrom": "action",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_action_account_id": {
+          "name": "FK_action_account_id",
+          "tableFrom": "action",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_action": {
+      "name": "app_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_c415fc186dda51fa260d338d776": {
+          "name": "FK_c415fc186dda51fa260d338d776",
+          "tableFrom": "app_action",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_app_action_account_id": {
+          "name": "FK_app_action_account_id",
+          "tableFrom": "app_action",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_data": {
+      "name": "app_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_6079b3bb63c13f815f7dd8d8a2": {
+          "name": "IDX_6079b3bb63c13f815f7dd8d8a2",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_8c3e2463c67d9865658941c9e2d": {
+          "name": "FK_8c3e2463c67d9865658941c9e2d",
+          "tableFrom": "app_data",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_27cb180cb3f372e4cf55302644a": {
+          "name": "FK_27cb180cb3f372e4cf55302644a",
+          "tableFrom": "app_data",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_app_data_account_id": {
+          "name": "FK_app_data_account_id",
+          "tableFrom": "app_data",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_61546c650608c1e68789c64915": {
+          "name": "IDX_61546c650608c1e68789c64915",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_f5922b885e2680beab8add96008": {
+          "name": "FK_f5922b885e2680beab8add96008",
+          "tableFrom": "app_setting",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_22d3d051ee6f94932c1373a3d09": {
+          "name": "FK_22d3d051ee6f94932c1373a3d09",
+          "tableFrom": "app_setting",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app": {
+      "name": "app",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_37eb7baab82e11150157ec0b5a6": {
+          "name": "FK_37eb7baab82e11150157ec0b5a6",
+          "tableFrom": "app",
+          "tableTo": "publisher",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_key_key": {
+          "name": "app_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "UQ_f36adbb7b096ceeb6f3e80ad14c": {
+          "name": "UQ_f36adbb7b096ceeb6f3e80ad14c",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "app_url_key": {
+          "name": "app_url_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category-name-type": {
+          "name": "category-name-type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_mention": {
+      "name": "chat_mention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "chat_mention_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unread'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_mention_message_id_chat_message_id_fk": {
+          "name": "chat_mention_message_id_chat_message_id_fk",
+          "tableFrom": "chat_mention",
+          "tableTo": "chat_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_mention_account_id_account_id_fk": {
+          "name": "chat_mention_account_id_account_id_fk",
+          "tableFrom": "chat_mention",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "FK_e5199951167b722215127651e7c": {
+          "name": "FK_e5199951167b722215127651e7c",
+          "tableFrom": "chat_mention",
+          "tableTo": "chat_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_chat_mention_account_id": {
+          "name": "FK_chat_mention_account_id",
+          "tableFrom": "chat_mention",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_b31e627ea7a4787672e265a1579": {
+          "name": "FK_b31e627ea7a4787672e265a1579",
+          "tableFrom": "chat_message",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_71fdcb9038eca1b903102bdfd17": {
+          "name": "FK_71fdcb9038eca1b903102bdfd17",
+          "tableFrom": "chat_message",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guest_password": {
+      "name": "guest_password",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_guest_password_guest_id": {
+          "name": "FK_guest_password_guest_id",
+          "tableFrom": "guest_password",
+          "tableTo": "account",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_guest_password_guest_id": {
+          "name": "UQ_guest_password_guest_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_creator_id_account_id_fk": {
+          "name": "invitation_creator_id_account_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_item_path_item_path_fk": {
+          "name": "invitation_item_path_item_path_fk",
+          "tableFrom": "invitation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "FK_7ad4a490d5b9f79a677827b641c": {
+          "name": "FK_7ad4a490d5b9f79a677827b641c",
+          "tableFrom": "invitation",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_dc1d92accde1c2fbb7e729e4dcc": {
+          "name": "FK_dc1d92accde1c2fbb7e729e4dcc",
+          "tableFrom": "invitation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item-email": {
+          "name": "item-email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_favorite": {
+      "name": "item_favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_a169d350392956511697f7e7d38": {
+          "name": "FK_a169d350392956511697f7e7d38",
+          "tableFrom": "item_favorite",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_10ea93bde287762010695378f94": {
+          "name": "FK_10ea93bde287762010695378f94",
+          "tableFrom": "item_favorite",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "favorite_key": {
+          "name": "favorite_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_638552fc7d9a2035c2b53182d8a": {
+          "name": "FK_638552fc7d9a2035c2b53182d8a",
+          "tableFrom": "item_category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_9a34a079b5b24f4396462546d26": {
+          "name": "FK_9a34a079b5b24f4396462546d26",
+          "tableFrom": "item_category",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_5681d1785eea699e9cae8818fe0": {
+          "name": "FK_5681d1785eea699e9cae8818fe0",
+          "tableFrom": "item_category",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category-item": {
+          "name": "category-item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path",
+            "category_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_flag": {
+      "name": "item_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_b04d0adf4b73d82537c92fa55ea": {
+          "name": "FK_b04d0adf4b73d82537c92fa55ea",
+          "tableFrom": "item_flag",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_bde9b9ab1da1483a71c9b916dd2": {
+          "name": "FK_bde9b9ab1da1483a71c9b916dd2",
+          "tableFrom": "item_flag",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item-flag-creator": {
+          "name": "item-flag-creator",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "creator_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_geolocation": {
+      "name": "item_geolocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressLabel": {
+          "name": "addressLabel",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "helperLabel": {
+          "name": "helperLabel",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_66d4b13df4e7765068c8268d719": {
+          "name": "FK_66d4b13df4e7765068c8268d719",
+          "tableFrom": "item_geolocation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_geolocation_unique_item": {
+          "name": "item_geolocation_unique_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_like": {
+      "name": "item_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_item_like_item": {
+          "name": "IDX_item_like_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_4a56eba1ce30dc93f118a51ff26": {
+          "name": "FK_4a56eba1ce30dc93f118a51ff26",
+          "tableFrom": "item_like",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_159827eb667d019dc71372d7463": {
+          "name": "FK_159827eb667d019dc71372d7463",
+          "tableFrom": "item_like",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id": {
+          "name": "id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_login_schema": {
+      "name": "item_login_schema",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "item_login_schema_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "item_login_schema_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_login_schema_item_path_item_path_fk": {
+          "name": "item_login_schema_item_path_item_path_fk",
+          "tableFrom": "item_login_schema",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item-login-schema": {
+          "name": "item-login-schema",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_membership": {
+      "name": "item_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_5ac5bdde333fca6bbeaf177ef9": {
+          "name": "IDX_5ac5bdde333fca6bbeaf177ef9",
+          "columns": [
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_d935785e7ecc015ed3ca048ff0": {
+          "name": "IDX_d935785e7ecc015ed3ca048ff0",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_gist_item_membership_path": {
+          "name": "IDX_gist_item_membership_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "IDX_item_membership_account_id": {
+          "name": "IDX_item_membership_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_item_membership_account_id_permission": {
+          "name": "IDX_item_membership_account_id_permission",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_membership_item_path_item_path_fk": {
+          "name": "item_membership_item_path_item_path_fk",
+          "tableFrom": "item_membership",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "item_membership_creator_id_account_id_fk": {
+          "name": "item_membership_creator_id_account_id_fk",
+          "tableFrom": "item_membership",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "item_membership_account_id_account_id_fk": {
+          "name": "item_membership_account_id_account_id_fk",
+          "tableFrom": "item_membership",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_membership-item-member": {
+          "name": "item_membership-item-member",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tag": {
+      "name": "item_tag",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_item_tag_item": {
+          "name": "IDX_item_tag_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_16ab8afb42f763f7cbaa4bff66a": {
+          "name": "FK_16ab8afb42f763f7cbaa4bff66a",
+          "tableFrom": "item_tag",
+          "tableTo": "tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_39b492fda03c7ac846afe164b58": {
+          "name": "FK_39b492fda03c7ac846afe164b58",
+          "tableFrom": "item_tag",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "PK_a04bb2298e37d95233a0c92347e": {
+          "name": "PK_a04bb2298e37d95233a0c92347e",
+          "columns": [
+            "tag_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "UQ_item_tag": {
+          "name": "UQ_item_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tag_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_validation_group": {
+      "name": "item_validation_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_a9e83cf5f53c026b774b53d3c60": {
+          "name": "FK_a9e83cf5f53c026b774b53d3c60",
+          "tableFrom": "item_validation_group",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_validation_review": {
+      "name": "item_validation_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_validation_id": {
+          "name": "item_validation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_59fd000835c70c728e525d82950": {
+          "name": "FK_59fd000835c70c728e525d82950",
+          "tableFrom": "item_validation_review",
+          "tableTo": "item_validation",
+          "columnsFrom": [
+            "item_validation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_44bf14fee580ae08702d70e622e": {
+          "name": "FK_44bf14fee580ae08702d70e622e",
+          "tableFrom": "item_validation_review",
+          "tableTo": "account",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_validation": {
+      "name": "item_validation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process": {
+          "name": "process",
+          "type": "item_validation_process",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "item_validation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_validation_group_id": {
+          "name": "item_validation_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_d60969d5e478e7c844532ac4e7f": {
+          "name": "FK_d60969d5e478e7c844532ac4e7f",
+          "tableFrom": "item_validation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_e92da280941f666acf87baedc65": {
+          "name": "FK_e92da280941f666acf87baedc65",
+          "tableFrom": "item_validation",
+          "tableTo": "item_validation_group",
+          "columnsFrom": [
+            "item_validation_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_visibility": {
+      "name": "item_visibility",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "item_visibility_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_gist_item_visibility_path": {
+          "name": "IDX_gist_item_visibility_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_item_visibility_creator": {
+          "name": "FK_item_visibility_creator",
+          "tableFrom": "item_visibility",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_item_visibility_item": {
+          "name": "FK_item_visibility_item",
+          "tableFrom": "item_visibility",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_item_visibility_item_type": {
+          "name": "UQ_item_visibility_item_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item": {
+      "name": "item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_bdc46717fadc2f04f3093e51fd": {
+          "name": "IDX_bdc46717fadc2f04f3093e51fd",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_gist_item_path": {
+          "name": "IDX_gist_item_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "IDX_gist_item_path_deleted_at": {
+          "name": "IDX_gist_item_path_deleted_at",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"item\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_bdc46717fadc2f04f3093e51fd5": {
+          "name": "FK_bdc46717fadc2f04f3093e51fd5",
+          "tableFrom": "item",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_path_key1": {
+          "name": "item_path_key1",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_password": {
+      "name": "member_password",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_password_member_id_account_id_fk": {
+          "name": "member_password_member_id_account_id_fk",
+          "tableFrom": "member_password",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member-password": {
+          "name": "member-password",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_profile": {
+      "name": "member_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "facebookId": {
+          "name": "facebookId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedinId": {
+          "name": "linkedinId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterId": {
+          "name": "twitterId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_91fa43bc5482dc6b00892baf01": {
+          "name": "IDX_91fa43bc5482dc6b00892baf01",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_profile_member_id_account_id_fk": {
+          "name": "member_profile_member_id_account_id_fk",
+          "tableFrom": "member_profile",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "FK_91fa43bc5482dc6b00892baf016": {
+          "name": "FK_91fa43bc5482dc6b00892baf016",
+          "tableFrom": "member_profile",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member-profile": {
+          "name": "member-profile",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_request": {
+      "name": "membership_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_membership_request_member_id": {
+          "name": "FK_membership_request_member_id",
+          "tableFrom": "membership_request",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_membership_request_item_id": {
+          "name": "FK_membership_request_item_id",
+          "tableFrom": "membership_request",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_membership_request_item-member": {
+          "name": "UQ_membership_request_item-member",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_published": {
+      "name": "item_published",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_gist_item_published_path": {
+          "name": "IDX_gist_item_published_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_published_creator_id_account_id_fk": {
+          "name": "item_published_creator_id_account_id_fk",
+          "tableFrom": "item_published",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "item_published_item_path_item_path_fk": {
+          "name": "item_published_item_path_item_path_fk",
+          "tableFrom": "item_published",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published-item": {
+          "name": "published-item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publisher": {
+      "name": "publisher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origins": {
+          "name": "origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "publisher_name_key": {
+          "name": "publisher_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recycled_item_data": {
+      "name": "recycled_item_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_3e3650ebd5c49843013429d510a": {
+          "name": "FK_3e3650ebd5c49843013429d510a",
+          "tableFrom": "recycled_item_data",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_f8a4db4476e3d81e18de5d63c42": {
+          "name": "FK_f8a4db4476e3d81e18de5d63c42",
+          "tableFrom": "recycled_item_data",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recycled-item-data": {
+          "name": "recycled-item-data",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.short_link": {
+      "name": "short_link",
+      "schema": "",
+      "columns": {
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "short_link_platform_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_43c8a0471d5e58f99fc9c36b99": {
+          "name": "IDX_43c8a0471d5e58f99fc9c36b99",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_43c8a0471d5e58f99fc9c36b991": {
+          "name": "FK_43c8a0471d5e58f99fc9c36b991",
+          "tableFrom": "short_link",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_859a3384cadaa460b84e04e5375": {
+          "name": "UQ_859a3384cadaa460b84e04e5375",
+          "nullsNotDistinct": false,
+          "columns": [
+            "platform",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "CHK_200ef28b2168aaf1e36b6896fc": {
+          "name": "CHK_200ef28b2168aaf1e36b6896fc",
+          "value": "(length((alias)::text) >= 6) AND (length((alias)::text) <= 255) AND ((alias)::text ~ '^[a-zA-Z0-9-]*$'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "tag_category_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_tag_name_category": {
+          "name": "UQ_tag_name_category",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type_enum": {
+      "name": "account_type_enum",
+      "schema": "public",
+      "values": [
+        "individual",
+        "guest"
+      ]
+    },
+    "public.action_request_export_format_enum": {
+      "name": "action_request_export_format_enum",
+      "schema": "public",
+      "values": [
+        "json",
+        "csv"
+      ]
+    },
+    "public.action_view_enum": {
+      "name": "action_view_enum",
+      "schema": "public",
+      "values": [
+        "builder",
+        "player",
+        "library",
+        "explorer",
+        "account",
+        "auth",
+        "unknown"
+      ]
+    },
+    "public.chat_mention_status_enum": {
+      "name": "chat_mention_status_enum",
+      "schema": "public",
+      "values": [
+        "unread",
+        "read"
+      ]
+    },
+    "public.item_login_schema_status": {
+      "name": "item_login_schema_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "freeze",
+        "disabled"
+      ]
+    },
+    "public.item_login_schema_type": {
+      "name": "item_login_schema_type",
+      "schema": "public",
+      "values": [
+        "username",
+        "username+password",
+        "anonymous",
+        "anonymous+password"
+      ]
+    },
+    "public.item_validation_process": {
+      "name": "item_validation_process",
+      "schema": "public",
+      "values": [
+        "bad-words-detection",
+        "image-classification"
+      ]
+    },
+    "public.item_validation_status": {
+      "name": "item_validation_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure",
+        "pending",
+        "pending-manual"
+      ]
+    },
+    "public.item_visibility_type": {
+      "name": "item_visibility_type",
+      "schema": "public",
+      "values": [
+        "public",
+        "hidden"
+      ]
+    },
+    "public.permission_enum": {
+      "name": "permission_enum",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "admin"
+      ]
+    },
+    "public.short_link_platform_enum": {
+      "name": "short_link_platform_enum",
+      "schema": "public",
+      "values": [
+        "builder",
+        "player",
+        "library"
+      ]
+    },
+    "public.tag_category_enum": {
+      "name": "tag_category_enum",
+      "schema": "public",
+      "values": [
+        "level",
+        "discipline",
+        "resource-type"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.guests_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "item_login_schema_id": {
+          "name": "item_login_schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"extra\", \"type\", \"created_at\", \"updated_at\", \"last_authenticated_at\", \"is_validated\", \"item_login_schema_id\" from \"account\" where (\"account\".\"type\" = 'guest' and \"account\".\"item_login_schema_id\" is not null)",
+      "name": "guests_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.item_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lang": {
+          "name": "lang",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"type\", \"description\", \"path\", \"creator_id\", \"extra\", \"settings\", \"created_at\", \"updated_at\", \"lang\", \"order\" from \"item\" where \"item\".\"deleted_at\" is null",
+      "name": "item_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.members_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agreements_date": {
+          "name": "user_agreements_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_save_actions": {
+          "name": "enable_save_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"email\", \"extra\", \"type\", \"created_at\", \"updated_at\", \"user_agreements_date\", \"enable_save_actions\", \"last_authenticated_at\", \"is_validated\" from \"account\" where (\"account\".\"type\" = 'individual' and \"account\".\"email\" is not null)",
+      "name": "members_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1744886643813,
       "tag": "0002_add-item-view-index",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1745474597532,
+      "tag": "0003_use-timezone-in-items-account",
+      "breakpoints": true
     }
   ]
 }

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -775,12 +775,14 @@ export const itemsRawTable = pgTable(
     // TODO: fix type
     extra: jsonb().$type<object>().default({}).notNull(),
     settings: jsonb().$type<ItemSettings>().default({}).notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
-    deletedAt: timestamp('deleted_at', { mode: 'string' }), // HACK: the softdeletion mechanism relies on the deletedAt being null or having a date
+    deletedAt: timestamp('deleted_at', { withTimezone: true, mode: 'string' }), // HACK: the softdeletion mechanism relies on the deletedAt being null or having a date
     lang: varchar().default('en').notNull(),
 
     order: customNumeric('order'),
@@ -813,7 +815,9 @@ export const membershipRequestsTable = pgTable(
   'membership_request',
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     memberId: uuid('member_id').notNull(),
     itemId: uuid('item_id').notNull(),
   },
@@ -840,14 +844,16 @@ export const accountsTable = pgTable(
     email: varchar({ length: 150 }),
     extra: jsonb().$type<CompleteMember['extra']>().default({}).notNull(),
     type: accountTypeEnum().default('individual').notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
-    userAgreementsDate: timestamp('user_agreements_date', { mode: 'string' }),
+    userAgreementsDate: timestamp('user_agreements_date', { withTimezone: true, mode: 'string' }),
     enableSaveActions: boolean('enable_save_actions').default(true),
-    lastAuthenticatedAt: timestamp('last_authenticated_at', { mode: 'string' }),
+    lastAuthenticatedAt: timestamp('last_authenticated_at', { withTimezone: true, mode: 'string' }),
     isValidated: boolean('is_validated').default(false),
     itemLoginSchemaId: uuid('item_login_schema_id').references(
       (): AnyPgColumn => itemLoginSchemasTable.id,

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -89,7 +89,9 @@ export const publishedItemsTable = pgTable(
   'item_published',
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     creatorId: uuid('creator_id').references(() => accountsTable.id, {
       onDelete: 'set null',
     }),
@@ -99,7 +101,7 @@ export const publishedItemsTable = pgTable(
         onUpdate: 'cascade',
         onDelete: 'cascade',
       }),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -130,8 +132,10 @@ export const itemMembershipsTable = pgTable(
     accountId: uuid('account_id')
       .notNull()
       .references(() => accountsTable.id, { onDelete: 'cascade' }),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -167,8 +171,10 @@ export const memberPasswordsTable = pgTable(
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
     password: varchar({ length: 100 }).notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -184,7 +190,9 @@ export const recycledItemDatasTable = pgTable(
   'recycled_item_data',
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     creatorId: uuid('creator_id'),
     itemPath: ltree('item_path').notNull(),
   },
@@ -209,7 +217,9 @@ export const itemLikesTable = pgTable(
   'item_like',
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     creatorId: uuid('creator_id').notNull(),
     itemId: uuid('item_id').notNull(),
   },
@@ -236,7 +246,9 @@ export const itemFlagsTable = pgTable(
     type: varchar().notNull(),
     creatorId: uuid('creator_id'),
     itemId: uuid('item_id'),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     foreignKey({
@@ -261,7 +273,9 @@ export const itemCategoriesTable = pgTable(
     creatorId: uuid('creator_id'),
     itemPath: ltree('item_path').notNull(),
     categoryId: uuid('category_id').notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     foreignKey({
@@ -291,8 +305,10 @@ export const chatMessagesTable = pgTable(
     id: uuid().defaultRandom().primaryKey().notNull(),
     itemId: uuid('item_id').notNull(),
     creatorId: uuid('creator_id'),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -322,8 +338,10 @@ export const chatMentionsTable = pgTable(
     accountId: uuid('account_id')
       .references(() => accountsTable.id)
       .notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -353,8 +371,10 @@ export const appDataTable = pgTable(
     type: varchar({ length: 25 }).notNull(),
     creatorId: uuid('creator_id'),
     visibility: varchar().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -392,7 +412,9 @@ export const appActionsTable = pgTable(
     itemId: uuid('item_id').notNull(),
     data: jsonb().$type<object>().default({}).notNull(),
     type: varchar({ length: 25 }).notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     foreignKey({
@@ -416,8 +438,10 @@ export const appSettingsTable = pgTable(
     creatorId: uuid('creator_id'),
     name: varchar().notNull(),
     data: jsonb().$type<object>().default({}).notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -452,8 +476,10 @@ export const invitationsTable = pgTable(
     name: varchar({ length: 100 }),
     email: varchar({ length: 100 }).notNull(),
     permission: permissionEnum().default('read').notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -481,8 +507,10 @@ export const publishersTable = pgTable(
     id: uuid().primaryKey().defaultRandom().notNull(),
     name: varchar({ length: 250 }).notNull(),
     origins: text().array().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -499,8 +527,10 @@ export const appsTable = pgTable(
     description: varchar({ length: 250 }).notNull(),
     url: varchar({ length: 250 }).notNull(),
     publisherId: uuid('publisher_id').notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -523,7 +553,9 @@ export const itemValidationGroupsTable = pgTable(
   {
     id: uuid().primaryKey().notNull().defaultRandom(),
     itemId: uuid('item_id').notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     foreignKey({
@@ -543,8 +575,10 @@ export const itemValidationsTable = pgTable(
     status: itemValidationStatusEnum().notNull(),
     result: varchar(),
     itemValidationGroupId: uuid('item_validation_group_id').notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -571,8 +605,10 @@ export const itemValidationReviewsTable = pgTable(
     reviewerId: uuid('reviewer_id'),
     status: varchar().notNull(),
     reason: varchar(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -595,7 +631,9 @@ export const itemBookmarksTable = pgTable(
   'item_favorite',
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     memberId: uuid('member_id').notNull(),
     itemId: uuid('item_id').notNull(),
   },
@@ -625,8 +663,10 @@ export const memberProfilesTable = pgTable(
     facebookId: varchar({ length: 100 }),
     linkedinId: varchar({ length: 100 }),
     twitterId: varchar({ length: 100 }),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -653,7 +693,9 @@ export const shortLinksTable = pgTable(
   {
     alias: varchar({ length: 255 }).primaryKey().notNull(),
     platform: shortLinkPlatformEnum().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     itemId: uuid('item_id').notNull(),
   },
   (table) => [
@@ -684,7 +726,9 @@ export const actionsTable = pgTable(
     type: varchar().notNull(),
     extra: jsonb().$type<object>().default({}).notNull(),
     geolocation: jsonb().$type<geoip.Lookup>(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     accountId: uuid('account_id'),
     itemId: uuid('item_id'),
   },
@@ -717,8 +761,10 @@ export const itemGeolocationsTable = pgTable(
     lat: doublePrecision().notNull(),
     lng: doublePrecision().notNull(),
     country: varchar({ length: 4 }),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -742,7 +788,9 @@ export const actionRequestExportsTable = pgTable(
   'action_request_export',
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
     memberId: uuid('member_id').notNull(),
     itemPath: ltree('item_path'),
     format: actionRequestExportFormatEnum().default('json').notNull(),
@@ -905,8 +953,10 @@ export const guestPasswordsTable = pgTable(
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
     password: varchar({ length: 100 }).notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -927,8 +977,10 @@ export const itemLoginSchemasTable = pgTable(
   {
     id: uuid().primaryKey().defaultRandom().notNull(),
     type: itemLoginSchemaTypeEnum().notNull(),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'string' })
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
       .defaultNow()
       .notNull()
       .$onUpdate(() => sql.raw('DEFAULT')),
@@ -950,7 +1002,9 @@ export const itemVisibilitiesTable = pgTable(
     type: itemVisibilityEnum().notNull(),
     itemPath: ltree('item_path').notNull(),
     creatorId: uuid('creator_id'),
-    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
   },
   (table) => [
     index('IDX_gist_item_visibility_path').using(


### PR DESCRIPTION
In this PR, I alter the type of the timestamp columns for `item`, `account` and `membership_request` to include the timezone. This solves and issue in the serialization where the timestamp was not timezone aware and the frontend would interpret it as local time leading to wrong dates.

We can change other tables as well, and in the end it would be better to have all tables using `timestamp with time zone` for consistency. 