### PR TITLE
feat: move membership endpoints

### DIFF
--- a/API Collections/Item/Memberships/Delete membership.bru
+++ b/API Collections/Item/Memberships/Delete membership.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{host}}/item-memberships/{{item_id}}/{{membership_id}}
+  url: {{host}}/items/{{item_id}}/memberships/{{membership_id}}
   body: none
   auth: none
 }

--- a/API Collections/Item/Memberships/Get Item memberships.bru
+++ b/API Collections/Item/Memberships/Get Item memberships.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/item-memberships/?itemId={{item_id}}
+  url: {{host}}/items/{{item_id}}/memberships
   body: none
   auth: none
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,6 @@ import { schemaRegisterPlugin } from './plugins/typebox';
 import authPlugin from './services/auth';
 import { plugin as passportPlugin } from './services/auth/plugins/passport';
 import ItemServiceApi from './services/item';
-import ItemMembershipServiceApi from './services/itemMembership/membership.controller';
 import { maintenancePlugin } from './services/maintenance/maintenance.controller';
 import MemberServiceApi from './services/member';
 import tagPlugin from './services/tag/tag.controller';

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,7 +59,6 @@ export default async function (instance: FastifyInstance): Promise<void> {
       })
       .register(fp(MemberServiceApi))
       .register(fp(ItemServiceApi))
-      .register(fp(ItemMembershipServiceApi))
       .register(tagPlugin);
   });
 }

--- a/src/services/item/index.ts
+++ b/src/services/item/index.ts
@@ -12,6 +12,7 @@ import {
 } from '../../utils/config';
 import chatController from '../chat/chatMessage.controller';
 import graaspItemLogin from '../itemLogin/itemLogin.controller';
+import itemMembershipsPlugin from '../itemMembership/membership.controller';
 import itemController from './item.controller';
 import actionItemPlugin from './plugins/action/itemAction.controller';
 import graaspApps from './plugins/app/app.controller';
@@ -70,6 +71,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
       fastify.register(graaspFavoritePlugin);
 
       fastify.register(graaspItemPublish);
+
+      fastify.register(itemMembershipsPlugin);
 
       fastify.register(graaspShortcutPlugin);
 

--- a/src/services/item/index.ts
+++ b/src/services/item/index.ts
@@ -12,7 +12,7 @@ import {
 } from '../../utils/config';
 import chatController from '../chat/chatMessage.controller';
 import graaspItemLogin from '../itemLogin/itemLogin.controller';
-import itemMembershipsPlugin from '../itemMembership/membership.controller';
+import { itemMembershipsController } from '../itemMembership/membership.controller';
 import itemController from './item.controller';
 import actionItemPlugin from './plugins/action/itemAction.controller';
 import graaspApps from './plugins/app/app.controller';
@@ -72,7 +72,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
 
       fastify.register(graaspItemPublish);
 
-      fastify.register(itemMembershipsPlugin);
+      fastify.register(itemMembershipsController);
 
       fastify.register(graaspShortcutPlugin);
 

--- a/src/services/itemMembership/membership.controller.test.ts
+++ b/src/services/itemMembership/membership.controller.test.ts
@@ -53,7 +53,7 @@ describe('Membership routes tests', () => {
     app.close();
   });
 
-  describe('GET /item-memberships?itemId=<itemId>', () => {
+  describe('GET /items/:itemId/memberships', () => {
     it('Returns error if signed out', async () => {
       const {
         items: [item],
@@ -61,7 +61,7 @@ describe('Membership routes tests', () => {
 
       const response = await app.inject({
         method: HttpMethod.Get,
-        url: `/item-memberships?itemId=${item.id}`,
+        url: `/items/${item.id}/memberships`,
       });
 
       expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
@@ -82,7 +82,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
         });
         expect(response.statusCode).toBe(StatusCodes.OK);
 
@@ -93,124 +93,10 @@ describe('Membership routes tests', () => {
           expectMembership(im, m);
         }
       });
-      // WE DO NOT WANT TO SUPPORT GET MANY ANYMORE
-      // it('Returns successfully for two ids', async () => {
-      //   const {
-      //     actor,
-      //     items: [item1, item2],
-      //     itemMemberships,
-      //   } = await seedFromJson({
-      //     items: [
-      //       { memberships: [{ account: 'actor' }, { account: { name: 'bob' } }] },
-      //       { memberships: [{ account: 'actor' }, { account: { name: 'bob' } }] },
-      //     ],
-      //   });
-      //   assertIsDefined(actor);
-      //   assertIsMember(actor);
-      //   mockAuthenticate(actor);
-
-      //   const response = await app.inject({
-      //     method: HttpMethod.Get,
-      //     url: `/item-memberships?itemId=${item1.id}&itemId=${item2.id}`,
-      //   });
-      //   expect(response.statusCode).toBe(StatusCodes.OK);
-      //   const data = response.json();
-
-      //   for (const m of itemMemberships) {
-      //     const im = data.find(({ id }) => id === m.id);
-      //     expect(im).toBeTruthy();
-      //     expectMembership(im, m);
-      //   }
-      // });
-      //     it('Nested usecase', async () => {
-      //       // A (Membership)
-      //       // |-> B
-      //       //     |-> C (Membership)
-      //       //         |-> D
-      //       //             |-> E (Membership)
-
-      //       const {
-      //         actor,
-      //         items: [_itemA, itemB, _itemC, itemD, itemE, item2],
-      //         itemMemberships: [im1, im2, im3, im4, im5],
-      //       } = await seedFromJson({
-      //         items: [
-      //           {
-      //             name: 'A',
-      //             memberships: [
-      //               { account: 'actor', permission: PermissionLevel.Read },
-      //               { account: { name: 'bob' } },
-      //             ],
-      //             children: [
-      //               {
-      //                 name: 'B',
-      //                 children: [
-      //                   {
-      //                     name: 'C',
-      //                     memberships: [
-      //                       { account: 'actor', permission: PermissionLevel.Write },
-      //                       { account: { name: 'bob' } },
-      //                     ],
-      //                     children: [
-      //                       {
-      //                         name: 'D',
-      //                         children: [
-      //                           {
-      //                             name: 'E',
-      //                             memberships: [
-      //                               { account: 'actor', permission: PermissionLevel.Admin },
-      //                               { account: { name: 'bob' } },
-      //                             ],
-      //                           },
-      //                         ],
-      //                       },
-      //                     ],
-      //                   },
-      //                 ],
-      //               },
-      //             ],
-      //           },
-      //           // actor cannot access
-      //           { name: '2', memberships: [{ account: { name: 'bob' } }] },
-      //         ],
-      //       });
-      //       assertIsDefined(actor);
-      //       assertIsMember(actor);
-      //       mockAuthenticate(actor);
-      //       const memberships1 = [im1, im2];
-      //       const memberships2 = [im3];
-      //       const memberships3 = [im4, im5];
-      //       const response = await app.inject({
-      //         method: HttpMethod.Get,
-      //         url: `/item-memberships?itemId=${item2.id}&itemId=${itemB.id}&itemId=${itemD.id}&itemId=${itemE.id}`,
-      //       });
-      //       const { data, errors } = response.json();
-
-      //       expect(Object.keys(data)).toHaveLength(3);
-      //       expect(Object.keys(data)).not.toContain(item2.id);
-      //       expect(errors).toHaveLength(1);
-      //       expect(response.statusCode).toBe(StatusCodes.OK);
-
-      //       for (const m of memberships1) {
-      //         const im = data[itemB.id].find(({ id }) => id === m.id);
-      //         expect(im).toBeTruthy();
-      //         expectMembership(im, m, actor);
-      //       }
-      //       for (const m of memberships2) {
-      //         const im = data[itemD.id].find(({ id }) => id === m.id);
-      //         expect(im).toBeTruthy();
-      //         expectMembership(im, m, actor);
-      //       }
-      //       for (const m of memberships3) {
-      //         const im = data[itemE.id].find(({ id }) => id === m.id);
-      //         expect(im).toBeTruthy();
-      //         expectMembership(im, m, actor);
-      //       }
-      //     });
       it('Bad request for invalid id', async () => {
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: '/item-memberships?itemId=invalid-id',
+          url: `/items/invalid-id/memberships`,
         });
 
         expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
@@ -224,7 +110,7 @@ describe('Membership routes tests', () => {
         const itemId = v4();
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `/item-memberships?itemId=${itemId}`,
+          url: `/items/${itemId}/memberships`,
         });
 
         expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
@@ -241,7 +127,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
         });
         expect(response.statusCode).toBe(StatusCodes.FORBIDDEN);
         expect(response.json().message).toEqual(new MemberCannotAccess(item.id).message);
@@ -268,7 +154,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Get,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
         });
         const data = response.json();
         for (const m of itemMemberships) {
@@ -293,7 +179,7 @@ describe('Membership routes tests', () => {
       };
       const response = await app.inject({
         method: HttpMethod.Post,
-        url: `/item-memberships?itemId=${item.id}`,
+        url: `/items/${item.id}/memberships`,
         payload,
       });
       expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
@@ -316,7 +202,7 @@ describe('Membership routes tests', () => {
         };
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
           payload,
         });
         expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
@@ -360,7 +246,7 @@ describe('Membership routes tests', () => {
         const [_actorMembership, membership, anotherMembership] = itemMemberships;
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${parent.id}`,
+          url: `/items/${parent.id}/memberships`,
           payload: newMembership,
         });
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -404,7 +290,7 @@ describe('Membership routes tests', () => {
         };
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${targetItem.id}`,
+          url: `/items/${targetItem.id}/memberships`,
           payload,
         });
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -455,7 +341,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
           payload: {
             permission: PermissionLevel.Read,
             itemId: item.id,
@@ -495,7 +381,7 @@ describe('Membership routes tests', () => {
         };
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
           payload: newMembership,
         });
 
@@ -519,7 +405,7 @@ describe('Membership routes tests', () => {
         const id = 'invalid-id';
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${id}`,
+          url: `/items/${id}/memberships`,
           payload: {
             permission: PermissionLevel.Read,
             itemId: item.id,
@@ -545,7 +431,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Post,
-          url: `/item-memberships?itemId=${item.id}`,
+          url: `/items/${item.id}/memberships`,
           payload: {
             accountId: member.id,
             // missing permission
@@ -557,142 +443,18 @@ describe('Membership routes tests', () => {
       });
     });
   });
-  // describe('POST many /item-memberships/itemId', () => {
-  //   it('Throws if signed out', async () => {
-  //     const {
-  //       members,
-  //       items: [item],
-  //     } = await seedFromJson({
-  //       actor: null,
-  //       members: [{}],
-  //       items: [{}],
-  //     });
-
-  //     const response = await app.inject({
-  //       method: HttpMethod.Post,
-  //       url: `/item-memberships/${item.id}`,
-  //       payload: {
-  //         memberships: [
-  //           {
-  //             accountId: members[0].id,
-  //             itemId: item.id,
-  //             permission: PermissionLevel.Write,
-  //           },
-  //         ],
-  //       },
-  //     });
-  //     expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-  //   });
-  // describe('Signed In', () => {
-  //   it('Create new memberships successfully', async () => {
-  //     const mailerService = resolveDependency(MailerService);
-  //     const notificationMock = jest.spyOn(mailerService, 'sendRaw');
-  //     const {
-  //       actor,
-  //       members: [member1, member2],
-  //       items: [item],
-  //     } = await seedFromJson({
-  //       members: [{}, {}],
-  //       items: [
-  //         {
-  //           memberships: [{ account: 'actor' }],
-  //         },
-  //       ],
-  //     });
-  //     assertIsDefined(actor);
-  //     assertIsMember(actor);
-  //     mockAuthenticate(actor);
-  //     expect(await getMembershipsByItemPath(item.path)).toHaveLength(1);
-
-  //     const members = [member1, member2];
-  //     const newMemberships = [
-  //       { accountId: member1.id, permission: PermissionLevel.Read },
-  //       { accountId: member2.id, permission: PermissionLevel.Write },
-  //     ];
-  //     const response = await app.inject({
-  //       method: HttpMethod.Post,
-  //       url: `/item-memberships/${item.id}`,
-  //       payload: { memberships: newMemberships },
-  //     });
-  //     expect(response.statusCode).toBe(StatusCodes.OK);
-
-  //     expect(await getMembershipsByItemPath(item.path)).toHaveLength(3);
-  //     const savedMemberships = await getMembershipsByItemPath(item.path);
-  //     newMemberships.forEach((m) => {
-  //       const member = members.find(({ id: thisId }) => thisId === m.accountId);
-  //       const im = savedMemberships.find(({ accountId }) => accountId === m.accountId);
-  //       expect(im).toBeDefined();
-  //     });
-  //     expect(notificationMock).toHaveBeenCalledTimes(newMemberships.length);
-  //   });
-  //     it('Bad Request for invalid id', async () => {
-  //       const {
-  //         actor,
-  //         members: [member],
-  //       } = await seedFromJson({
-  //         members: [{}],
-  //         items: [
-  //           {
-  //             memberships: [{ account: 'actor' }],
-  //           },
-  //         ],
-  //       });
-  //       mockAuthenticate(actor);
-  //       const id = 'invalid-id';
-  //       const newMemberships = [
-  //         { accountId: member.id, permission: PermissionLevel.Read },
-  //         { accountId: member.id, permission: PermissionLevel.Write },
-  //       ];
-  //       const response = await app.inject({
-  //         method: HttpMethod.Post,
-  //         url: `/item-memberships/${id}`,
-  //         payload: { memberships: newMemberships },
-  //       });
-  //       expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
-  //       expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
-  //     });
-  //     it('Return error array for invalid payload', async () => {
-  //       const {
-  //         actor,
-  //         members: [member],
-  //         items: [item],
-  //       } = await seedFromJson({
-  //         members: [{}],
-  //         items: [
-  //           {
-  //             memberships: [{ account: 'actor' }],
-  //           },
-  //         ],
-  //       });
-  //       mockAuthenticate(actor);
-  //       const response = await app.inject({
-  //         method: HttpMethod.Post,
-  //         url: `/item-memberships/${item.id}`,
-  //         payload: {
-  //           memberships: [
-  //             {
-  //               accountId: member.id,
-  //               // missing permission
-  //             },
-  //           ],
-  //         },
-  //       });
-  //       expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
-  //       expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
-  //     });
-  //   });
-  // });
   describe('PATCH /item-memberships/:id', () => {
     it('Throws if signed out', async () => {
       const {
         itemMemberships: [itemMembership],
+        items: [item],
       } = await seedFromJson({ items: [{ memberships: [{ account: 'actor' }] }] });
       const payload = {
         permission: PermissionLevel.Write,
       };
       const response = await app.inject({
         method: HttpMethod.Patch,
-        url: `/item-memberships/${itemMembership.id}`,
+        url: `/items/${item.id}/memberships/${itemMembership.id}`,
         payload,
       });
       expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
@@ -728,7 +490,7 @@ describe('Membership routes tests', () => {
         };
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${writeMembership.id}`,
+          url: `/items/${child.id}/memberships/${writeMembership.id}`,
           payload: newMembership,
         });
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -761,7 +523,7 @@ describe('Membership routes tests', () => {
         };
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${membership.id}`,
+          url: `/items/${item.id}/memberships/${membership.id}`,
           payload: newMembership,
         });
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -801,7 +563,7 @@ describe('Membership routes tests', () => {
         const newMembership = { permission: PermissionLevel.Write };
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${readMembership.id}`,
+          url: `/items/${parent.id}/memberships/${readMembership.id}`,
           payload: newMembership,
         });
         expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -816,7 +578,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${v4()}`,
+          url: `/items/${v4()}/memberships/${v4()}`,
           payload: { permission: 'permission' },
         });
         expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
@@ -830,7 +592,7 @@ describe('Membership routes tests', () => {
         const id = 'invalid-id';
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${id}`,
+          url: `/items/${id}/memberships/${id}`,
           payload: { permission: PermissionLevel.Write },
         });
         expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
@@ -840,6 +602,7 @@ describe('Membership routes tests', () => {
         const {
           actor,
           members: [member],
+          items: [_parent, child],
           itemMemberships: [_actorMembership, _writeMembership, adminMembership],
         } = await seedFromJson({
           items: [
@@ -861,7 +624,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${adminMembership.id}`,
+          url: `/items/${child.id}/memberships/${adminMembership.id}`,
           payload: {
             permission: PermissionLevel.Read,
             accountId: member.id,
@@ -874,6 +637,7 @@ describe('Membership routes tests', () => {
         const {
           actor,
           guests: [guest],
+          items: [item],
           itemMemberships: [_actorMembership, guestMembership],
         } = await seedFromJson({
           items: [
@@ -894,7 +658,7 @@ describe('Membership routes tests', () => {
         };
         const response = await app.inject({
           method: HttpMethod.Patch,
-          url: `/item-memberships/${guestMembership.id}`,
+          url: `/items/${item.id}/memberships/${guestMembership.id}`,
           payload: newMembership,
         });
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
@@ -904,6 +668,7 @@ describe('Membership routes tests', () => {
   describe('DELETE /item-memberships/:id?purgeBelow=<boolean>', () => {
     it('Throws if signed out', async () => {
       const {
+        items: [item],
         itemMemberships: [itemMembership],
       } = await seedFromJson({
         actor: null,
@@ -911,7 +676,7 @@ describe('Membership routes tests', () => {
       });
       const response = await app.inject({
         method: HttpMethod.Delete,
-        url: `/item-memberships/${itemMembership.id}`,
+        url: `/items/${item.id}/memberships/${itemMembership.id}`,
       });
       expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
     });
@@ -919,6 +684,7 @@ describe('Membership routes tests', () => {
       it('Delete successfully', async () => {
         const {
           actor,
+          items: [item],
           itemMemberships: [_actorMembership, membership, lowerMembership],
         } = await seedFromJson({
           items: [
@@ -939,7 +705,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${membership.id}`,
+          url: `/items/${item.id}/memberships/${membership.id}`,
         });
         expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
 
@@ -950,6 +716,7 @@ describe('Membership routes tests', () => {
       it('Delete successfully with purgeBelow=true', async () => {
         const {
           actor,
+          items: [item],
           itemMemberships: [_actorMembership, membership, lowerMembership],
         } = await seedFromJson({
           items: [
@@ -969,7 +736,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${membership.id}?purgeBelow=true`,
+          url: `/items/${item.id}/memberships/${membership.id}?purgeBelow=true`,
         });
         expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);
 
@@ -985,20 +752,23 @@ describe('Membership routes tests', () => {
         const id = 'invalid-id';
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${id}`,
+          url: `/items/${v4()}/memberships/${id}`,
         });
         expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
         expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
       });
       it('Cannot delete membership if does not exist', async () => {
-        const { actor } = await seedFromJson({ items: [{ memberships: [{ account: 'actor' }] }] });
+        const {
+          actor,
+          items: [item],
+        } = await seedFromJson({ items: [{ memberships: [{ account: 'actor' }] }] });
         assertIsDefined(actor);
         mockAuthenticate(actor);
 
         const id = v4();
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${id}`,
+          url: `/items/${item.id}/memberships/${id}`,
         });
         expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
         expect(response.json()).toEqual(new ItemMembershipNotFound({ id }));
@@ -1023,7 +793,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${membership.id}`,
+          url: `/items/${item.id}/memberships/${membership.id}`,
         });
         expect(response.statusCode).toEqual(StatusCodes.FORBIDDEN);
         expect(response.json()).toEqual(new MemberCannotAdminItem(item.id));
@@ -1049,7 +819,7 @@ describe('Membership routes tests', () => {
 
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${membership.id}`,
+          url: `/items/${item.id}/memberships/${membership.id}`,
         });
         expect(response.statusCode).toEqual(StatusCodes.FORBIDDEN);
         expect(response.json()).toEqual(new MemberCannotAdminItem(item.id));
@@ -1058,6 +828,7 @@ describe('Membership routes tests', () => {
       it('Cannot delete last admin membership', async () => {
         const {
           actor,
+          items: [item],
           itemMemberships: [membership],
         } = await seedFromJson({
           items: [
@@ -1070,7 +841,7 @@ describe('Membership routes tests', () => {
         mockAuthenticate(actor);
         const response = await app.inject({
           method: HttpMethod.Delete,
-          url: `/item-memberships/${membership.id}`,
+          url: `/items/${item.id}/memberships/${membership.id}`,
         });
         expect(response.statusCode).toEqual(StatusCodes.FORBIDDEN);
         expect(response.json()).toMatchObject(new CannotDeleteOnlyAdmin({ id: expect.anything() }));

--- a/src/services/itemMembership/membership.controller.test.ts
+++ b/src/services/itemMembership/membership.controller.test.ts
@@ -443,7 +443,7 @@ describe('Membership routes tests', () => {
       });
     });
   });
-  describe('PATCH /item-memberships/:id', () => {
+  describe('PATCH /items/:id/memberships/:id', () => {
     it('Throws if signed out', async () => {
       const {
         itemMemberships: [itemMembership],
@@ -665,7 +665,7 @@ describe('Membership routes tests', () => {
       });
     });
   });
-  describe('DELETE /item-memberships/:id?purgeBelow=<boolean>', () => {
+  describe('DELETE /items/:id/memberships/:id?purgeBelow=<boolean>', () => {
     it('Throws if signed out', async () => {
       const {
         items: [item],

--- a/src/services/itemMembership/membership.controller.test.ts
+++ b/src/services/itemMembership/membership.controller.test.ts
@@ -166,7 +166,7 @@ describe('Membership routes tests', () => {
       });
     });
   });
-  describe('POST /item-memberships', () => {
+  describe('POST /items/:id/memberships', () => {
     it('Throws if signed out', async () => {
       const {
         members: [member],

--- a/src/services/itemMembership/membership.controller.ts
+++ b/src/services/itemMembership/membership.controller.ts
@@ -1,6 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { fastifyCors } from '@fastify/cors';
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
 import { resolveDependency } from '../../di/utils';
@@ -14,23 +13,16 @@ import { ItemMembershipService } from './membership.service';
 import MembershipRequestAPI from './plugins/MembershipRequest/membershipRequest.controller';
 import { membershipWsHooks } from './ws/hooks';
 
-const ROUTES_PREFIX = '/item-memberships';
-
 const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   const itemMembershipService = resolveDependency(ItemMembershipService);
 
   fastify.register(MembershipRequestAPI, {
-    prefix: '/items/:itemId/memberships/requests',
+    prefix: '/:itemId/memberships/requests',
   });
 
   // routes
   fastify.register(
     async function (fastify: FastifyInstanceTypebox) {
-      // add CORS support
-      if (fastify.corsPluginOptions) {
-        fastify.register(fastifyCors, fastify.corsPluginOptions);
-      }
-
       fastify.register(membershipWsHooks);
 
       // get many item's memberships
@@ -94,7 +86,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         },
       );
     },
-    { prefix: ROUTES_PREFIX },
+    { prefix: '/:itemId/memberships' },
   );
 };
 

--- a/src/services/itemMembership/membership.controller.ts
+++ b/src/services/itemMembership/membership.controller.ts
@@ -30,7 +30,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       fastify.get(
         '/',
         { schema: getItemMembershipsForItem, preHandler: optionalIsAuthenticated },
-        async ({ user, query: { itemId } }) => {
+        async ({ user, params: { itemId } }) => {
           return itemMembershipService.getForItem(db, user?.account, itemId);
         },
       );
@@ -42,7 +42,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           schema: create,
           preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
         },
-        async ({ user, query: { itemId }, body }, reply) => {
+        async ({ user, params: { itemId }, body }, reply) => {
           const account = asDefined(user?.account);
           await db.transaction(async (tx) => {
             await itemMembershipService.create(tx, account, {

--- a/src/services/itemMembership/membership.controller.ts
+++ b/src/services/itemMembership/membership.controller.ts
@@ -28,7 +28,7 @@ export const itemMembershipsController: FastifyPluginAsyncTypebox = async (fasti
       // get many item's memberships
       // returns empty for item not found
       fastify.get(
-        '/',
+        '',
         { schema: getItemMembershipsForItem, preHandler: optionalIsAuthenticated },
         async ({ user, params: { itemId } }) => {
           return itemMembershipService.getForItem(db, user?.account, itemId);
@@ -37,7 +37,7 @@ export const itemMembershipsController: FastifyPluginAsyncTypebox = async (fasti
 
       // create item membership
       fastify.post(
-        '/',
+        '',
         {
           schema: create,
           preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],

--- a/src/services/itemMembership/membership.controller.ts
+++ b/src/services/itemMembership/membership.controller.ts
@@ -13,17 +13,17 @@ import { ItemMembershipService } from './membership.service';
 import MembershipRequestAPI from './plugins/MembershipRequest/membershipRequest.controller';
 import { membershipWsHooks } from './ws/hooks';
 
-const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
+export const itemMembershipsController: FastifyPluginAsyncTypebox = async (fastify) => {
   const itemMembershipService = resolveDependency(ItemMembershipService);
-
-  fastify.register(MembershipRequestAPI, {
-    prefix: '/:itemId/memberships/requests',
-  });
 
   // routes
   fastify.register(
     async function (fastify: FastifyInstanceTypebox) {
       fastify.register(membershipWsHooks);
+
+      fastify.register(MembershipRequestAPI, {
+        prefix: '/requests',
+      });
 
       // get many item's memberships
       // returns empty for item not found
@@ -89,5 +89,3 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     { prefix: '/:itemId/memberships' },
   );
 };
-
-export default plugin;

--- a/src/services/itemMembership/membership.schemas.ts
+++ b/src/services/itemMembership/membership.schemas.ts
@@ -97,6 +97,7 @@ export const updateOne = {
 
   params: customType.StrictObject({
     id: customType.UUID(),
+    itemId: customType.UUID(),
   }),
   body: customType.StrictObject({
     permission: customType.EnumString(Object.values(PermissionLevel)),
@@ -116,6 +117,7 @@ export const deleteOne = {
 
   params: customType.StrictObject({
     id: customType.UUID(),
+    itemId: customType.UUID(),
   }),
   querystring: customType.StrictObject({
     purgeBelow: Type.Optional(Type.Boolean()),

--- a/src/services/itemMembership/membership.schemas.ts
+++ b/src/services/itemMembership/membership.schemas.ts
@@ -63,7 +63,7 @@ export const create = {
   summary: 'Create access to item for account',
   description: 'Create access to item for account, given permission',
 
-  querystring: customType.StrictObject({
+  params: customType.StrictObject({
     itemId: customType.UUID(),
   }),
   body: createItemMembershipSchema,
@@ -79,7 +79,7 @@ export const getItemMembershipsForItem = {
   summary: 'Get memberships for one item',
   description: 'Get memberships for one item',
 
-  querystring: customType.StrictObject({
+  params: customType.StrictObject({
     itemId: customType.UUID(),
   }),
   response: {

--- a/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
@@ -34,7 +34,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   const authorizationService = resolveDependency(AuthorizationService);
 
   fastify.get(
-    '/',
+    '',
     {
       schema: getAllByItem,
       preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
@@ -91,7 +91,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   );
 
   fastify.post(
-    '/',
+    '',
     {
       schema: createOne,
       preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],

--- a/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
@@ -1,6 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { fastifyCors } from '@fastify/cors';
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
 import { MembershipRequestStatus, PermissionLevel } from '@graasp/sdk';

--- a/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
@@ -34,10 +34,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   const itemLoginService = resolveDependency(ItemLoginService);
   const authorizationService = resolveDependency(AuthorizationService);
 
-  if (fastify.corsPluginOptions) {
-    await fastify.register(fastifyCors, fastify.corsPluginOptions);
-  }
-
   fastify.get(
     '/',
     {

--- a/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.schemas.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.schemas.ts
@@ -28,6 +28,7 @@ export const simpleMembershipRequestSchemaRef = registerSchemaAsRef(
 );
 
 export const getAllByItem = {
+  operationId: 'getMembershipRequestsByItemId',
   tags: ['membership-request'],
   summary: 'Get all membership requests for an item',
   description: 'Get all membership requests with member information for an item by its ID',
@@ -42,6 +43,7 @@ export const getAllByItem = {
 } as const satisfies FastifySchema;
 
 export const createOne = {
+  operationId: 'createMembershipRequest',
   tags: ['membership-request'],
   summary: 'Create a membership request',
   description: `Create a membership request for an item with the authenticated member.
@@ -56,6 +58,7 @@ export const createOne = {
 } as const satisfies FastifySchema;
 
 export const getOwn = {
+  operationId: 'getOwnMembershipRequestByItemId',
   tags: ['membership-request'],
   summary: 'Get the status of the membership request for the authenticated member',
   description:
@@ -71,6 +74,7 @@ export const getOwn = {
 } as const satisfies FastifySchema;
 
 export const deleteOne = {
+  operationId: 'deleteMembershipRequest',
   tags: ['membership-request'],
   summary: 'Delete a membership request',
   description: 'Delete a membership request from a member id and an item id.',

--- a/src/services/itemMembership/ws/ws.test.ts
+++ b/src/services/itemMembership/ws/ws.test.ts
@@ -151,7 +151,7 @@ describe('Item websocket hooks', () => {
 
       const response = await app.inject({
         method: HttpMethod.Patch,
-        url: `/item-memberships/${membership.id}`,
+        url: `/items/${item.id}memberships/${membership.id}`,
         payload: { permission: PermissionLevel.Admin },
       });
       expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -196,7 +196,7 @@ describe('Item websocket hooks', () => {
 
       const response = await app.inject({
         method: HttpMethod.Delete,
-        url: `/item-memberships/${membership.id}`,
+        url: `/items/${item.id}/memberships/${membership.id}`,
       });
       expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
 

--- a/src/services/itemMembership/ws/ws.test.ts
+++ b/src/services/itemMembership/ws/ws.test.ts
@@ -110,7 +110,7 @@ describe('Item websocket hooks', () => {
       const payload = { accountId: bob.id, permission: PermissionLevel.Read };
       const response = await app.inject({
         method: HttpMethod.Post,
-        url: `/item-memberships?itemId=${item.id}`,
+        url: `/items/${item.id}/memberships`,
         payload,
       });
       expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
@@ -151,7 +151,7 @@ describe('Item websocket hooks', () => {
 
       const response = await app.inject({
         method: HttpMethod.Patch,
-        url: `/items/${item.id}memberships/${membership.id}`,
+        url: `/items/${item.id}/memberships/${membership.id}`,
         payload: { permission: PermissionLevel.Admin },
       });
       expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);


### PR DESCRIPTION
Move membership endpoints inside items to have the following route: `items/:id/memberships`
This allows to remove cors options.