### PR TITLE
chore(dev): use hostnames instead of container names

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 {
   "name": "Node.js & PostgreSQL",
   "dockerComposeFile": "docker-compose.yml",
-  "service": "app",
+  "service": "core",
   "workspaceFolder": "/workspace",
   // Set *default* container specific settings.json values on container create.
   "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 services:
-  app:
-    container_name: graasp-core
+  core:
+    hostname: core
     build:
       context: .
       dockerfile: Dockerfile
@@ -43,7 +43,7 @@ services:
       # the Localstack config is set by the "localstack" service below
       S3_FILE_ITEM_HOST: http://localstack:4566
       # the Iframely config is set by the "iframely" service below
-      EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN: http://graasp-iframely:8061
+      EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN: http://iframely:8061
 
     volumes:
       - ..:/workspace:cached
@@ -54,7 +54,7 @@ services:
       - 3000:3000
 
   db:
-    container_name: db
+    hostname: db
     image: postgres:15.8-alpine
     restart: on-failure
     ports:
@@ -73,12 +73,12 @@ services:
       retries: 5
 
   redis:
-    container_name: graasp-redis
+    hostname: redis
     image: redis
     restart: on-failure
 
   etherpad:
-    container_name: graasp-etherpad
+    hostname: etherpad
     image: etherpad/etherpad
     # start the server with dev API key
     # https://hub.docker.com/r/etherpad/etherpad/dockerfile
@@ -105,7 +105,7 @@ services:
       - db
 
   meilisearch:
-    container_name: graasp-meilisearch
+    hostname: meilisearch
     image: getmeili/meilisearch:v1.8
     restart: on-failure
     environment:
@@ -121,7 +121,7 @@ services:
       - ./meilisearch_data:/meili_data
 
   umami:
-    container_name: umami
+    hostname: umami
     image: ghcr.io/umami-software/umami:postgresql-latest
     environment:
       DATABASE_URL: postgresql://umami:umami@db:5432/umami
@@ -141,7 +141,7 @@ services:
 
   # Localstack is used to test aws services locally
   localstack:
-    container_name: graasp-localstack
+    hostname: localstack
     image: localstack/localstack
     volumes:
       - ../tmp:/tmp/graasp-localstack
@@ -156,7 +156,7 @@ services:
       - 4566-4583:4566-4583
 
   localfile:
-    container_name: localfile
+    hostname: localfile
     image: joseluisq/static-web-server:2
     environment:
       # Note: those envs are customizable but also optional
@@ -170,7 +170,7 @@ services:
 
   # necessary for graasp-embedded-link-item
   iframely:
-    container_name: graasp-iframely
+    hostname: iframely
     image: graasp/iframely:latest
     environment:
       NODE_ENV: production # required in order for the responses to not timeout
@@ -180,7 +180,7 @@ services:
 
   # necessary for validation
   nudenet:
-    container_name: graasp-nudenet
+    hostname: nudenet
     image: notaitech/nudenet:classifier
     # exposing these ports is not necessary
     # ports:
@@ -188,7 +188,7 @@ services:
 
   # a mock mailbox on port 1025 (web UI at http://localhost:1080)
   mailer:
-    container_name: mailer
+    hostname: mailer
     image: schickling/mailcatcher
     ports:
       - "1080:1080"


### PR DESCRIPTION
In this PR I propose to change the way container are defined in the devcontainer file.

## The issue

Currently the compose file used to scaffold the dev environment uses the `container_name` property to name containers.
This allows use to have nice container names like `etherpad` instead of `etherpad-1` (autoamtic name given by docker). 

But this also means that it throws an error if we try to run another devcontainer that has the same container names (e.g. another branch or a fork). Docker complains that containers names need to be unique and `etherpad` is already in use.

Currently the solution is to delete the offending container inside the docker desktop app and relaunch the devcontainer. But this is cumbersome to do every time you want to switch

## Solution

We can use the `hostname` property that allows containers to have a defined hostname so we can talk to them.
This does not affect the container name that will be chosen by docker (usually `etherpad-1` or somthing) but inside the docker network we will be able to talk to etherpad via `http://etherpad` which is convenient.

## Changes required for developers

- Rebuild the devcontainer
- Check your overrides for the following service urls:
   - `EMBEDDED_LINK_ITEM_IFRAMELY_HREF_ORIGIN`: `http://graasp-iframely:8061` -> `http://iframely:8061`

