### PR TITLE
chore: split configs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import type { FastifyInstance } from 'fastify';
 import fp from 'fastify-plugin';
 
+import { REDIS_CONNECTION } from './config/redis';
 import { registerDependencies } from './di/container';
 import databasePlugin from './plugins/database';
 import metaPlugin from './plugins/meta';
@@ -17,7 +18,6 @@ import { maintenancePlugin } from './services/maintenance/maintenance.controller
 import MemberServiceApi from './services/member';
 import tagPlugin from './services/tag/tag.controller';
 import websocketsPlugin from './services/websockets/websocket.controller';
-import { REDIS_CONNECTION } from './utils/config';
 
 export default async function (instance: FastifyInstance): Promise<void> {
   await instance

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,44 @@
+import { config } from 'dotenv';
+
+const Environment = {
+  production: 'production',
+  staging: 'staging',
+  development: 'development',
+  test: 'test',
+} as const;
+
+export const NODE_ENV: string | undefined = process.env.NODE_ENV;
+
+const once = (fn) => {
+  let called = false;
+  return function (...args) {
+    if (called) return;
+    called = true;
+    return fn.apply(this, args);
+  };
+};
+
+/**
+ * Pull env vars from file depending on `NODE_ENV` variable
+ */
+export const getEnv = once(() => {
+  switch (NODE_ENV) {
+    case Environment.production:
+      config({ path: '.env.production', override: true });
+      return Environment.production;
+    case Environment.staging:
+      config({ path: '.env.staging', override: true });
+      return Environment.staging;
+    case Environment.test:
+      config({ path: '.env.test', override: true });
+      return Environment.test;
+    default:
+      config({ path: '.env.development', override: true });
+      return Environment.development;
+  }
+});
+
+export const PROD = NODE_ENV === Environment.production;
+export const STAGING = NODE_ENV === Environment.staging;
+export const DEV = NODE_ENV === Environment.development;
+export const TEST = NODE_ENV === Environment.test;

--- a/src/config/helpers.ts
+++ b/src/config/helpers.ts
@@ -1,0 +1,20 @@
+export class ExpectedEnvVariable extends Error {
+  constructor(envVarName: string) {
+    super(`Expected to find env variable "${envVarName}" but it was undefined.`);
+    this.name = 'MissingEnvVar';
+  }
+}
+
+/**
+ *
+ * @param name the name of the env var
+ * @throws an error if the var is not defined
+ * @returns the env var value if it is defined
+ */
+export function requiredEnvVar(name: string) {
+  const varValue = process.env[name];
+  if (varValue === undefined) {
+    throw new ExpectedEnvVariable(name);
+  }
+  return varValue;
+}

--- a/src/config/mailer.ts
+++ b/src/config/mailer.ts
@@ -1,0 +1,8 @@
+import { getEnv } from './env';
+import { requiredEnvVar } from './helpers';
+
+getEnv();
+
+export const MAILER_CONNECTION = requiredEnvVar('MAILER_CONNECTION');
+export const MAILER_CONFIG_FROM_EMAIL =
+  process.env.MAILER_CONFIG_FROM_EMAIL ?? 'no-reply@graasp.org';

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,0 +1,6 @@
+import { getEnv } from './env';
+import { requiredEnvVar } from './helpers';
+
+getEnv();
+
+export const REDIS_CONNECTION = requiredEnvVar('REDIS_CONNECTION');

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -1,0 +1,46 @@
+import { getEnv } from './env';
+import { requiredEnvVar } from './helpers';
+
+// ensure env is setup
+getEnv();
+
+/**
+ * Session cookie key
+ */
+export const SECURE_SESSION_SECRET_KEY = requiredEnvVar('SECURE_SESSION_SECRET_KEY');
+export const SECURE_SESSION_EXPIRATION_IN_SECONDS = 604800; // 7days
+export const MAX_SECURE_SESSION_EXPIRATION_IN_SECONDS = 15552000; // 6 * 30days -> 6 months
+
+/**
+ * JWT
+ */
+export const JWT_SECRET = requiredEnvVar('JWT_SECRET');
+/** Register token expiration, in minutes */
+export const REGISTER_TOKEN_EXPIRATION_IN_MINUTES = 60;
+/** Login token expiration, in minutes */
+export const LOGIN_TOKEN_EXPIRATION_IN_MINUTES = 30;
+
+/** Password reset token Secret */
+export const PASSWORD_RESET_JWT_SECRET: string = requiredEnvVar('PASSWORD_RESET_JWT_SECRET');
+/** Password reset token expiration, in minutes */
+export const PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES = 1440; // 24 hours
+
+/** Email change token Secret */
+export const EMAIL_CHANGE_JWT_SECRET: string = requiredEnvVar('EMAIL_CHANGE_JWT_SECRET');
+/** Email change token expiration, in minutes */
+export const EMAIL_CHANGE_JWT_EXPIRATION_IN_MINUTES = 1440; // 24 hours
+
+/** Graasp apps authentication */
+export const APPS_JWT_SECRET = requiredEnvVar('APPS_JWT_SECRET');
+
+// TODO: remove mobile auth variables as it is deprecated and not supported anymore
+/**
+ * Mobile auth
+ */
+export const AUTH_TOKEN_JWT_SECRET = requiredEnvVar('AUTH_TOKEN_JWT_SECRET');
+/** Auth token expiration, in minutes */
+export const AUTH_TOKEN_EXPIRATION_IN_MINUTES = 10080; // 7 days
+
+export const REFRESH_TOKEN_JWT_SECRET = requiredEnvVar('REFRESH_TOKEN_JWT_SECRET');
+/** Refresh token expiration, in minutes */
+export const REFRESH_TOKEN_EXPIRATION_IN_MINUTES = 86400; // 60 days

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from 'fastify';
 
 import Etherpad from '@graasp/etherpad-api';
 
+import { MAILER_CONFIG_FROM_EMAIL } from '../config/mailer';
 import { CRON_3AM_MONDAY, JobServiceBuilder } from '../jobs';
 import { BaseLogger } from '../logger';
 import { MailerService } from '../plugins/mailer/mailer.service';
@@ -21,7 +22,6 @@ import {
   FILE_STORAGE_TYPE,
   GEOLOCATION_API_KEY,
   IMAGE_CLASSIFIER_API,
-  MAILER_CONFIG_FROM_EMAIL,
   MAILER_CONNECTION,
   MEILISEARCH_MASTER_KEY,
   MEILISEARCH_URL,

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -5,7 +5,8 @@ import type { FastifyInstance } from 'fastify';
 
 import Etherpad from '@graasp/etherpad-api';
 
-import { MAILER_CONFIG_FROM_EMAIL } from '../config/mailer';
+import { MAILER_CONFIG_FROM_EMAIL, MAILER_CONNECTION } from '../config/mailer';
+import { REDIS_CONNECTION } from '../config/redis';
 import { CRON_3AM_MONDAY, JobServiceBuilder } from '../jobs';
 import { BaseLogger } from '../logger';
 import { MailerService } from '../plugins/mailer/mailer.service';
@@ -22,10 +23,8 @@ import {
   FILE_STORAGE_TYPE,
   GEOLOCATION_API_KEY,
   IMAGE_CLASSIFIER_API,
-  MAILER_CONNECTION,
   MEILISEARCH_MASTER_KEY,
   MEILISEARCH_URL,
-  REDIS_CONNECTION,
   S3_FILE_ITEM_PLUGIN_OPTIONS,
 } from '../utils/config';
 import {

--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -3,18 +3,11 @@ import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { fastify } from 'fastify';
 
 import registerAppPlugins from './app';
+import { DEV, NODE_ENV, PROD } from './config/env';
 import { client } from './drizzle/db';
 import ajvFormats from './schemas/ajvFormats';
 import { initSentry } from './sentry';
-import {
-  APP_VERSION,
-  CORS_ORIGIN_REGEX,
-  DEV,
-  ENVIRONMENT,
-  HOST_LISTEN_ADDRESS,
-  PORT,
-  PROD,
-} from './utils/config';
+import { APP_VERSION, CORS_ORIGIN_REGEX, HOST_LISTEN_ADDRESS, PORT } from './utils/config';
 import { GREETING } from './utils/constants';
 
 export const instance = fastify({
@@ -65,7 +58,7 @@ const start = async () => {
 
   try {
     await instance.listen({ port: PORT, host: HOST_LISTEN_ADDRESS });
-    instance.log.info('App is running version %s in %s mode', APP_VERSION, ENVIRONMENT);
+    instance.log.info('App is running version %s in %s mode', APP_VERSION, NODE_ENV);
     if (DEV) {
       // greet the world
       // eslint-disable-next-line no-console

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,7 +1,8 @@
 import { type ConnectionOptions, Queue, Worker } from 'bullmq';
 
+import { REDIS_CONNECTION } from './config/redis';
 import { BaseLogger } from './logger';
-import { JOB_SCHEDULING, REDIS_CONNECTION } from './utils/config';
+import { JOB_SCHEDULING } from './utils/config';
 
 const connection: ConnectionOptions = {
   url: REDIS_CONNECTION,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -3,9 +3,9 @@ import '@sentry/tracing';
 
 import type { FastifyInstance } from 'fastify';
 
+import { NODE_ENV } from './config/env';
 import {
   APP_VERSION,
-  NODE_ENV,
   SENTRY_DSN,
   SENTRY_ENABLE_PERFORMANCE,
   SENTRY_ENABLE_PROFILING,

--- a/src/services/auth/auth.service.ts
+++ b/src/services/auth/auth.service.ts
@@ -1,17 +1,17 @@
 import { sign } from 'jsonwebtoken';
 import { singleton } from 'tsyringe';
 
+import {
+  JWT_SECRET,
+  LOGIN_TOKEN_EXPIRATION_IN_MINUTES,
+  REGISTER_TOKEN_EXPIRATION_IN_MINUTES,
+} from '../../config/secrets';
 import { TRANSLATIONS } from '../../langs/constants';
 import { BaseLogger } from '../../logger';
 import { MailBuilder } from '../../plugins/mailer/builder';
 import { MailerService } from '../../plugins/mailer/mailer.service';
 import type { MemberInfo } from '../../types';
-import {
-  JWT_SECRET,
-  LOGIN_TOKEN_EXPIRATION_IN_MINUTES,
-  PUBLIC_URL,
-  REGISTER_TOKEN_EXPIRATION_IN_MINUTES,
-} from '../../utils/config';
+import { PUBLIC_URL } from '../../utils/config';
 import { SHORT_TOKEN_PARAM } from './plugins/passport';
 import { getRedirectionLink } from './utils';
 

--- a/src/services/auth/plugins/captcha/captcha.ts
+++ b/src/services/auth/plugins/captcha/captcha.ts
@@ -5,7 +5,8 @@ import type { FastifyReply, FastifyRequest, RouteHandlerMethod } from 'fastify';
 
 import type { RecaptchaActionType } from '@graasp/sdk';
 
-import { DEV, RECAPTCHA_SECRET_ACCESS_KEY } from '../../../../utils/config';
+import { DEV } from '../../../../config/env';
+import { RECAPTCHA_SECRET_ACCESS_KEY } from '../../../../utils/config';
 import { AuthenticationError } from './errors';
 
 export const RECAPTCHA_VERIFY_LINK = 'https://www.google.com/recaptcha/api/siteverify';

--- a/src/services/auth/plugins/magicLink/magicLink.controller.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.controller.test.ts
@@ -19,11 +19,11 @@ import { FAILURE_MESSAGES } from '@graasp/translations';
 import build, { MOCK_CAPTCHA, clearDatabase } from '../../../../../test/app';
 import { seedFromJson } from '../../../../../test/mocks/seed';
 import { URL_REGEX } from '../../../../../test/utils';
+import { JWT_SECRET } from '../../../../config/secrets';
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
 import { accountsTable } from '../../../../drizzle/schema';
 import { MailerService } from '../../../../plugins/mailer/mailer.service';
-import { JWT_SECRET } from '../../../../utils/config';
 
 jest.mock('node-fetch');
 

--- a/src/services/auth/plugins/passport/plugin.test.ts
+++ b/src/services/auth/plugins/passport/plugin.test.ts
@@ -9,16 +9,16 @@ import { HttpMethod } from '@graasp/sdk';
 
 import build from '../../../../../test/app';
 import { seedFromJson } from '../../../../../test/mocks/seed';
-import { resolveDependency } from '../../../../di/utils';
-import { db } from '../../../../drizzle/db';
-import type { ItemRaw, MemberRaw } from '../../../../drizzle/types';
-import { assertIsDefined } from '../../../../utils/assertions';
 import {
   APPS_JWT_SECRET,
   EMAIL_CHANGE_JWT_SECRET,
   JWT_SECRET,
   PASSWORD_RESET_JWT_SECRET,
-} from '../../../../utils/config';
+} from '../../../../config/secrets';
+import { resolveDependency } from '../../../../di/utils';
+import { db } from '../../../../drizzle/db';
+import { ItemRaw, MemberRaw } from '../../../../drizzle/types';
+import { assertIsDefined } from '../../../../utils/assertions';
 import { assertIsMember, assertIsMemberForTest } from '../../../authentication';
 import { expectItem } from '../../../item/test/fixtures/items';
 import { MemberPasswordService } from '../password/password.service';

--- a/src/services/auth/plugins/passport/plugin.ts
+++ b/src/services/auth/plugins/passport/plugin.ts
@@ -2,19 +2,18 @@ import fastifyPassport from '@fastify/passport';
 import { fastifySecureSession } from '@fastify/secure-session';
 import type { FastifyInstance, FastifyPluginAsync, PassportUser } from 'fastify';
 
-import { resolveDependency } from '../../../../di/utils';
-import { db } from '../../../../drizzle/db';
-import { assertIsDefined } from '../../../../utils/assertions';
+import { PROD, STAGING } from '../../../../config/env';
 import {
-  COOKIE_DOMAIN,
   JWT_SECRET,
   MAX_SECURE_SESSION_EXPIRATION_IN_SECONDS,
-  PROD,
   REFRESH_TOKEN_JWT_SECRET,
   SECURE_SESSION_EXPIRATION_IN_SECONDS,
   SECURE_SESSION_SECRET_KEY,
-  STAGING,
-} from '../../../../utils/config';
+} from '../../../../config/secrets';
+import { resolveDependency } from '../../../../di/utils';
+import { db } from '../../../../drizzle/db';
+import { assertIsDefined } from '../../../../utils/assertions';
+import { COOKIE_DOMAIN } from '../../../../utils/config';
 import { AccountRepository } from '../../../account/account.repository';
 import { ItemRepository } from '../../../item/item.repository';
 import { MemberRepository } from '../../../member/member.repository';

--- a/src/services/auth/plugins/passport/strategies/emailChange.ts
+++ b/src/services/auth/plugins/passport/strategies/emailChange.ts
@@ -2,8 +2,8 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
+import { EMAIL_CHANGE_JWT_SECRET } from '../../../../../config/secrets';
 import { db } from '../../../../../drizzle/db';
-import { EMAIL_CHANGE_JWT_SECRET } from '../../../../../utils/config';
 import { MemberNotFound, UnauthorizedMember } from '../../../../../utils/errors';
 import { MemberRepository } from '../../../../member/member.repository';
 import { PassportStrategy } from '../strategies';

--- a/src/services/auth/plugins/passport/strategies/jwtApps.ts
+++ b/src/services/auth/plugins/passport/strategies/jwtApps.ts
@@ -2,8 +2,8 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
+import { APPS_JWT_SECRET } from '../../../../../config/secrets';
 import { db } from '../../../../../drizzle/db';
-import { APPS_JWT_SECRET } from '../../../../../utils/config';
 import { UnauthorizedMember } from '../../../../../utils/errors';
 import { AccountRepository } from '../../../../account/account.repository';
 import { ItemRepository } from '../../../../item/item.repository';

--- a/src/services/auth/plugins/passport/strategies/jwtChallengeVerifier.ts
+++ b/src/services/auth/plugins/passport/strategies/jwtChallengeVerifier.ts
@@ -3,8 +3,8 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
+import { JWT_SECRET } from '../../../../../config/secrets';
 import { db } from '../../../../../drizzle/db';
-import { JWT_SECRET } from '../../../../../utils/config';
 import { ChallengeFailed, MemberNotFound, UnauthorizedMember } from '../../../../../utils/errors';
 import { AccountRepository } from '../../../../account/account.repository';
 import { SHORT_TOKEN_PARAM } from '../constants';

--- a/src/services/auth/plugins/passport/strategies/passwordReset.ts
+++ b/src/services/auth/plugins/passport/strategies/passwordReset.ts
@@ -2,7 +2,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Authenticator } from '@fastify/passport';
 
-import { PASSWORD_RESET_JWT_SECRET } from '../../../../../utils/config';
+import { PASSWORD_RESET_JWT_SECRET } from '../../../../../config/secrets';
 import { MemberNotFound, UnauthorizedMember } from '../../../../../utils/errors';
 import { MemberPasswordService } from '../../password/password.service';
 import { PassportStrategy } from '../strategies';

--- a/src/services/auth/plugins/password/password.controller.test.ts
+++ b/src/services/auth/plugins/password/password.controller.test.ts
@@ -20,16 +20,14 @@ import build, {
 } from '../../../../../test/app';
 import { seedFromJson } from '../../../../../test/mocks/seed';
 import { TOKEN_REGEX, mockCaptchaValidationOnce } from '../../../../../test/utils';
+import { REDIS_CONNECTION } from '../../../../config/redis';
+import { PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES } from '../../../../config/secrets';
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
 import { memberPasswordsTable } from '../../../../drizzle/schema';
 import type { MemberRaw } from '../../../../drizzle/types';
 import { MailerService } from '../../../../plugins/mailer/mailer.service';
 import { assertIsDefined } from '../../../../utils/assertions';
-import {
-  PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES,
-  REDIS_CONNECTION,
-} from '../../../../utils/config';
 import { assertIsMember, assertIsMemberForTest } from '../../../authentication';
 
 async function login(

--- a/src/services/auth/plugins/password/password.controller.ts
+++ b/src/services/auth/plugins/password/password.controller.ts
@@ -4,11 +4,12 @@ import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
 import { ActionTriggers, Context, RecaptchaAction } from '@graasp/sdk';
 
+import { LOGIN_TOKEN_EXPIRATION_IN_MINUTES } from '../../../../config/secrets';
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
 import type { ActionInsertDTO } from '../../../../drizzle/types';
 import { asDefined } from '../../../../utils/assertions';
-import { LOGIN_TOKEN_EXPIRATION_IN_MINUTES, PUBLIC_URL } from '../../../../utils/config';
+import { PUBLIC_URL } from '../../../../utils/config';
 import { ActionService } from '../../../action/action.service';
 import { View } from '../../../item/plugins/action/itemAction.schemas';
 import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
@@ -55,7 +56,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       const { url } = body;
       const member = asDefined(user?.account);
 
-      const token = await memberPasswordService.generateToken(
+      const token = memberPasswordService.generateToken(
         { sub: member.id },
         `${LOGIN_TOKEN_EXPIRATION_IN_MINUTES}m`,
       );

--- a/src/services/auth/plugins/password/password.service.ts
+++ b/src/services/auth/plugins/password/password.service.ts
@@ -5,17 +5,17 @@ import { v4 as uuid } from 'uuid';
 
 import { ClientManager, Context } from '@graasp/sdk';
 
+import {
+  JWT_SECRET,
+  PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES,
+  PASSWORD_RESET_JWT_SECRET,
+} from '../../../../config/secrets';
 import { type DBConnection } from '../../../../drizzle/db';
 import { TRANSLATIONS } from '../../../../langs/constants';
 import { BaseLogger } from '../../../../logger';
 import { MailBuilder } from '../../../../plugins/mailer/builder';
 import { MailerService } from '../../../../plugins/mailer/mailer.service';
 import type { AuthenticatedUser, MemberInfo } from '../../../../types';
-import {
-  JWT_SECRET,
-  PASSWORD_RESET_JWT_EXPIRATION_IN_MINUTES,
-  PASSWORD_RESET_JWT_SECRET,
-} from '../../../../utils/config';
 import {
   EmptyCurrentPassword,
   InvalidPassword,

--- a/src/services/auth/plugins/password/utils.ts
+++ b/src/services/auth/plugins/password/utils.ts
@@ -1,6 +1,5 @@
 import { compare, hash } from 'bcrypt';
 
-import { SALT_ROUNDS } from '../../../../utils/config';
 import { PasswordNotDefined } from './errors';
 
 export async function verifyCurrentPassword(savedPassword: string, password: string) {
@@ -34,6 +33,7 @@ export async function comparePasswords(password: string, hash: string): Promise<
   return compare(password, hash);
 }
 
+const SALT_ROUNDS = 10;
 export async function encryptPassword(password: string) {
   /* encrypted: stores the output of bcrypt.hash().
   bcrypt.hash() creates the salt and hashes the password.

--- a/src/services/auth/utils.ts
+++ b/src/services/auth/utils.ts
@@ -5,12 +5,12 @@ import type { FastifyBaseLogger } from 'fastify';
 import { ClientManager, Context } from '@graasp/sdk';
 
 import {
-  ALLOWED_ORIGINS,
   AUTH_TOKEN_EXPIRATION_IN_MINUTES,
   AUTH_TOKEN_JWT_SECRET,
   REFRESH_TOKEN_EXPIRATION_IN_MINUTES,
   REFRESH_TOKEN_JWT_SECRET,
-} from '../../utils/config';
+} from '../../config/secrets';
+import { ALLOWED_ORIGINS } from '../../utils/config';
 
 const defaultClientHost = ClientManager.getInstance().getLinkByContext(Context.Home);
 

--- a/src/services/authentication.ts
+++ b/src/services/authentication.ts
@@ -7,6 +7,7 @@ import {
   type MinimalGuest,
   type MinimalMember,
 } from '../types';
+import { NotMemberOrGuest } from './account/errors';
 import { NotMember } from './member/error';
 
 // TODO: allow AccountRow or apply DTO on all relations?
@@ -47,6 +48,20 @@ export function assertIsMemberForTest<Err extends Error, Args extends unknown[]>
       const defaultError = new NotMember();
       defaultError.statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
       throw defaultError;
+    }
+  }
+}
+
+export function assertIsMemberOrGuest<Err extends Error, Args extends unknown[]>(
+  account: AuthenticatedUser,
+  error?: new (...args: Args) => Err,
+  ...args: Args
+): asserts account is MinimalMember | MinimalGuest {
+  if (!(isMember(account) || isGuest(account))) {
+    if (error) {
+      throw new error(...args);
+    } else {
+      throw new NotMemberOrGuest();
     }
   }
 }

--- a/src/services/item/index.ts
+++ b/src/services/item/index.ts
@@ -2,8 +2,8 @@ import { fastifyCors } from '@fastify/cors';
 import type { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
+import { APPS_JWT_SECRET } from '../../config/secrets';
 import {
-  APPS_JWT_SECRET,
   APPS_PUBLISHER_ID,
   APP_ITEMS_PREFIX,
   FILE_ITEM_PLUGIN_OPTIONS,

--- a/src/services/item/plugins/app/app.service.ts
+++ b/src/services/item/plugins/app/app.service.ts
@@ -4,10 +4,10 @@ import { singleton } from 'tsyringe';
 
 import { type AuthTokenSubject, ItemType, PermissionLevel } from '@graasp/sdk';
 
+import { APPS_JWT_SECRET } from '../../../../config/secrets';
 import { type DBConnection } from '../../../../drizzle/db';
 import type { ItemRaw, MinimalAccount } from '../../../../drizzle/types';
 import type { AuthenticatedUser, MaybeUser } from '../../../../types';
-import { APPS_JWT_SECRET } from '../../../../utils/config';
 import { AuthorizedItemService } from '../../../authorizedItem.service';
 import { ItemMembershipRepository } from '../../../itemMembership/membership.repository';
 import { WrongItemTypeError } from '../../errors';

--- a/src/services/item/plugins/etherpad/etherpad.controller.ts
+++ b/src/services/item/plugins/etherpad/etherpad.controller.ts
@@ -6,9 +6,9 @@ import fp from 'fastify-plugin';
 
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
-import { asDefined, assertIsMemberOrGuest } from '../../../../utils/assertions';
+import { asDefined } from '../../../../utils/assertions';
 import { isAuthenticated, matchOne } from '../../../auth/plugins/passport';
-import { assertIsMember } from '../../../authentication';
+import { assertIsMember, assertIsMemberOrGuest } from '../../../authentication';
 import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
 import { ItemService } from '../../item.service';
 import { createEtherpad, getEtherpadFromItem, updateEtherpad } from './etherpad.schemas';

--- a/src/services/member/member.controller.email.storage.test.ts
+++ b/src/services/member/member.controller.email.storage.test.ts
@@ -11,12 +11,12 @@ import { type FileItemExtra, HttpMethod } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
 import { buildFile, seedFromJson } from '../../../test/mocks/seed';
+import { EMAIL_CHANGE_JWT_SECRET } from '../../config/secrets';
 import { db } from '../../drizzle/db';
 import { accountsTable } from '../../drizzle/schema';
 import type { ItemRaw } from '../../drizzle/types';
 import { MailerService } from '../../plugins/mailer/mailer.service';
 import { assertIsDefined } from '../../utils/assertions';
-import { EMAIL_CHANGE_JWT_SECRET } from '../../utils/config';
 import { assertIsMember } from '../authentication';
 import {
   FILE_METADATA_MAX_PAGE_SIZE,

--- a/src/services/member/member.service.ts
+++ b/src/services/member/member.service.ts
@@ -4,6 +4,10 @@ import { singleton } from 'tsyringe';
 import { ClientManager, Context, type UUID } from '@graasp/sdk';
 import { DEFAULT_LANG } from '@graasp/translations';
 
+import {
+  EMAIL_CHANGE_JWT_EXPIRATION_IN_MINUTES,
+  EMAIL_CHANGE_JWT_SECRET,
+} from '../../config/secrets';
 import { type DBConnection } from '../../drizzle/db';
 import type { MemberCreationDTO, MemberRaw } from '../../drizzle/types';
 import { TRANSLATIONS } from '../../langs/constants';
@@ -11,10 +15,6 @@ import { BaseLogger } from '../../logger';
 import { MailBuilder } from '../../plugins/mailer/builder';
 import { MailerService } from '../../plugins/mailer/mailer.service';
 import { type MemberInfo } from '../../types';
-import {
-  EMAIL_CHANGE_JWT_EXPIRATION_IN_MINUTES,
-  EMAIL_CHANGE_JWT_SECRET,
-} from '../../utils/config';
 import { MemberAlreadySignedUp } from '../../utils/errors';
 import { NEW_EMAIL_PARAM, SHORT_TOKEN_PARAM } from '../auth/plugins/passport';
 import { MemberRepository } from './member.repository';

--- a/src/services/websockets/test/test-utils.ts
+++ b/src/services/websockets/test/test-utils.ts
@@ -10,7 +10,7 @@ import fp from 'fastify-plugin';
 
 import { Websocket as GraaspWebsocket } from '@graasp/sdk';
 
-import { REDIS_CONNECTION } from '../../../utils/config';
+import { REDIS_CONNECTION } from '../../../config/redis';
 import { AjvMessageSerializer } from '../message-serializer';
 import graaspWebSockets, { type WebsocketsPluginOptions } from '../websocket.controller';
 import { WebSocketChannels } from '../ws-channels';

--- a/src/services/websockets/websocket.controller.ts
+++ b/src/services/websockets/websocket.controller.ts
@@ -9,7 +9,7 @@
 import fws from '@fastify/websocket';
 import type { FastifyPluginAsync } from 'fastify';
 
-import { NODE_ENV } from '../../utils/config';
+import { NODE_ENV } from '../../config/env';
 import { optionalIsAuthenticated } from '../auth/plugins/passport';
 import { AjvMessageSerializer } from './message-serializer';
 import { MultiInstanceChannelsBroker } from './multi-instance';

--- a/src/utils/assertions.ts
+++ b/src/utils/assertions.ts
@@ -1,6 +1,3 @@
-import { NotMemberOrGuest } from '../services/account/errors';
-import { isGuest, isMember } from '../services/authentication';
-import type { AuthenticatedUser, MinimalGuest, MinimalMember } from '../types';
 import { UnexpectedError } from './errors';
 
 export type Nullable<T> = T | null | undefined;
@@ -44,20 +41,6 @@ export function assertIsDefined<T, Err extends Error, Args extends unknown[]>(
 ): asserts object is NonNullable<T> {
   if (!isDefined(object)) {
     throw error ? new error(...args) : new UnexpectedError();
-  }
-}
-
-export function assertIsMemberOrGuest<Err extends Error, Args extends unknown[]>(
-  account: AuthenticatedUser,
-  error?: new (...args: Args) => Err,
-  ...args: Args
-): asserts account is MinimalMember | MinimalGuest {
-  if (!(isMember(account) || isGuest(account))) {
-    if (error) {
-      throw new error(...args);
-    } else {
-      throw new NotMemberOrGuest();
-    }
   }
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,13 +7,6 @@ import { FAILURE_MESSAGES } from '@graasp/translations';
 
 export const ConfigurationError = ErrorFactory('config');
 
-export class ExpectedEnvVariable extends Error {
-  constructor(envVarName: string) {
-    super(`Expected to find env variable "${envVarName}" but it was undefined.`);
-    this.name = 'MissingEnvVar';
-  }
-}
-
 export const CoreError = ErrorFactory('core');
 
 export const ItemNotFound = createError(


### PR DESCRIPTION
In this PR:
- split configs into separate files inside `src/config` 
  - `redis`: Redis related configs
  - `env`: environment related configs
  - `mailer`: email related configs
  - `secrets`: JWT secrets
- add utils for required env vars
- move `SALT_ROUNDS` to the file it is used in
- move `assertIsMemberOrGuest` inside `authentication`
