### PR TITLE
chore(build): update comments and values in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in docker-compose.yml to pick a Node version: 10, 12, 14
-ARG VARIANT=20
+# Update the VARIANT arg in docker-compose.yml to pick a Node version: 22, 24
+ARG VARIANT=22
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
-// Update the VARIANT arg in docker-compose.yml to pick a Node.js version: 10, 12, 14
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version: 22, 24
 {
-  "name": "Node.js & PostgreSQL",
+  "name": "Graasp backend",
   "dockerComposeFile": "docker-compose.yml",
   "service": "core",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 14, 12, 10
+        # [Choice] Node.js version: 22, 24
         VARIANT: 22
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
@@ -33,8 +33,7 @@ services:
       ETHERPAD_API_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       # the Redis config is set by the "redis" service below
       REDIS_CONNECTION: redis://redis:6379
-      
-      # the Mailer config is set by the "mailer" service below 
+      # the Mailer config is set by the "mailer" service below
       MAILER_CONNECTION: smtp://docker:docker@mailer:1025
       # the Localstack config is set by the "localstack" service below
       S3_FILE_ITEM_HOST: http://localstack:4566


### PR DESCRIPTION
In this PR:
- update comments to be up to date with current versions of node (22, 24)
- update name of dev container to be less generic

These changes are not required, but I think it is a good idea to maintain these once in a while.