### PR TITLE
fix: add endpoint for featured collections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ env:
   # random keys
   APPS_JWT_SECRET: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   APPS_PUBLISHER_ID: 9c9cea73-f3b7-48a3-aa6e-ead82c0685e7 # mock uuid
+  GRAASPER_CREATOR_ID: bbbf7cac-6139-45e4-8fbf-4cf767b50b29 # mock uuid
   AUTH_TOKEN_JWT_SECRET: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   COOKIE_DOMAIN: localhost
   CLIENT_HOST: http://localhost:3114

--- a/src/services/item/plugins/publication/published/plugins/search/search.controller.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.controller.test.ts
@@ -18,7 +18,7 @@ import { db } from '../../../../../../../drizzle/db';
 import { itemsRawTable } from '../../../../../../../drizzle/schema';
 import { type ItemRaw } from '../../../../../../../drizzle/types';
 import { assertIsDefined } from '../../../../../../../utils/assertions';
-import { ITEMS_ROUTE_PREFIX } from '../../../../../../../utils/config';
+import { GRAASPER_CREATOR_ID, ITEMS_ROUTE_PREFIX } from '../../../../../../../utils/config';
 import { MeiliSearchWrapper } from './meilisearch';
 
 jest.mock('./meilisearch');
@@ -495,6 +495,117 @@ describe('Collection Search endpoints', () => {
 
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(res.json()).toEqual(fakeResponse.results[0].facetDistribution.discipline);
+    });
+  });
+
+  describe('GET /collections/featured', () => {
+    it('get featured collections', async () => {
+      // Meilisearch is mocked so format of API doesn't matter, we just want it to proxy MultiSearchParams;
+      const fakeResponse = {
+        results: [
+          {
+            indexUid: 'index',
+            hits: [
+              {
+                name: 'Geogebra',
+                description: 'Interactive tools from geogebra for mathematics.',
+                content: '',
+                creator: {
+                  id: GRAASPER_CREATOR_ID,
+                  name: 'Graasper',
+                },
+                level: [],
+                discipline: [],
+                'resource-type': [],
+                id: v4(),
+                type: 'folder',
+                isPublishedRoot: true,
+                isHidden: false,
+                publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                createdAt: '2021-10-20T13:12:47.821Z',
+                updatedAt: '2021-10-23T09:25:39.798Z',
+                lang: 'en',
+                likes: 9,
+                _formatted: {
+                  name: 'Geogebra',
+                  description: 'Interactive tools from geogebra for mathematics.',
+                  content: '',
+                  creator: {
+                    id: GRAASPER_CREATOR_ID,
+                    name: 'Graasper',
+                  },
+                  level: [],
+                  discipline: [],
+                  'resource-type': [],
+                  id: v4(),
+                  type: 'folder',
+                  isPublishedRoot: true,
+                  isHidden: false,
+                  publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                  createdAt: '2021-10-20T13:12:47.821Z',
+                  updatedAt: '2021-10-23T09:25:39.798Z',
+                  lang: 'en',
+                  likes: 9,
+                },
+              },
+              {
+                name: 'PhET',
+                content: '',
+                description: '',
+                creator: {
+                  id: GRAASPER_CREATOR_ID,
+                  name: 'Graasper',
+                },
+                level: [],
+                discipline: [],
+                'resource-type': [],
+                id: v4(),
+                type: 'folder',
+                isPublishedRoot: true,
+                isHidden: false,
+                publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                createdAt: '2021-10-20T13:03:42.712Z',
+                updatedAt: '2021-11-10T10:49:39.296Z',
+                lang: 'en',
+                likes: 7,
+                _formatted: {
+                  name: 'PhET',
+                  description: '',
+                  content: '',
+                  creator: {
+                    id: GRAASPER_CREATOR_ID,
+                    name: 'Graasper',
+                  },
+                  level: [],
+                  discipline: [],
+                  'resource-type': [],
+                  id: v4(),
+                  type: 'folder',
+                  isPublishedRoot: true,
+                  isHidden: false,
+                  publicationUpdatedAt: '2021-10-20T13:03:42.712Z',
+                  createdAt: '2021-10-20T13:03:42.712Z',
+                  updatedAt: '2021-11-10T10:49:39.296Z',
+                  lang: 'en',
+                  likes: 7,
+                },
+              },
+            ] as never[],
+            processingTimeMs: 123,
+            query: '',
+          },
+        ],
+      };
+      jest.spyOn(MeiliSearchWrapper.prototype, 'search').mockResolvedValue(fakeResponse);
+      const res = await app.inject({
+        method: HttpMethod.Get,
+        url: `${ITEMS_ROUTE_PREFIX}/collections/featured`,
+      });
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      // The creator should be Graasp (GRAASPER_CREATOR_ID)
+      res.json().hits.forEach(({ creator }) => {
+        expect(creator.id).toEqual(GRAASPER_CREATOR_ID);
+      });
     });
   });
 

--- a/src/services/item/plugins/publication/published/plugins/search/search.controller.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.controller.ts
@@ -6,10 +6,10 @@ import { ActionTriggers } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../../../../di/utils';
 import { db } from '../../../../../../../drizzle/db';
-import { MEILISEARCH_REBUILD_SECRET } from '../../../../../../../utils/config';
+import { GRAASPER_CREATOR_ID, MEILISEARCH_REBUILD_SECRET } from '../../../../../../../utils/config';
 import { ActionService } from '../../../../../../action/action.service';
 import { optionalIsAuthenticated } from '../../../../../../auth/plugins/passport';
-import { getFacets, getMostLiked, getMostRecent, search } from './search.schemas';
+import { getFacets, getFeatured, getMostLiked, getMostRecent, search } from './search.schemas';
 import { SearchService } from './search.service';
 
 export type SearchFields = {
@@ -48,6 +48,15 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     async (request) => {
       const { body, query } = request;
       const searchResults = await searchService.getFacets(query.facetName, body);
+      return searchResults;
+    },
+  );
+
+  fastify.get(
+    '/collections/featured',
+    { preHandler: optionalIsAuthenticated, schema: getFeatured },
+    async ({ query }) => {
+      const searchResults = await searchService.getFeatured(GRAASPER_CREATOR_ID, query.limit);
       return searchResults;
     },
   );

--- a/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
@@ -8,6 +8,7 @@ import { ItemType, TagCategory } from '@graasp/sdk';
 import { customType, registerSchemaAsRef } from '../../../../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../../../../schemas/global';
 import {
+  GET_FEATURED_ITEMS_MAXIMUM,
   GET_MOST_LIKED_ITEMS_MAXIMUM,
   GET_MOST_RECENT_ITEMS_MAXIMUM,
 } from '../../../../../../../utils/config';
@@ -106,7 +107,7 @@ export const getFeatured = {
 
   querystring: customType.StrictObject({
     limit: Type.Optional(
-      Type.Number({ minimum: 1, maximum: GET_MOST_LIKED_ITEMS_MAXIMUM, default: 12 }),
+      Type.Number({ minimum: 1, maximum: GET_FEATURED_ITEMS_MAXIMUM, default: 12 }),
     ),
   }),
   response: {

--- a/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
@@ -98,6 +98,23 @@ export const search = {
   },
 } as const satisfies FastifySchema;
 
+export const getFeatured = {
+  operationId: 'getFeaturedCollections',
+  tags: ['collection'],
+  summary: 'Get featured collections',
+  description: 'Get collections that we want to feature on the library home page.',
+
+  querystring: customType.StrictObject({
+    limit: Type.Optional(
+      Type.Number({ minimum: 1, maximum: GET_MOST_LIKED_ITEMS_MAXIMUM, default: 12 }),
+    ),
+  }),
+  response: {
+    [StatusCodes.OK]: meilisearchSearchResponseSchema,
+    '4xx': errorSchemaRef,
+  },
+} as const satisfies FastifySchema;
+
 export const getMostLiked = {
   operationId: 'getMostLikedCollections',
   tags: ['collection', 'like'],

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
@@ -185,7 +185,7 @@ describe('getFeatured', () => {
     expect(creatorId).toEqual(GRAASPER_CREATOR_ID);
     // verify arguments passed to the meilisearch API
     const { sort, hitsPerPage } = spy.mock.calls[0][0].queries[0];
-    expect(sort).toEqual(['publicationUpdatedAt:desc']);
+    expect(sort).toEqual(['name:asc']);
     expect(hitsPerPage).toEqual(4);
   });
 });

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
@@ -184,9 +184,9 @@ describe('getFeatured', () => {
     const { creatorId } = serviceSpy.mock.calls[0][0];
     expect(creatorId).toEqual(GRAASPER_CREATOR_ID);
     // verify arguments passed to the meilisearch API
-    const { sort, limit } = spy.mock.calls[0][0].queries[0];
+    const { sort, hitsPerPage } = spy.mock.calls[0][0].queries[0];
     expect(sort).toEqual(['publicationUpdatedAt:desc']);
-    expect(limit).toEqual(4);
+    expect(hitsPerPage).toEqual(4);
   });
 });
 

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
@@ -1,6 +1,7 @@
 import { v4 } from 'uuid';
 
 import { MOCK_LOGGER } from '../../../../../../../../test/app';
+import { GRAASPER_CREATOR_ID } from '../../../../../../../utils/config';
 import HookManager from '../../../../../../../utils/hook';
 import { ItemService } from '../../../../../item.service';
 import { ItemPublishedService } from '../../itemPublished.service';
@@ -159,6 +160,30 @@ describe('getMostRecent', () => {
     const results = await searchService.getMostRecent(4);
     expect(results).toEqual(MOCK_RESULT);
 
+    const { sort, limit } = spy.mock.calls[0][0].queries[0];
+    expect(sort).toEqual(['publicationUpdatedAt:desc']);
+    expect(limit).toEqual(4);
+  });
+});
+
+describe('getFeatured', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('apply creator and sort by publication updatedAt', async () => {
+    const MOCK_RESULT = { hits: [] } as never;
+    const spy = jest
+      .spyOn(meilisearchClient, 'search')
+      .mockResolvedValue({ results: [MOCK_RESULT] });
+    const serviceSpy = jest.spyOn(searchService, 'search');
+
+    const results = await searchService.getFeatured(GRAASPER_CREATOR_ID, 4);
+    expect(results).toEqual(MOCK_RESULT);
+
+    // verify the arguments passed to the search function inside the service
+    const { creatorId } = serviceSpy.mock.calls[0][0];
+    expect(creatorId).toEqual(GRAASPER_CREATOR_ID);
+    // verify arguments passed to the meilisearch API
     const { sort, limit } = spy.mock.calls[0][0].queries[0];
     expect(sort).toEqual(['publicationUpdatedAt:desc']);
     expect(limit).toEqual(4);

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
@@ -141,9 +141,9 @@ describe('getMostLiked', () => {
     const results = await searchService.getMostLiked(4);
     expect(results).toEqual(MOCK_RESULT);
 
-    const { sort, limit } = spy.mock.calls[0][0].queries[0];
+    const { sort, hitsPerPage } = spy.mock.calls[0][0].queries[0];
     expect(sort).toEqual(['likes:desc']);
-    expect(limit).toEqual(4);
+    expect(hitsPerPage).toEqual(4);
   });
 });
 
@@ -160,9 +160,9 @@ describe('getMostRecent', () => {
     const results = await searchService.getMostRecent(4);
     expect(results).toEqual(MOCK_RESULT);
 
-    const { sort, limit } = spy.mock.calls[0][0].queries[0];
+    const { sort, hitsPerPage } = spy.mock.calls[0][0].queries[0];
     expect(sort).toEqual(['publicationUpdatedAt:desc']);
-    expect(limit).toEqual(4);
+    expect(hitsPerPage).toEqual(4);
   });
 });
 

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.test.ts
@@ -141,9 +141,9 @@ describe('getMostLiked', () => {
     const results = await searchService.getMostLiked(4);
     expect(results).toEqual(MOCK_RESULT);
 
-    const { sort, hitsPerPage } = spy.mock.calls[0][0].queries[0];
+    const { sort, limit } = spy.mock.calls[0][0].queries[0];
     expect(sort).toEqual(['likes:desc']);
-    expect(hitsPerPage).toEqual(4);
+    expect(limit).toEqual(4);
   });
 });
 
@@ -160,9 +160,9 @@ describe('getMostRecent', () => {
     const results = await searchService.getMostRecent(4);
     expect(results).toEqual(MOCK_RESULT);
 
-    const { sort, hitsPerPage } = spy.mock.calls[0][0].queries[0];
+    const { sort, limit } = spy.mock.calls[0][0].queries[0];
     expect(sort).toEqual(['publicationUpdatedAt:desc']);
-    expect(hitsPerPage).toEqual(4);
+    expect(limit).toEqual(4);
   });
 });
 

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.ts
@@ -83,7 +83,7 @@ export class SearchService {
       creatorId,
       hitsPerPage: limit,
       // order by most recently updated first
-      sort: ['publicationUpdatedAt:desc'],
+      sort: ['name:asc'],
       // only include top level content
       isPublishedRoot: true,
     });

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.ts
@@ -122,6 +122,8 @@ export class SearchService {
           indexUid: this.meilisearchClient.getActiveIndexName(),
           attributesToHighlight: ['*'],
           ...q,
+          limit,
+          page,
           q: query,
           filter: filters,
         },

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.ts
@@ -77,6 +77,17 @@ export class SearchService {
     return filters;
   }
 
+  async getFeatured(creatorId: string, limit: number = GET_MOST_LIKED_ITEMS_MAXIMUM) {
+    return await this.search({
+      creatorId,
+      limit,
+      // order by most recently updated first
+      sort: ['publicationUpdatedAt:desc'],
+      // only include top level content
+      isPublishedRoot: true,
+    });
+  }
+
   async getMostLiked(limit: number = GET_MOST_LIKED_ITEMS_MAXIMUM) {
     return await this.search({ sort: ['likes:desc'], limit });
   }

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.ts
@@ -97,7 +97,7 @@ export class SearchService {
   }
 
   async search(body: Omit<MultiSearchQuery, 'filter' | 'indexUid' | 'q'> & SearchFilters) {
-    const { tags, langs, isPublishedRoot, query, creatorId, ...q } = body;
+    const { tags, langs, isPublishedRoot, query, creatorId, limit, ...q } = body;
     const filters = this.buildFilters({
       creatorId,
       tags,
@@ -112,6 +112,7 @@ export class SearchService {
           indexUid: this.meilisearchClient.getActiveIndexName(),
           attributesToHighlight: ['*'],
           ...q,
+          hitsPerPage: limit,
           q: query,
           filter: filters,
         },

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.ts
@@ -6,6 +6,7 @@ import { TagCategory, TagCategoryType, UUID } from '@graasp/sdk';
 import { TagRaw } from '../../../../../../../drizzle/types';
 import { BaseLogger } from '../../../../../../../logger';
 import {
+  GET_FEATURED_ITEMS_MAXIMUM,
   GET_MOST_LIKED_ITEMS_MAXIMUM,
   GET_MOST_RECENT_ITEMS_MAXIMUM,
 } from '../../../../../../../utils/config';
@@ -77,10 +78,10 @@ export class SearchService {
     return filters;
   }
 
-  async getFeatured(creatorId: string, limit: number = GET_MOST_LIKED_ITEMS_MAXIMUM) {
+  async getFeatured(creatorId: string, limit: number = GET_FEATURED_ITEMS_MAXIMUM) {
     return await this.search({
       creatorId,
-      limit,
+      hitsPerPage: limit,
       // order by most recently updated first
       sort: ['publicationUpdatedAt:desc'],
       // only include top level content
@@ -97,7 +98,16 @@ export class SearchService {
   }
 
   async search(body: Omit<MultiSearchQuery, 'filter' | 'indexUid' | 'q'> & SearchFilters) {
-    const { tags, langs, isPublishedRoot, query, creatorId, limit, ...q } = body;
+    const { tags, langs, isPublishedRoot, query, creatorId, limit, page, ...q } = body;
+    // should allways use pagination arguments together
+    // page + hitsPerPage
+    // limit + offset
+    if (limit && page) {
+      throw new Error(
+        "'page' used together with 'limit'. Use 'page' in combination with 'hitsPerPage'. Otherwise use 'limit' with 'offset'. For more information see: https://www.meilisearch.com/docs/guides/front_end/pagination",
+      );
+    }
+
     const filters = this.buildFilters({
       creatorId,
       tags,
@@ -112,7 +122,6 @@ export class SearchService {
           indexUid: this.meilisearchClient.getActiveIndexName(),
           attributesToHighlight: ['*'],
           ...q,
-          hitsPerPage: limit,
           q: query,
           filter: filters,
         },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -331,6 +331,10 @@ if (!process.env.APPS_PUBLISHER_ID) {
   throw new Error('APPS_PUBLISHER_ID is not defined');
 }
 export const APPS_PUBLISHER_ID = process.env.APPS_PUBLISHER_ID;
+if (!process.env.GRAASPER_CREATOR_ID) {
+  throw new Error('GRAASPER_CREATOR_ID is not defined');
+}
+export const GRAASPER_CREATOR_ID = process.env.GRAASPER_CREATOR_ID;
 
 // used for hashing password
 export const SALT_ROUNDS = 10;
@@ -345,7 +349,7 @@ export const RECAPTCHA_SECRET_ACCESS_KEY = process.env.RECAPTCHA_SECRET_ACCESS_K
 export const RECAPTCHA_VERIFY_LINK = 'https://www.google.com/recaptcha/api/siteverify';
 export const RECAPTCHA_SCORE_THRESHOLD = 0.5;
 
-// todo: use env var?
+export const GET_FEATURED_ITEMS_MAXIMUM = 50;
 export const GET_MOST_LIKED_ITEMS_MAXIMUM = 50;
 export const GET_MOST_RECENT_ITEMS_MAXIMUM = 50;
 


### PR DESCRIPTION
In this PR I propose to add an endpoint to get the featured collections.

This allows to call a sinlge route wihout needing prior knowledge from the frontend.
This also allows us to potentially apply custom sorting on the retrieved collections.

For this to work, we need to add an env varaiable in the backend that has the value of the Graasper user account.

## Breaking change

Add `GRAASPER_CREATOR_ID` to env variables.

