### PR TITLE
fix: allow to post twice a like on an item

### DIFF
--- a/src/services/item/plugins/itemLike/itemLike.controller.test.ts
+++ b/src/services/item/plugins/itemLike/itemLike.controller.test.ts
@@ -325,6 +325,37 @@ describe('Item Like', () => {
         expect(savedLikes[1].creatorId).toEqual(actor.id);
       });
 
+      it('Allows to override like if already exist', async () => {
+        const {
+          actor,
+          items: [item],
+        } = await seedFromJson({
+          items: [
+            {
+              likes: ['actor'],
+              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            },
+          ],
+        });
+        assertIsDefined(actor);
+        assertIsMember(actor);
+        mockAuthenticate(actor);
+
+        const res = await app.inject({
+          method: HttpMethod.Post,
+          url: `/items/${item.id}/like`,
+        });
+        expect(res.statusCode).toBe(StatusCodes.OK);
+        // the creatorId should be the same
+        expect(res.json().creatorId).toEqual(actor.id);
+
+        // check received item like
+        // since we don't have full item, deduce from saved value
+        const savedLikes = await getItemLikesByItem(item.id);
+        expect(savedLikes).toHaveLength(1);
+        expect(savedLikes[0].creatorId).toEqual(actor.id);
+      });
+
       it('Cannot like item if does not have rights', async () => {
         const {
           actor,

--- a/src/services/item/plugins/itemLike/itemLike.controller.ts
+++ b/src/services/item/plugins/itemLike/itemLike.controller.ts
@@ -54,8 +54,8 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       } = request;
       const member = asDefined(user?.account);
       assertIsMember(member);
-      await db.transaction(async (tx) => {
-        await itemLikeService.post(tx, member, itemId);
+      return await db.transaction(async (tx) => {
+        const itemLike = await itemLikeService.post(tx, member, itemId);
         // action like item
         const item = await basicItemService.get(tx, member, itemId);
         const action = {
@@ -66,6 +66,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           },
         };
         await actionService.postMany(tx, member, request, [action]);
+        return itemLike;
       });
     },
   );

--- a/src/services/item/plugins/itemLike/itemLike.repository.ts
+++ b/src/services/item/plugins/itemLike/itemLike.repository.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import { and, eq } from 'drizzle-orm/sql';
 import { singleton } from 'tsyringe';
 
@@ -36,6 +37,10 @@ export class ItemLikeRepository {
     const result = await dbConnection
       .insert(itemLikesTable)
       .values({ itemId, creatorId })
+      .onConflictDoUpdate({
+        target: [itemLikesTable.itemId, itemLikesTable.creatorId],
+        set: { createdAt: sql.raw('DEFAULT') },
+      })
       .returning();
     if (result.length != 1) {
       throw new Error('Expected to receive, created item, but did not get it.');

--- a/src/services/item/plugins/itemLike/itemLike.schemas.ts
+++ b/src/services/item/plugins/itemLike/itemLike.schemas.ts
@@ -71,7 +71,7 @@ const rawItemLikeSchemaRef = registerSchemaAsRef(
       createdAt: customType.DateTime(),
     },
     {
-      description: 'Raw Like entry created when a member likes a published collection.',
+      description: 'Raw Like entry created when a member likes an item.',
     },
   ),
 );

--- a/src/services/item/plugins/itemLike/itemLike.schemas.ts
+++ b/src/services/item/plugins/itemLike/itemLike.schemas.ts
@@ -60,6 +60,22 @@ export const getLikesForItem = {
   },
 };
 
+const rawItemLikeSchemaRef = registerSchemaAsRef(
+  'rawItemLike',
+  'Raw Item Like',
+  customType.StrictObject(
+    {
+      id: customType.UUID(),
+      itemId: customType.UUID(),
+      creatorId: customType.UUID(),
+      createdAt: customType.DateTime(),
+    },
+    {
+      description: 'Raw Like entry created when a member likes a published collection.',
+    },
+  ),
+);
+
 export const create = {
   operationId: 'createItemLike',
   tags: ['like'],
@@ -70,7 +86,7 @@ export const create = {
     itemId: customType.UUID(),
   }),
   response: {
-    [StatusCodes.OK]: itemLikeSchemaRef,
+    [StatusCodes.OK]: rawItemLikeSchemaRef,
     '4xx': errorSchemaRef,
   },
 };


### PR DESCRIPTION
In this PR:
- fix #1863 
- add return data to the `POST item like` 
- allow to post twice 
- add a test that ensures this is allowed
