### PR TITLE
chore(sonar-cloud): use a fixed tag for the builder base image in the migration docker file

### DIFF
--- a/docker/migrate.Dockerfile
+++ b/docker/migrate.Dockerfile
@@ -1,5 +1,5 @@
 # -----> Build image
-FROM node:latest AS build
+FROM node:22.14.0-bookworm AS build
 # update packages and install the minimal init system "dumb-init"
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 


### PR DESCRIPTION
In this PR I fix [an issue related to the use of the `node:latest` tag in the migration Docker file](https://sonarcloud.io/project/issues?open=AZZDc6BjseWYDCZo2X5D&id=graasp_graasp).

It is best practice to use a specific version in order to ensure consistency.
