### PR TITLE
fix: add strict facetName schema from filterable attributes

### DIFF
--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
@@ -76,16 +76,20 @@ const DISPLAY_ATTRIBUTES: (keyof IndexItem)[] = [
   'isHidden',
   'lang',
   'likes',
-  ...Object.values(TagCategory),
+  TagCategory.Level,
+  TagCategory.Discipline,
+  TagCategory.ResourceType,
 ];
-const FILTERABLE_ATTRIBUTES: (keyof IndexItem)[] = [
+export const FILTERABLE_ATTRIBUTES = [
   'isPublishedRoot',
   'isHidden',
   'lang',
   'likes',
   'creator',
-  ...Object.values(TagCategory),
-];
+  TagCategory.Level,
+  TagCategory.Discipline,
+  TagCategory.ResourceType,
+] as const;
 const TYPO_TOLERANCE: TypoTolerance = {
   enabled: true,
   minWordSizeForTypos: {
@@ -451,7 +455,7 @@ export class MeiliSearchWrapper {
     const updateSettings = await tmpIndex.updateSettings({
       searchableAttributes: SEARCHABLE_ATTRIBUTES,
       displayedAttributes: DISPLAY_ATTRIBUTES,
-      filterableAttributes: FILTERABLE_ATTRIBUTES,
+      filterableAttributes: [...FILTERABLE_ATTRIBUTES], // make a shallow copy because the initial parameter is readonly
       sortableAttributes: SORT_ATTRIBUTES,
       typoTolerance: TYPO_TOLERANCE,
     });

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.ts
@@ -40,6 +40,7 @@ import { ItemTagRepository } from '../../../../tag/ItemTag.repository';
 import { stripHtml } from '../../../validation/utils';
 import { ItemPublishedNotFound } from '../../errors';
 import { ItemPublishedRepository } from '../../itemPublished.repository';
+import { FILTERABLE_ATTRIBUTES } from './search.constants';
 import type { Hit } from './search.schemas';
 
 const ACTIVE_INDEX = 'itemIndex';
@@ -80,16 +81,7 @@ const DISPLAY_ATTRIBUTES: (keyof IndexItem)[] = [
   TagCategory.Discipline,
   TagCategory.ResourceType,
 ];
-export const FILTERABLE_ATTRIBUTES = [
-  'isPublishedRoot',
-  'isHidden',
-  'lang',
-  'likes',
-  'creator',
-  TagCategory.Level,
-  TagCategory.Discipline,
-  TagCategory.ResourceType,
-] as const;
+
 const TYPO_TOLERANCE: TypoTolerance = {
   enabled: true,
   minWordSizeForTypos: {

--- a/src/services/item/plugins/publication/published/plugins/search/search.constants.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.constants.ts
@@ -1,0 +1,12 @@
+import { TagCategory } from '@graasp/sdk';
+
+export const FILTERABLE_ATTRIBUTES = [
+  'isPublishedRoot',
+  'isHidden',
+  'lang',
+  'likes',
+  'creator',
+  TagCategory.Level,
+  TagCategory.Discipline,
+  TagCategory.ResourceType,
+] as const;

--- a/src/services/item/plugins/publication/published/plugins/search/search.controller.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.controller.test.ts
@@ -432,6 +432,17 @@ describe('Collection Search endpoints', () => {
       expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
     });
 
+    it('throw if facet name is not allowed', async () => {
+      const res = await app.inject({
+        method: HttpMethod.Post,
+        url: `${ITEMS_ROUTE_PREFIX}/collections/facets`,
+        query: { facetName: 'toto' },
+        body: {},
+      });
+
+      expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    });
+
     it('get facets', async () => {
       // Meilisearch is mocked so format of API doesn't matter, we just want it to proxy MultiSearchParams;
       const fakeResponse = {
@@ -453,7 +464,6 @@ describe('Collection Search endpoints', () => {
         ],
       };
       jest.spyOn(MeiliSearchWrapper.prototype, 'search').mockResolvedValue(fakeResponse);
-
       const res = await app.inject({
         method: HttpMethod.Post,
         url: `${ITEMS_ROUTE_PREFIX}/collections/facets`,

--- a/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
@@ -12,7 +12,7 @@ import {
   GET_MOST_LIKED_ITEMS_MAXIMUM,
   GET_MOST_RECENT_ITEMS_MAXIMUM,
 } from '../../../../../../../utils/config';
-import { FILTERABLE_ATTRIBUTES } from './meilisearch';
+import { FILTERABLE_ATTRIBUTES } from './search.constants';
 
 const meilisearchHitRef = registerSchemaAsRef(
   'searchHit',
@@ -153,6 +153,7 @@ export const getMostRecent = {
 
 export type Hit = Static<(typeof search)['response']['200']>['hits'][0];
 
+const facetOptions = Type.Union(FILTERABLE_ATTRIBUTES.map((attribute) => Type.Literal(attribute)));
 export const getFacets = {
   operationId: 'getFacetsForName',
   tags: ['collection', 'search'],
@@ -161,14 +162,14 @@ export const getFacets = {
     'Get list of facets and how many collections are tagged with those given a facet name.',
 
   querystring: customType.StrictObject({
-    facetName: Type.Union(FILTERABLE_ATTRIBUTES.map((attribute) => Type.Literal(attribute))),
+    facetName: facetOptions,
   }),
   body: Type.Partial(
     customType.StrictObject({
       query: Type.String(),
       langs: Type.Array(Type.String()),
       isPublishedRoot: Type.Boolean(),
-      facets: Type.Array(Type.String()),
+      facets: Type.Array(facetOptions),
       tags: Type.Partial(Type.Record(Type.Enum(TagCategory), Type.Array(Type.String()))),
     }),
   ),

--- a/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.schemas.ts
@@ -12,6 +12,7 @@ import {
   GET_MOST_LIKED_ITEMS_MAXIMUM,
   GET_MOST_RECENT_ITEMS_MAXIMUM,
 } from '../../../../../../../utils/config';
+import { FILTERABLE_ATTRIBUTES } from './meilisearch';
 
 const meilisearchHitRef = registerSchemaAsRef(
   'searchHit',
@@ -160,7 +161,7 @@ export const getFacets = {
     'Get list of facets and how many collections are tagged with those given a facet name.',
 
   querystring: customType.StrictObject({
-    facetName: Type.String(),
+    facetName: Type.Union(FILTERABLE_ATTRIBUTES.map((attribute) => Type.Literal(attribute))),
   }),
   body: Type.Partial(
     customType.StrictObject({


### PR DESCRIPTION
In this PR I make the validation schema stricter for the `/items/collections/search/facets?facetName=XXX` XXX will now check on valid values and throw a BadRequest error if it does not match the set of values. 

The allowed values are taken from the filterable attributes defined on the index. 
This change should:

- prevent errors with invalid parameters thrown by the search
- make the generation better by explicitly typing the input params

> [!NOTE]
> There was a big footgun in this PR, the tact that we are mocking the `meilisearch.ts` file in the test meant that the constant `FILTERABLE_ATTRIBUTES` did not exist ... and so the tests failed ... it took me a while to figure it out ...