### PR TITLE
fix(opti): remove join on accountsTable for `getInheritedMany`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "watch-debug": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"yarn watch-ts\" \"yarn serve-debug\"",
     "hooks:uninstall": "husky uninstall",
     "hooks:install": "node .husky/install.mjs",
-    "postinstall": "node .husky/install.mjs",
     "pre-commit": "yarn prettier:check && yarn lint",
     "openapi:generate": "node dist/scripts/generateOpenAPI.js",
     "openapi:lint": "vacuum lint ./openapi.json",

--- a/src/services/itemMembership/membership.repository.ts
+++ b/src/services/itemMembership/membership.repository.ts
@@ -423,12 +423,10 @@ export class ItemMembershipRepository {
       .select({
         ...getTableColumns(itemMembershipsTable),
         item: getTableColumns(itemsRawTable),
-        // account: getTableColumns(accountsTable),
         // Keep only closest membership per descendant
         descendantId: itemsRawTable.id,
       })
       .from(itemMembershipsTable)
-      // .innerJoin(accountsTable, eq(itemMembershipsTable.accountId, accountsTable.id))
       // Map each membership to the item it can affect
       .innerJoin(itemsRawTable, isAncestorOrSelf(itemMembershipsTable.itemPath, itemsRawTable.path))
       .where(and(...andConditions))

--- a/src/services/itemMembership/membership.repository.ts
+++ b/src/services/itemMembership/membership.repository.ts
@@ -404,7 +404,7 @@ export class ItemMembershipRepository {
     inputItems: ItemRaw[],
     accountId: AccountId,
     considerLocal = false,
-  ): Promise<ResultOf<ItemMembershipWithItemAndAccount>> {
+  ): Promise<ResultOf<ItemMembershipWithItem>> {
     if (inputItems.length === 0) {
       return { data: {}, errors: [] };
     }
@@ -423,12 +423,12 @@ export class ItemMembershipRepository {
       .select({
         ...getTableColumns(itemMembershipsTable),
         item: getTableColumns(itemsRawTable),
-        account: getTableColumns(accountsTable),
+        // account: getTableColumns(accountsTable),
         // Keep only closest membership per descendant
         descendantId: itemsRawTable.id,
       })
       .from(itemMembershipsTable)
-      .innerJoin(accountsTable, eq(itemMembershipsTable.accountId, accountsTable.id))
+      // .innerJoin(accountsTable, eq(itemMembershipsTable.accountId, accountsTable.id))
       // Map each membership to the item it can affect
       .innerJoin(itemsRawTable, isAncestorOrSelf(itemMembershipsTable.itemPath, itemsRawTable.path))
       .where(and(...andConditions))


### PR DESCRIPTION
I have noticed that this specific query is slow in production (500ms)

Looking at the code I could not justify why we were returning the account props, so I removed them.

Let me know if you think this is a mistake.