### PR TITLE
fix: sanitize original order before copy

### DIFF
--- a/src/services/item/item.repository.test.ts
+++ b/src/services/item/item.repository.test.ts
@@ -374,7 +374,7 @@ describe('Item Repository', () => {
     });
   });
 
-  describe('getChildrenWithCreator', () => {
+  describe('getFilteredChildren', () => {
     it('Returns successfully', async () => {
       const {
         actor,
@@ -396,7 +396,7 @@ describe('Item Repository', () => {
       assertIsMemberForTest(actor);
       const maybeUser = new MemberDTO(actor).toMaybeUser();
 
-      const data = await itemRepository.getChildrenWithCreator(db, maybeUser, parentItem);
+      const data = await itemRepository.getFilteredChildren(db, maybeUser, parentItem);
       expect(data).toHaveLength(children.length);
       expectManyItems(data, children, actor);
       data.forEach((d) => expect(d.creator!.name).toEqual(actor.name));
@@ -410,7 +410,7 @@ describe('Item Repository', () => {
       assertIsDefined(actor);
       const maybeUser = new MemberDTO(actor).toMaybeUser();
 
-      const response = await itemRepository.getChildrenWithCreator(db, maybeUser, parent);
+      const response = await itemRepository.getFilteredChildren(db, maybeUser, parent);
 
       expect(response).toEqual([]);
     });
@@ -437,7 +437,7 @@ describe('Item Repository', () => {
       assertIsDefined(actor);
       const maybeUser = new MemberDTO(actor).toMaybeUser();
 
-      const data = await itemRepository.getChildrenWithCreator(db, maybeUser, parent);
+      const data = await itemRepository.getFilteredChildren(db, maybeUser, parent);
       expect(data).toHaveLength(children.length);
       // verify order and content
       childrenInOrder.forEach((child, idx) => {
@@ -458,7 +458,7 @@ describe('Item Repository', () => {
       const children = [child2];
       assertIsDefined(actor);
       const maybeUser = new MemberDTO(actor).toMaybeUser();
-      const data = await itemRepository.getChildrenWithCreator(db, maybeUser, parent, {
+      const data = await itemRepository.getFilteredChildren(db, maybeUser, parent, {
         types: [ItemType.FOLDER],
       });
       expect(data).toHaveLength(children.length);
@@ -484,7 +484,7 @@ describe('Item Repository', () => {
       assertIsDefined(actor);
       const maybeUser = new MemberDTO(actor).toMaybeUser();
 
-      const data = await itemRepository.getChildrenWithCreator(db, maybeUser, parent, {
+      const data = await itemRepository.getFilteredChildren(db, maybeUser, parent, {
         keywords: ['child'],
       });
       expect(data).toHaveLength(children.length);
@@ -502,9 +502,9 @@ describe('Item Repository', () => {
       assertIsDefined(actor);
       const maybeUser = new MemberDTO(actor).toMaybeUser();
 
-      await expect(
-        itemRepository.getChildrenWithCreator(db, maybeUser, item),
-      ).rejects.toMatchObject(new ItemNotFolder({ id: item.id }));
+      await expect(itemRepository.getFilteredChildren(db, maybeUser, item)).rejects.toMatchObject(
+        new ItemNotFolder({ id: item.id }),
+      );
     });
   });
 

--- a/src/services/item/item.repository.ts
+++ b/src/services/item/item.repository.ts
@@ -306,8 +306,8 @@ export class ItemRepository {
       .select()
       .from(items)
       .where(isDirectChild(items.path, parent.path))
-      // use order for ordering
-      // backup order by in case two items has same ordering
+      // use `order` column for sorting
+      // use `createdAt` column as a backup in case two items have the same `order` value
       .orderBy(() => [asc(items.order), asc(items.createdAt)]);
   }
 
@@ -319,7 +319,7 @@ export class ItemRepository {
    * @param params
    * @returns
    */
-  async getChildrenWithCreator(
+  async getFilteredChildren(
     dbConnection: DBConnection,
     actor: MaybeUser,
     parent: ItemRaw,

--- a/src/services/item/item.service.ts
+++ b/src/services/item/item.service.ts
@@ -492,7 +492,7 @@ export class ItemService {
   ) {
     const item = await this.authorizedItemService.getItemById(dbConnection, { actor, itemId });
 
-    return this.itemRepository.getChildrenWithCreator(dbConnection, actor, item, params);
+    return this.itemRepository.getFilteredChildren(dbConnection, actor, item, params);
   }
 
   async getChildren(

--- a/src/services/item/item.service.ts
+++ b/src/services/item/item.service.ts
@@ -331,7 +331,7 @@ export class ItemService {
 
     // rescale the item ordering, if there's more than one item
     if (items.length > 1) {
-      await this.itemRepository.rescaleOrder(dbConnection, member, parentItem);
+      await this.itemRepository.rescaleOrder(dbConnection, parentItem);
     }
 
     return createdItems;
@@ -492,7 +492,7 @@ export class ItemService {
   ) {
     const item = await this.authorizedItemService.getItemById(dbConnection, { actor, itemId });
 
-    return this.itemRepository.getChildren(dbConnection, actor, item, params);
+    return this.itemRepository.getChildrenWithCreator(dbConnection, actor, item, params);
   }
 
   async getChildren(
@@ -793,7 +793,7 @@ export class ItemService {
 
     // newly moved items needs rescaling since they are added in parallel
     if (parentItem) {
-      await this.itemRepository.rescaleOrder(dbConnection, member, parentItem);
+      await this.itemRepository.rescaleOrder(dbConnection, parentItem);
     }
 
     return {
@@ -869,6 +869,11 @@ export class ItemService {
       item,
       MAX_DESCENDANTS_FOR_COPY,
     );
+
+    // make sure the order of the descendants are correct
+    if (item.type === ItemType.FOLDER) {
+      await this.itemRepository.fixOrderForTree(dbConnection, item.path);
+    }
 
     let items = [item];
     if (isItemType(item, ItemType.FOLDER)) {
@@ -988,7 +993,7 @@ export class ItemService {
 
     // rescale order because copies happen in parallel
     if (parentItem) {
-      await this.itemRepository.rescaleOrder(dbConnection, member, parentItem);
+      await this.itemRepository.rescaleOrder(dbConnection, parentItem);
     }
 
     return {
@@ -1033,7 +1038,7 @@ export class ItemService {
         actor: member,
         itemId: parentId,
       })) as FolderItem;
-      await this.itemRepository.rescaleOrder(dbConnection, member, parentItem);
+      await this.itemRepository.rescaleOrder(dbConnection, parentItem);
     }
   }
 }


### PR DESCRIPTION
- add `getChildrenWithCreator` opposed to `getChildren` so we don't leftjoin the creator when it is not necessary. This simplified `rescaleOrder`
- add `fixOrderForTree` which is a sql query that rescale and correctly set orders in a tree.
- apply `fixOrderForTree` before copying, ensuring the order for the copied.