### PR TITLE
fix: auto-deploy

### DIFF
--- a/.github/actions/build-images/action.yml
+++ b/.github/actions/build-images/action.yml
@@ -8,6 +8,9 @@ inputs:
   aws-ecr-uri:
     description: "AWS ECR URI, similar to 'public.ecr.aws/ecr-default-alias'"
     required: true
+  aws-region:
+    description: "AWS REGION, similar to 'eu-central-1'"
+    required: true
   aws-role-arn:
     description: 'AWS Role to assume'
     required: true
@@ -19,7 +22,11 @@ runs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
-        aws-region: us-east-1
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Auth to the ECR
+      run: bash ./docker/auth.sh ${{ inputs.aws-ecr-uri }} ${{ inputs.aws-region }}
+      shell: bash
 
     - name: Build and push the images
       run: bash ./docker/build.sh ${{ inputs.aws-ecr-uri }} ${{ inputs.tag }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build images
         uses: ./.github/actions/build-images
         with:
-          tag: next
+          tag: nightly
           aws-ecr-uri: ${{ vars.PRIVATE_ECR }}
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,26 +1,21 @@
 name: Deploy to development environment
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push events only for the main branch
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  NODE_OPTIONS: '--max_old_space_size=8192' # Allows to increase Node's max heap size
+# env:
+#   NODE_OPTIONS: '--max_old_space_size=8192' # Allows to increase Node's max heap size
 
 jobs:
   # Build image and push to ECR
   build:
     name: Build & Push Image
     runs-on: ubuntu-latest
-    # Define job output that is available to all downstream jobs that depend on this job
-    outputs:
-      image_url: ${{ steps.image-url.outputs.image_url }}
     environment: development
 
     steps:
@@ -30,110 +25,110 @@ jobs:
       - name: Build images
         uses: ./.github/actions/build-images
         with:
-          tag: ${{ github.ref_name || github.ref || github.sha }}
+          tag: next
           aws-ecr-uri: ${{ vars.PRIVATE_ECR }}/graasp
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
   # Deploy to dev environment
-  deploy:
-    needs: build
-    name: Deploy
-    runs-on: ubuntu-latest
-    environment: development
+  # deploy:
+  #   needs: build
+  #   name: Deploy
+  #   runs-on: ubuntu-latest
+  #   environment: development
 
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
 
-      # Configure AWS credential and region environment variables for use in next steps
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }} # todo: add in envs
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }} # todo: add in envs
-          aws-region: ${{ vars.AWS_REGION }}
+  #     # Configure AWS credential and region environment variables for use in next steps
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }} # todo: add in envs
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }} # todo: add in envs
+  #         aws-region: ${{ vars.AWS_REGION }}
 
-      # Log in the local Docker client
-      - name: Login to Amazon ECR
-        id: login-ecr-deploy
-        uses: aws-actions/amazon-ecr-login@v2
+  #     # Log in the local Docker client
+  #     - name: Login to Amazon ECR
+  #       id: login-ecr-deploy
+  #       uses: aws-actions/amazon-ecr-login@v2
 
-      # Insert a container image URI into template Amazon ECS task definition JSON file, creating a new task definition file.
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def-1
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: ${{ vars.ECS_TASK_DEFINITION }}
-          container-name: ${{ vars.CONTAINER_NAME_GRAASP }}
-          image: ${{ needs.build.outputs.image_url }}
-          environment-variables: |
-            DB_CONNECTION_POOL_SIZE=${{ vars.DB_CONNECTION_POOL_SIZE }}
-            APPS_JWT_SECRET=${{ secrets.APPS_JWT_SECRET }}
-            APPS_PUBLISHER_ID=${{ secrets.APPS_PUBLISHER_ID }}
-            AUTH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.AUTH_TOKEN_EXPIRATION_IN_MINUTES }}
-            AUTH_TOKEN_JWT_SECRET=${{ secrets.AUTH_TOKEN_JWT_SECRET }}
-            CLIENT_HOST=${{ vars.CLIENT_HOST }}
-            COOKIE_DOMAIN=${{ vars.COOKIE_DOMAIN }}
-            CORS_ORIGIN_REGEX=${{ secrets.CORS_ORIGIN_REGEX }}
-            DB_CONNECTION=postgres://${{ secrets.DB_USERNAME }}:${{ secrets.DB_PASSWORD }}@${{ secrets.DB_HOST }}:5432/${{ secrets.DB_NAME }}
+  #     # Insert a container image URI into template Amazon ECS task definition JSON file, creating a new task definition file.
+  #     - name: Fill in the new image ID in the Amazon ECS task definition
+  #       id: task-def-1
+  #       uses: aws-actions/amazon-ecs-render-task-definition@v1
+  #       with:
+  #         task-definition: ${{ vars.ECS_TASK_DEFINITION }}
+  #         container-name: ${{ vars.CONTAINER_NAME_GRAASP }}
+  #         image: ${{ needs.build.outputs.image_url }}
+  #         environment-variables: |
+  #           DB_CONNECTION_POOL_SIZE=${{ vars.DB_CONNECTION_POOL_SIZE }}
+  #           APPS_JWT_SECRET=${{ secrets.APPS_JWT_SECRET }}
+  #           APPS_PUBLISHER_ID=${{ secrets.APPS_PUBLISHER_ID }}
+  #           AUTH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.AUTH_TOKEN_EXPIRATION_IN_MINUTES }}
+  #           AUTH_TOKEN_JWT_SECRET=${{ secrets.AUTH_TOKEN_JWT_SECRET }}
+  #           CLIENT_HOST=${{ vars.CLIENT_HOST }}
+  #           COOKIE_DOMAIN=${{ vars.COOKIE_DOMAIN }}
+  #           CORS_ORIGIN_REGEX=${{ secrets.CORS_ORIGIN_REGEX }}
+  #           DB_CONNECTION=postgres://${{ secrets.DB_USERNAME }}:${{ secrets.DB_PASSWORD }}@${{ secrets.DB_HOST }}:5432/${{ secrets.DB_NAME }}
 
-            DB_READ_REPLICA_CONNECTIONS=${{ secrets.DB_READ_REPLICA_CONNECTIONS }}
-            SENTRY_ENV=${{ vars.SENTRY_ENV }}
-            EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ vars.EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN }}
-            ETHERPAD_API_KEY=${{ secrets.ETHERPAD_API_KEY }}
-            ETHERPAD_COOKIE_DOMAIN=${{ vars.ETHERPAD_COOKIE_DOMAIN }}
-            ETHERPAD_URL=${{ vars.ETHERPAD_URL }}
-            FILE_STORAGE_ROOT_PATH=${{ secrets.FILE_STORAGE_ROOT_PATH }}
-            H5P_CONTENT_ACCESS_KEY_ID=${{ secrets.H5P_CONTENT_ACCESS_KEY_ID }}
-            H5P_CONTENT_BUCKET=${{ vars.H5P_CONTENT_BUCKET }}
-            H5P_CONTENT_REGION=${{ vars.H5P_CONTENT_REGION }}
-            H5P_CONTENT_SECRET_ACCESS_KEY_ID=${{ secrets.H5P_CONTENT_SECRET_ACCESS_KEY }}
-            H5P_FILE_STORAGE_TYPE=${{ vars.H5P_FILE_STORAGE_TYPE }}
-            H5P_PATH_PREFIX=${{ vars.H5P_PATH_PREFIX }}
-            HOSTNAME=${{ vars.HOSTNAME }}
-            IMAGE_CLASSIFIER_API=${{ vars.IMAGE_CLASSIFIER_API }}
-            JOB_SCHEDULING=${{ vars.JOB_SCHEDULING || false }}
-            JWT_SECRET=${{ secrets.JWT_SECRET }}
-            PASSWORD_RESET_JWT_SECRET=${{ secrets.PASSWORD_RESET_JWT_SECRET }}
-            EMAIL_CHANGE_JWT_SECRET=${{ secrets.EMAIL_CHANGE_JWT_SECRET }}
-            LIBRARY_CLIENT_HOST=${{ vars.LIBRARY_CLIENT_HOST }}
-            LOG_LEVEL=${{ vars.LOG_LEVEL }}
-            MAILER_CONFIG_FROM_EMAIL=${{ secrets.MAILER_CONFIG_FROM_EMAIL }}
-            MAILER_CONFIG_PASSWORD=${{ secrets.MAILER_CONFIG_PASSWORD_DEV }}
-            MAILER_CONFIG_SMTP_HOST=${{ secrets.MAILER_CONFIG_SMTP_HOST }}
-            MAILER_CONFIG_USERNAME=${{ secrets.MAILER_CONFIG_USERNAME }}
-            MEILISEARCH_MASTER_KEY=${{ secrets.MEILISEARCH_MASTER_KEY }}
-            MEILISEARCH_REBUILD_SECRET=${{ secrets.MEILISEARCH_REBUILD_SECRET }}
-            MEILISEARCH_URL=${{ secrets.MEILISEARCH_URL }}
-            NODE_ENV=${{ vars.NODE_ENV }}
-            PORT=${{ vars.PORT }}
-            PUBLIC_URL=${{ secrets.PUBLIC_URL }}
-            RECAPTCHA_SECRET_ACCESS_KEY=${{ secrets.RECAPTCHA_SECRET_ACCESS_KEY }}
-            REDIS_HOST=${{ secrets.REDIS_HOST }}
-            REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
-            REDIS_PORT=${{ secrets.REDIS_PORT }}
-            REDIS_USERNAME=${{ secrets.REDIS_USERNAME }}
-            REFRESH_TOKEN_EXPIRATION_IN_MINUTES=${{ vars.REFRESH_TOKEN_EXPIRATION_IN_MINUTES }}
-            REFRESH_TOKEN_JWT_SECRET=${{ secrets.REFRESH_TOKEN_JWT_SECRET }}
-            S3_FILE_ITEM_ACCESS_KEY_ID=${{ secrets.S3_FILE_ITEM_ACCESS_KEY_ID }}
-            S3_FILE_ITEM_BUCKET=${{ vars.S3_FILE_ITEM_BUCKET }}
-            S3_FILE_ITEM_PLUGIN=${{ vars.S3_FILE_ITEM_PLUGIN }}
-            S3_FILE_ITEM_REGION=${{ vars.S3_FILE_ITEM_REGION }}
-            S3_FILE_ITEM_SECRET_ACCESS_KEY=${{ secrets.S3_FILE_ITEM_SECRET_ACCESS_KEY }}
-            SECURE_SESSION_SECRET_KEY=${{ secrets.SECURE_SESSION_SECRET_KEY }}
-            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-            WEBSOCKETS_PLUGIN=${{ vars.WEBSOCKETS_PLUGIN }}
-            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-            OPENAI_ORG_ID=${{ secrets.OPENAI_ORG_ID }}
-            GEOLOCATION_API_HOST=${{ vars.GEOLOCATION_API_HOST }}
-            GEOLOCATION_API_KEY=${{ secrets.GEOLOCATION_API_KEY }}
+  #           DB_READ_REPLICA_CONNECTIONS=${{ secrets.DB_READ_REPLICA_CONNECTIONS }}
+  #           SENTRY_ENV=${{ vars.SENTRY_ENV }}
+  #           EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ vars.EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN }}
+  #           ETHERPAD_API_KEY=${{ secrets.ETHERPAD_API_KEY }}
+  #           ETHERPAD_COOKIE_DOMAIN=${{ vars.ETHERPAD_COOKIE_DOMAIN }}
+  #           ETHERPAD_URL=${{ vars.ETHERPAD_URL }}
+  #           FILE_STORAGE_ROOT_PATH=${{ secrets.FILE_STORAGE_ROOT_PATH }}
+  #           H5P_CONTENT_ACCESS_KEY_ID=${{ secrets.H5P_CONTENT_ACCESS_KEY_ID }}
+  #           H5P_CONTENT_BUCKET=${{ vars.H5P_CONTENT_BUCKET }}
+  #           H5P_CONTENT_REGION=${{ vars.H5P_CONTENT_REGION }}
+  #           H5P_CONTENT_SECRET_ACCESS_KEY_ID=${{ secrets.H5P_CONTENT_SECRET_ACCESS_KEY }}
+  #           H5P_FILE_STORAGE_TYPE=${{ vars.H5P_FILE_STORAGE_TYPE }}
+  #           H5P_PATH_PREFIX=${{ vars.H5P_PATH_PREFIX }}
+  #           HOSTNAME=${{ vars.HOSTNAME }}
+  #           IMAGE_CLASSIFIER_API=${{ vars.IMAGE_CLASSIFIER_API }}
+  #           JOB_SCHEDULING=${{ vars.JOB_SCHEDULING || false }}
+  #           JWT_SECRET=${{ secrets.JWT_SECRET }}
+  #           PASSWORD_RESET_JWT_SECRET=${{ secrets.PASSWORD_RESET_JWT_SECRET }}
+  #           EMAIL_CHANGE_JWT_SECRET=${{ secrets.EMAIL_CHANGE_JWT_SECRET }}
+  #           LIBRARY_CLIENT_HOST=${{ vars.LIBRARY_CLIENT_HOST }}
+  #           LOG_LEVEL=${{ vars.LOG_LEVEL }}
+  #           MAILER_CONFIG_FROM_EMAIL=${{ secrets.MAILER_CONFIG_FROM_EMAIL }}
+  #           MAILER_CONFIG_PASSWORD=${{ secrets.MAILER_CONFIG_PASSWORD_DEV }}
+  #           MAILER_CONFIG_SMTP_HOST=${{ secrets.MAILER_CONFIG_SMTP_HOST }}
+  #           MAILER_CONFIG_USERNAME=${{ secrets.MAILER_CONFIG_USERNAME }}
+  #           MEILISEARCH_MASTER_KEY=${{ secrets.MEILISEARCH_MASTER_KEY }}
+  #           MEILISEARCH_REBUILD_SECRET=${{ secrets.MEILISEARCH_REBUILD_SECRET }}
+  #           MEILISEARCH_URL=${{ secrets.MEILISEARCH_URL }}
+  #           NODE_ENV=${{ vars.NODE_ENV }}
+  #           PORT=${{ vars.PORT }}
+  #           PUBLIC_URL=${{ secrets.PUBLIC_URL }}
+  #           RECAPTCHA_SECRET_ACCESS_KEY=${{ secrets.RECAPTCHA_SECRET_ACCESS_KEY }}
+  #           REDIS_HOST=${{ secrets.REDIS_HOST }}
+  #           REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
+  #           REDIS_PORT=${{ secrets.REDIS_PORT }}
+  #           REDIS_USERNAME=${{ secrets.REDIS_USERNAME }}
+  #           REFRESH_TOKEN_EXPIRATION_IN_MINUTES=${{ vars.REFRESH_TOKEN_EXPIRATION_IN_MINUTES }}
+  #           REFRESH_TOKEN_JWT_SECRET=${{ secrets.REFRESH_TOKEN_JWT_SECRET }}
+  #           S3_FILE_ITEM_ACCESS_KEY_ID=${{ secrets.S3_FILE_ITEM_ACCESS_KEY_ID }}
+  #           S3_FILE_ITEM_BUCKET=${{ vars.S3_FILE_ITEM_BUCKET }}
+  #           S3_FILE_ITEM_PLUGIN=${{ vars.S3_FILE_ITEM_PLUGIN }}
+  #           S3_FILE_ITEM_REGION=${{ vars.S3_FILE_ITEM_REGION }}
+  #           S3_FILE_ITEM_SECRET_ACCESS_KEY=${{ secrets.S3_FILE_ITEM_SECRET_ACCESS_KEY }}
+  #           SECURE_SESSION_SECRET_KEY=${{ secrets.SECURE_SESSION_SECRET_KEY }}
+  #           SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+  #           WEBSOCKETS_PLUGIN=${{ vars.WEBSOCKETS_PLUGIN }}
+  #           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+  #           OPENAI_ORG_ID=${{ secrets.OPENAI_ORG_ID }}
+  #           GEOLOCATION_API_HOST=${{ vars.GEOLOCATION_API_HOST }}
+  #           GEOLOCATION_API_KEY=${{ secrets.GEOLOCATION_API_KEY }}
 
-      # Use latest revision of the task-definition to deploy the application to ECS
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.task-def-1.outputs.task-definition }}
-          service: ${{ vars.ECS_SERVICE_GRAASP }}
-          cluster: ${{ vars.ECS_CLUSTER_GRAASP }}
-          wait-for-service-stability: true
+  #     # Use latest revision of the task-definition to deploy the application to ECS
+  #     - name: Deploy Amazon ECS task definition
+  #       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+  #       with:
+  #         task-definition: ${{ steps.task-def-1.outputs.task-definition }}
+  #         service: ${{ vars.ECS_SERVICE_GRAASP }}
+  #         cluster: ${{ vars.ECS_CLUSTER_GRAASP }}
+  #         wait-for-service-stability: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,39 +24,16 @@ jobs:
     environment: development
 
     steps:
-      # Check-out repository under $GITHUB_WORKSPACE, so the job can access it
-      - name: Check out code
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      # Configure AWS credential and region environment variables for use in next steps
-      - name: Configure AWS Credentials
-        id: configure-aws
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Build images
+        uses: ./.github/actions/build-images
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }} # todo: add in envs
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }} # todo: add in envs
+          tag: ${{ github.ref_name || github.ref || github.sha }}
+          aws-ecr-uri: ${{ vars.PRIVATE_ECR }}/graasp
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
-
-      # Log in the local Docker client
-      - name: Login to Amazon ECR
-        id: login-ecr-build
-        uses: aws-actions/amazon-ecr-login@v2
-
-      # Set output variable tag with the current checked out ref
-      - name: Set Image Url
-        id: image-url
-        env:
-          TARGET_IMAGE_URL: ${{ steps.login-ecr-build.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.ref_name || github.ref || github.sha }}
-        run: echo "image_url=${TARGET_IMAGE_URL}" >> $GITHUB_OUTPUT
-
-      # Build and tag the docker image
-      - name: Build, tag and push image to AWS ECR
-        id: build-image
-        env:
-          TARGET_IMAGE_URL: ${{ steps.image-url.outputs.image_url }}
-        run: |
-          docker build -t $TARGET_IMAGE_URL -f docker/Dockerfile --build-arg APP_VERSION=${{ github.sha }} .
-          docker push $TARGET_IMAGE_URL
 
   # Deploy to dev environment
   deploy:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/build-images
         with:
           tag: next
-          aws-ecr-uri: ${{ vars.PRIVATE_ECR }}/graasp
+          aws-ecr-uri: ${{ vars.PRIVATE_ECR }}
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,14 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# env:
-#   NODE_OPTIONS: '--max_old_space_size=8192' # Allows to increase Node's max heap size
-
 permissions:
-  id-token: write # This is required for requesting the JWT ofr OIDC
+  id-token: write # This is required for requesting the JWT for OIDC
 
 jobs:
-  # Build image and push to ECR
   build:
     name: Build & Push Image
     runs-on: ubuntu-latest
@@ -32,106 +28,3 @@ jobs:
           aws-ecr-uri: ${{ vars.PRIVATE_ECR }}
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
-
-  # Deploy to dev environment
-  # deploy:
-  #   needs: build
-  #   name: Deploy
-  #   runs-on: ubuntu-latest
-  #   environment: development
-
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-
-  #     # Configure AWS credential and region environment variables for use in next steps
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }} # todo: add in envs
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }} # todo: add in envs
-  #         aws-region: ${{ vars.AWS_REGION }}
-
-  #     # Log in the local Docker client
-  #     - name: Login to Amazon ECR
-  #       id: login-ecr-deploy
-  #       uses: aws-actions/amazon-ecr-login@v2
-
-  #     # Insert a container image URI into template Amazon ECS task definition JSON file, creating a new task definition file.
-  #     - name: Fill in the new image ID in the Amazon ECS task definition
-  #       id: task-def-1
-  #       uses: aws-actions/amazon-ecs-render-task-definition@v1
-  #       with:
-  #         task-definition: ${{ vars.ECS_TASK_DEFINITION }}
-  #         container-name: ${{ vars.CONTAINER_NAME_GRAASP }}
-  #         image: ${{ needs.build.outputs.image_url }}
-  #         environment-variables: |
-  #           DB_CONNECTION_POOL_SIZE=${{ vars.DB_CONNECTION_POOL_SIZE }}
-  #           APPS_JWT_SECRET=${{ secrets.APPS_JWT_SECRET }}
-  #           APPS_PUBLISHER_ID=${{ secrets.APPS_PUBLISHER_ID }}
-  #           AUTH_TOKEN_EXPIRATION_IN_MINUTES=${{ secrets.AUTH_TOKEN_EXPIRATION_IN_MINUTES }}
-  #           AUTH_TOKEN_JWT_SECRET=${{ secrets.AUTH_TOKEN_JWT_SECRET }}
-  #           CLIENT_HOST=${{ vars.CLIENT_HOST }}
-  #           COOKIE_DOMAIN=${{ vars.COOKIE_DOMAIN }}
-  #           CORS_ORIGIN_REGEX=${{ secrets.CORS_ORIGIN_REGEX }}
-  #           DB_CONNECTION=postgres://${{ secrets.DB_USERNAME }}:${{ secrets.DB_PASSWORD }}@${{ secrets.DB_HOST }}:5432/${{ secrets.DB_NAME }}
-
-  #           DB_READ_REPLICA_CONNECTIONS=${{ secrets.DB_READ_REPLICA_CONNECTIONS }}
-  #           SENTRY_ENV=${{ vars.SENTRY_ENV }}
-  #           EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ vars.EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN }}
-  #           ETHERPAD_API_KEY=${{ secrets.ETHERPAD_API_KEY }}
-  #           ETHERPAD_COOKIE_DOMAIN=${{ vars.ETHERPAD_COOKIE_DOMAIN }}
-  #           ETHERPAD_URL=${{ vars.ETHERPAD_URL }}
-  #           FILE_STORAGE_ROOT_PATH=${{ secrets.FILE_STORAGE_ROOT_PATH }}
-  #           H5P_CONTENT_ACCESS_KEY_ID=${{ secrets.H5P_CONTENT_ACCESS_KEY_ID }}
-  #           H5P_CONTENT_BUCKET=${{ vars.H5P_CONTENT_BUCKET }}
-  #           H5P_CONTENT_REGION=${{ vars.H5P_CONTENT_REGION }}
-  #           H5P_CONTENT_SECRET_ACCESS_KEY_ID=${{ secrets.H5P_CONTENT_SECRET_ACCESS_KEY }}
-  #           H5P_FILE_STORAGE_TYPE=${{ vars.H5P_FILE_STORAGE_TYPE }}
-  #           H5P_PATH_PREFIX=${{ vars.H5P_PATH_PREFIX }}
-  #           HOSTNAME=${{ vars.HOSTNAME }}
-  #           IMAGE_CLASSIFIER_API=${{ vars.IMAGE_CLASSIFIER_API }}
-  #           JOB_SCHEDULING=${{ vars.JOB_SCHEDULING || false }}
-  #           JWT_SECRET=${{ secrets.JWT_SECRET }}
-  #           PASSWORD_RESET_JWT_SECRET=${{ secrets.PASSWORD_RESET_JWT_SECRET }}
-  #           EMAIL_CHANGE_JWT_SECRET=${{ secrets.EMAIL_CHANGE_JWT_SECRET }}
-  #           LIBRARY_CLIENT_HOST=${{ vars.LIBRARY_CLIENT_HOST }}
-  #           LOG_LEVEL=${{ vars.LOG_LEVEL }}
-  #           MAILER_CONFIG_FROM_EMAIL=${{ secrets.MAILER_CONFIG_FROM_EMAIL }}
-  #           MAILER_CONFIG_PASSWORD=${{ secrets.MAILER_CONFIG_PASSWORD_DEV }}
-  #           MAILER_CONFIG_SMTP_HOST=${{ secrets.MAILER_CONFIG_SMTP_HOST }}
-  #           MAILER_CONFIG_USERNAME=${{ secrets.MAILER_CONFIG_USERNAME }}
-  #           MEILISEARCH_MASTER_KEY=${{ secrets.MEILISEARCH_MASTER_KEY }}
-  #           MEILISEARCH_REBUILD_SECRET=${{ secrets.MEILISEARCH_REBUILD_SECRET }}
-  #           MEILISEARCH_URL=${{ secrets.MEILISEARCH_URL }}
-  #           NODE_ENV=${{ vars.NODE_ENV }}
-  #           PORT=${{ vars.PORT }}
-  #           PUBLIC_URL=${{ secrets.PUBLIC_URL }}
-  #           RECAPTCHA_SECRET_ACCESS_KEY=${{ secrets.RECAPTCHA_SECRET_ACCESS_KEY }}
-  #           REDIS_HOST=${{ secrets.REDIS_HOST }}
-  #           REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
-  #           REDIS_PORT=${{ secrets.REDIS_PORT }}
-  #           REDIS_USERNAME=${{ secrets.REDIS_USERNAME }}
-  #           REFRESH_TOKEN_EXPIRATION_IN_MINUTES=${{ vars.REFRESH_TOKEN_EXPIRATION_IN_MINUTES }}
-  #           REFRESH_TOKEN_JWT_SECRET=${{ secrets.REFRESH_TOKEN_JWT_SECRET }}
-  #           S3_FILE_ITEM_ACCESS_KEY_ID=${{ secrets.S3_FILE_ITEM_ACCESS_KEY_ID }}
-  #           S3_FILE_ITEM_BUCKET=${{ vars.S3_FILE_ITEM_BUCKET }}
-  #           S3_FILE_ITEM_PLUGIN=${{ vars.S3_FILE_ITEM_PLUGIN }}
-  #           S3_FILE_ITEM_REGION=${{ vars.S3_FILE_ITEM_REGION }}
-  #           S3_FILE_ITEM_SECRET_ACCESS_KEY=${{ secrets.S3_FILE_ITEM_SECRET_ACCESS_KEY }}
-  #           SECURE_SESSION_SECRET_KEY=${{ secrets.SECURE_SESSION_SECRET_KEY }}
-  #           SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-  #           WEBSOCKETS_PLUGIN=${{ vars.WEBSOCKETS_PLUGIN }}
-  #           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-  #           OPENAI_ORG_ID=${{ secrets.OPENAI_ORG_ID }}
-  #           GEOLOCATION_API_HOST=${{ vars.GEOLOCATION_API_HOST }}
-  #           GEOLOCATION_API_KEY=${{ secrets.GEOLOCATION_API_KEY }}
-
-  #     # Use latest revision of the task-definition to deploy the application to ECS
-  #     - name: Deploy Amazon ECS task definition
-  #       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-  #       with:
-  #         task-definition: ${{ steps.task-def-1.outputs.task-definition }}
-  #         service: ${{ vars.ECS_SERVICE_GRAASP }}
-  #         cluster: ${{ vars.ECS_CLUSTER_GRAASP }}
-  #         wait-for-service-stability: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,6 +11,9 @@ on:
 # env:
 #   NODE_OPTIONS: '--max_old_space_size=8192' # Allows to increase Node's max heap size
 
+permissions:
+  id-token: write # This is required for requesting the JWT ofr OIDC
+
 jobs:
   # Build image and push to ECR
   build:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -103,11 +103,8 @@ jobs:
             CLIENT_HOST=${{ vars.CLIENT_HOST }}
             COOKIE_DOMAIN=${{ vars.COOKIE_DOMAIN }}
             CORS_ORIGIN_REGEX=${{ secrets.CORS_ORIGIN_REGEX }}
-            DB_HOST=${{ secrets.DB_HOST }}
-            DB_NAME=${{ secrets.DB_NAME }}
-            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            DB_CONNECTION=postgres://${{ secrets.DB_USERNAME }}:${{ secrets.DB_PASSWORD }}@${{ secrets.DB_HOST }}:5432/${{ secrets.DB_NAME }}
             DB_READ_REPLICA_CONNECTIONS=${{ secrets.DB_READ_REPLICA_CONNECTIONS }}
-            DB_USERNAME=${{ secrets.DB_USERNAME }}
             SENTRY_ENV=${{ vars.SENTRY_ENV }}
             EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN=${{ vars.EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN }}
             ETHERPAD_API_KEY=${{ secrets.ETHERPAD_API_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,7 @@ jobs:
           tag: ${{ steps.release.outputs.tag_name }}
           aws-ecr-uri: ${{ vars.GRAASP_PUBLIC_ECR }}
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       # ------ Legacy behavior ---
       # put created tag in an env variable to be sent to the dispatch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,9 @@ FROM node:${NODE_VERSION}-bookworm-slim AS runner
 ARG APP_VERSION
 # Set APP_VERSION as ENV variable from ARG passed at build step
 ENV APP_VERSION=${APP_VERSION:-latest}
+# Set BUILD_TIMESTAMP as ENV variable from ARG passed at build step
+ARG BUILD_TIMESTAMP
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP:-not-provided}
 # Set NODE_ENV to production so we don't trigger .husky/install.mjs
 ENV NODE_ENV=production
 

--- a/docker/auth.sh
+++ b/docker/auth.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+function show_help() {
+    echo "This script allows to auth to the ECR service"
+    echo "Usage: bash docker/auth.sh ECR_URI REGION"
+    echo "Arguments:"
+    echo "  ECR_URI      URI of the ECR in AWS, example: public.ecr.aws/qzuer78 or a private ECR XXXXXXXX.dkr.ecr.region.amazonaws.com/repo."
+    echo "  REGION       REGION of the ECR in AWS, example: eu-central-1"
+}
+
+# Check if no arguments are provided
+if [ "$#" -eq 0 ]; then
+    show_help
+    exit 1
+fi
+
+# Get inputs from command line
+if [ -z "$1" ]; then
+  echo "Missing required ECR_URI argument"
+  exit 1
+fi
+aws_ecr_uri=$1
+
+# Get inputs from command line
+if [ -z "$2" ]; then
+  echo "Missing required REGION argument"
+  exit 1
+fi
+aws_region=$2
+
+# Check if the aws cli is authenticated
+aws_identity=$(aws sts get-caller-identity)
+if [ $? -eq 0 ]; then
+  echo -e "Using AWS identity:\n$aws_identity"
+else
+  echo "AWS CLI is not authenticated, please ensure the cli is authenticated before running this script";
+  exit 1
+fi
+
+if [[ $aws_ecr_uri == public.ecr* ]]; then
+  echo "Using Public ECR"
+  ecr_credentials=$(aws ecr-public get-login-password --region us-east-1)
+else
+  echo "Using Private ECR"
+  ecr_credentials=$(aws ecr get-login-password --region $aws_region)
+fi
+
+if [ -z $ecr_credentials ]; then
+  echo "The AWS credentials were not received"
+  echo "Please check that the ECR_URI is correct and that you are logged into an account or role that is allowed to use that ECR"
+  exit 1
+fi
+# login the docker client with the ECR credentials derived from the currently authenticated user
+echo $ecr_credentials | docker login --username AWS --password-stdin $aws_ecr_uri

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,7 +4,7 @@ function show_help() {
     echo "This script allows to build and push the docker images for the core and the migration"
     echo "Usage: bash docker/build.sh ECR_URI VERSION"
     echo "Arguments:"
-    echo "  ECR_URI      URI of the ECR in AWS, example: public.ecr.aws/qzuer78"
+    echo "  ECR_URI      URI of the ECR in AWS, example: public.ecr.aws/qzuer78 or a private ECR XXXXXXXX.dkr.ecr.region.amazonaws.com/repo."
     echo "  VERSION      The version that is deployed, should be a semantic version i.e 1.45.8"
 }
 
@@ -26,24 +26,6 @@ if [ -z "$2" ]; then
   exit 1
 fi
 tag_version=$2
-
-# Check if the aws cli is authenticated
-aws_identity=$(aws sts get-caller-identity)
-if [ $? -eq 0 ]; then
-  echo -e "Using AWS identity:\n$aws_identity"
-else
-  echo "AWS CLI is not authenticated, please ensure the cli is authenticated before running this script";
-  exit 1
-fi
-
-ecr_credentials=$(aws ecr-public get-login-password --region us-east-1)
-if [ -z $ecr_credentials ]; then
-  echo "The AWS credentials were not received"
-  echo "Please check that the ECR_URI is correct and that you are logged into an account or role that is allowed to use that ECR"
-  exit 1
-fi
-# login the docker client with the ECR credentials derived from the currently authenticated user
-echo $ecr_credentials | docker login --username AWS --password-stdin $aws_ecr_uri
 
 # define the image tags including the ecr uri
 core_tag_short="graasp:core-$tag_version"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -34,7 +34,7 @@ core_tag_full="$aws_ecr_uri/$core_tag_short"
 migrate_tag_short="graasp:migrate-$tag_version"
 migrate_tag_full="$aws_ecr_uri/$migrate_tag_short"
 
-docker build -t $core_tag_full -f docker/Dockerfile --platform linux/amd64 --build-arg APP_VERSION=$tag_version .
+docker build -t $core_tag_full -f docker/Dockerfile --platform linux/amd64 --build-arg APP_VERSION=$tag_version --build-arg BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S) .
 docker push $core_tag_full
 
 docker build -t $migrate_tag_full -f docker/migrate.Dockerfile --platform linux/amd64 .

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -126,7 +126,7 @@ services:
       # copy the init script inside the docker container where it will be executed
       # WARNING: It will only be executed when there is no data mounted to the container
       # If you want to execute it, down the container, delete the volume associated to it and up the container again, it should execute.
-      - ../bootstrapDB.sql:/docker-entrypoint-initdb.d/init.sql
+      - ../.devcontainer/postgresql:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_DB: docker
       POSTGRES_USER: docker

--- a/src/plugins/meta.ts
+++ b/src/plugins/meta.ts
@@ -12,6 +12,7 @@ import { SearchService } from '../services/item/plugins/publication/published/pl
 import { assertIsError } from '../utils/assertions';
 import {
   APP_VERSION,
+  BUILD_TIMESTAMP,
   EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN,
   ETHERPAD_URL,
 } from '../utils/config';
@@ -112,7 +113,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   fastify.get('/version', async (_, reply) => {
     // allow request cross origin
     reply.header('Access-Control-Allow-Origin', '*');
-    return APP_VERSION;
+    return `${APP_VERSION} @ ${BUILD_TIMESTAMP}`;
   });
 };
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -47,6 +47,7 @@ export const DEV = ENVIRONMENT === Environment.development;
 export const TEST = ENVIRONMENT === Environment.test;
 
 export const APP_VERSION = process.env.APP_VERSION;
+export const BUILD_TIMESTAMP = process.env.BUILD_TIMESTAMP;
 
 export const CLIENT_HOST = process.env.CLIENT_HOST ?? 'http://localhost:3114';
 


### PR DESCRIPTION
In this PR I

- Split the `build.sh` script up into the AWS auth part and the docker build and push part
- add the aws region to use when building an image
- fix some left over changes to the prod deploy workflow
- add a `BUILD_TIMESTAMP` env var that is set at build time so we can get when the image was built on the `/version` endpoint
- fix the volume mount for the db init script in the docker compose for self hosting

### How the dev deploy works now

When we merge to main, we build an image that we push to the private ECR of the dev environment.
It is tagged as `core-next`.

Every morning a workflow in infra is triggered and deploy this `core-next` with the migration.
So at the latest the next day, the changes will be on dev.

