### PR TITLE
feat: create build index worker

### DIFF
--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -69,15 +69,17 @@ export class JobService {
 
   private setupWorker() {
     this.scheduledJobsWorker.on('completed', (job) => {
-      this.logger.info(`${job.id} has completed!`);
+      this.logger.info(`${job.queueName}'s ${job.id} has completed!`);
     });
 
     this.scheduledJobsWorker.on('active', (job) => {
-      this.logger.info(`${job.id} is now active!`);
+      this.logger.info(`${job.queueName}'s ${job.id} is now active!`);
     });
 
     this.scheduledJobsWorker.on('failed', (job, err) => {
-      this.logger.info(`${job?.id ?? 'unknown job'} has failed with ${err.message}`);
+      this.logger.info(
+        `${job?.queueName}'s ${job?.id ?? 'unknown job'} has failed with ${err.message}`,
+      );
     });
 
     this.scheduledJobsWorker.on('error', (err) => {

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.test.ts
@@ -21,7 +21,7 @@ import {
 
 import { MOCK_LOGGER } from '../../../../../../../../test/app';
 import { ItemFactory } from '../../../../../../../../test/factories/item.factory';
-import { type DBConnection, db } from '../../../../../../../drizzle/db';
+import { type DBConnection } from '../../../../../../../drizzle/db';
 import type {
   ItemPublishedWithItem,
   ItemPublishedWithItemWithCreator,
@@ -113,7 +113,6 @@ const itemVisibilityRepository = new ItemVisibilityRepository();
 
 const meilisearch = new MeiliSearchWrapper(
   fakeClient,
-  fileService,
   itemVisibilityRepository,
   itemRepository,
   itemPublishedRepository,
@@ -457,38 +456,6 @@ describe('MeilisearchWrapper', () => {
       expect(deleteSpy.mock.calls[0][0]).toMatchObject(
         expect.arrayContaining([item.id, descendant.id, descendant2.id]),
       );
-    });
-  });
-
-  describe('rebuilds index', () => {
-    it('reindex all items', async () => {
-      jest.spyOn(db, 'transaction').mockImplementation(async (fn) => await fn({} as never));
-      const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
-        return mockItemPublished({ id: index.toString(), path: index.toString() });
-      });
-      // prevent finding any PDFs to store because this part is temporary
-      jest.spyOn(meilisearch, 'findAndCountItems').mockResolvedValue([[], 0]);
-      // fake pagination
-      jest
-        .spyOn(itemPublishedRepository, 'getPaginatedItems')
-        .mockImplementation(async (_db, page, _) => {
-          if (page === 1) {
-            return [publishedItemsInDb.slice(0, 10), publishedItemsInDb.length];
-          } else if (page === 2) {
-            return [publishedItemsInDb.slice(10), publishedItemsInDb.length];
-          } else {
-            throw new Error();
-          }
-        });
-      const indexSpy = jest
-        .spyOn(MeiliSearchWrapper.prototype, 'index')
-        .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
-
-      await meilisearch.rebuildIndex(10);
-
-      expect(indexSpy).toHaveBeenCalledTimes(2);
-      expect(indexSpy.mock.calls[0][1]).toEqual(publishedItemsInDb.slice(0, 10));
-      expect(indexSpy.mock.calls[1][1]).toEqual(publishedItemsInDb.slice(10));
     });
   });
 });

--- a/src/services/item/plugins/publication/published/plugins/search/meilisearch.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/meilisearch.test.ts
@@ -28,7 +28,6 @@ import type {
   ItemRaw,
   ItemVisibilityWithItem,
 } from '../../../../../../../drizzle/types';
-import FileService from '../../../../../../file/file.service';
 import { ItemRepository } from '../../../../../item.repository';
 import { ItemLikeRepository } from '../../../../itemLike/itemLike.repository';
 import { ItemVisibilityRepository } from '../../../../itemVisibility/itemVisibility.repository';
@@ -56,8 +55,6 @@ const mockItemPublished = ({
 };
 
 const MOCK_DB = {} as DBConnection;
-
-const fileService = {} as jest.Mocked<FileService>;
 
 const mockIndex = {
   addDocuments: jest.fn(() => {

--- a/src/services/item/plugins/publication/published/plugins/search/search.service.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.service.ts
@@ -157,10 +157,6 @@ export class SearchService {
     return searchResult.results[0].facetDistribution?.[facetName] ?? {};
   }
 
-  async rebuildIndex() {
-    this.meilisearchClient.rebuildIndex();
-  }
-
   // Registers all hooks related to sync between database and meilisearch index
   // Make sure to not throw if indexation fail, so that the app can continue to work if Meilisearch is down.
   private registerSearchHooks(

--- a/src/workers/config.ts
+++ b/src/workers/config.ts
@@ -1,3 +1,4 @@
 export const Queues = {
   ItemExport: { queueName: 'item-export', jobs: { exportFolderZip: 'export-folder-zip' } },
+  SearchIndex: { queueName: 'search-index', jobs: { buildIndex: 'build-index' } },
 } as const;

--- a/src/workers/dashboard.controller.ts
+++ b/src/workers/dashboard.controller.ts
@@ -15,6 +15,7 @@ export const queueDashboardPlugin: FastifyPluginAsyncTypebox = async (instance) 
 
     const queues = [
       new Queue(Queues.ItemExport.queueName, { connection: { url: REDIS_CONNECTION } }),
+      new Queue(Queues.SearchIndex.queueName, { connection: { url: REDIS_CONNECTION } }),
     ];
 
     createBullBoard({

--- a/src/workers/entrypoint.ts
+++ b/src/workers/entrypoint.ts
@@ -5,9 +5,10 @@ import { registerDependencies } from '../di/container';
 import { resolveDependency } from '../di/utils';
 import { CRON_3AM_MONDAY, JobServiceBuilder } from '../jobs';
 import { BaseLogger } from '../logger';
-import { SearchService } from '../services/item/plugins/publication/published/plugins/search/search.service';
 import { ItemExportRequestService } from './itemExportRequest.service';
 import { ItemExportRequestWorker } from './itemExportRequest.worker';
+import { SearchIndexService } from './searchIndex.service';
+import { SearchIndexWorker } from './searchIndex.worker';
 
 const start = async () => {
   // register tsyringe dependencies
@@ -16,11 +17,15 @@ const start = async () => {
 
   logger.debug('STARTING WORKERS');
 
+  // start search index worker
+  const searchIndexService = resolveDependency(SearchIndexService);
+  new SearchIndexWorker(searchIndexService, logger);
+
   // worker for rebuild meilisearch index
   const jobServiceBuilder = new JobServiceBuilder(resolveDependency(BaseLogger));
   jobServiceBuilder
     .registerTask('rebuild-index', {
-      handler: () => resolveDependency(SearchService).rebuildIndex(),
+      handler: () => resolveDependency(SearchIndexService).buildIndex(),
       pattern: CRON_3AM_MONDAY,
     })
     .build();
@@ -28,6 +33,7 @@ const start = async () => {
   // start item export request worker
   const itemExportRequestService = resolveDependency(ItemExportRequestService);
   new ItemExportRequestWorker(itemExportRequestService, logger);
+
   logger.debug('WORKERS READY');
 };
 

--- a/src/workers/itemExportRequest.worker.ts
+++ b/src/workers/itemExportRequest.worker.ts
@@ -61,11 +61,13 @@ export class ItemExportRequestWorker {
     });
 
     this.worker.on('active', (job) => {
-      this.logger.info(`${job.id} is now active!`);
+      this.logger.info(`${job.queueName}'s ${job.id} is now active!`);
     });
 
     this.worker.on('failed', (job, err) => {
-      this.logger.info(`${job?.id ?? 'unknown job'} has failed with ${err.message}`);
+      this.logger.info(
+        `${job?.queueName}'s ${job?.id ?? 'unknown job'} has failed with ${err.message}`,
+      );
     });
 
     this.worker.on('error', (err) => {

--- a/src/workers/itemExportRequest.worker.ts
+++ b/src/workers/itemExportRequest.worker.ts
@@ -57,7 +57,7 @@ export class ItemExportRequestWorker {
     );
 
     this.worker.on('completed', (job) => {
-      this.logger.info(`${job.id} has completed!`);
+      this.logger.info(`${job.queueName}'s ${job.id} has completed!`);
     });
 
     this.worker.on('active', (job) => {

--- a/src/workers/searchIndex.service.test.ts
+++ b/src/workers/searchIndex.service.test.ts
@@ -114,7 +114,7 @@ describe('SearchIndexService', () => {
         .spyOn(meilisearchWrapper, 'index')
         .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
 
-      await meilisearch.buildIndex(10);
+      await meilisearch.buildIndex({ pageSize: 10 });
 
       expect(meilisearchWrapper.index).toHaveBeenCalledTimes(2);
       expect(indexSpy.mock.calls[0][1]).toEqual(publishedItemsInDb.slice(0, 10));

--- a/src/workers/searchIndex.service.test.ts
+++ b/src/workers/searchIndex.service.test.ts
@@ -75,6 +75,8 @@ jest
   .spyOn(fakeClient, 'waitForTask')
   .mockResolvedValue({ status: TaskStatus.TASK_SUCCEEDED } as Task);
 
+jest.spyOn(db, 'transaction').mockImplementation(async (fn) => await fn({} as never));
+
 const itemPublishedRepository = new ItemPublishedRepository();
 const meilisearchWrapper = {
   index: jest.fn(),
@@ -94,11 +96,9 @@ describe('SearchIndexService', () => {
 
   describe('builds index', () => {
     it('index all items', async () => {
-      jest.spyOn(db, 'transaction').mockImplementation(async (fn) => await fn({} as never));
       const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
         return mockItemPublished({ id: index.toString(), path: index.toString() });
       });
-      // fake pagination
       jest
         .spyOn(itemPublishedRepository, 'getPaginatedItems')
         .mockImplementation(async (_db, page, _) => {

--- a/src/workers/searchIndex.service.test.ts
+++ b/src/workers/searchIndex.service.test.ts
@@ -1,0 +1,124 @@
+import { expect, jest } from '@jest/globals';
+import { EnqueuedTask, Index, MeiliSearch, Task, TaskStatus } from 'meilisearch';
+import { v4 } from 'uuid';
+
+import { type IndexItem } from '@graasp/sdk';
+
+import { MOCK_LOGGER } from '../../test/app';
+import { ItemFactory } from '../../test/factories/item.factory';
+import { db } from '../drizzle/db';
+import { ItemPublishedWithItemWithCreator } from '../drizzle/types';
+import { ItemPublishedRepository } from '../services/item/plugins/publication/published/itemPublished.repository';
+import { MeiliSearchWrapper } from '../services/item/plugins/publication/published/plugins/search/meilisearch';
+import { SearchIndexService } from './searchIndex.service';
+
+const mockItemPublished = ({
+  id,
+  path,
+}: {
+  id: string;
+  path: string;
+}): ItemPublishedWithItemWithCreator => {
+  return {
+    id,
+    creatorId: v4(),
+    item: { ...ItemFactory({ id, path }), creator: null },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    itemPath: path,
+  };
+};
+
+const mockIndex = {
+  addDocuments: jest.fn(() => {
+    return Promise.resolve({ taskUid: '1' } as unknown as EnqueuedTask);
+  }),
+  waitForTask: jest.fn(() => {
+    return Promise.resolve({ status: TaskStatus.TASK_SUCCEEDED } as Task);
+  }),
+  waitForTasks: jest.fn(() => {
+    return Promise.resolve({ status: TaskStatus.TASK_SUCCEEDED } as Task);
+  }),
+  deleteDocuments: jest.fn(() => {
+    return Promise.resolve({ taskUid: '1' } as unknown as EnqueuedTask);
+  }),
+  deleteAllDocuments: jest.fn(() => {
+    return Promise.resolve({ taskUid: '1' } as unknown as EnqueuedTask);
+  }),
+  updateSettings: jest.fn(() => {
+    return Promise.resolve({ taskUid: '1' } as unknown as EnqueuedTask);
+  }),
+} as unknown as jest.Mocked<Index<IndexItem>>;
+
+const fakeClient = new MeiliSearch({
+  host: 'fake',
+  apiKey: 'fake',
+  httpClient: () => Promise.resolve(),
+});
+
+jest.spyOn(fakeClient, 'getIndex').mockResolvedValue(mockIndex);
+jest.spyOn(fakeClient, 'index').mockReturnValue({
+  updateFaceting: jest.fn(async () => {
+    return { taskUid: '1' } as unknown as EnqueuedTask;
+  }),
+  updateSettings: jest.fn(() => {
+    return Promise.resolve({ taskUid: '1' } as unknown as EnqueuedTask);
+  }),
+  waitForTask: jest.fn(() => {
+    return Promise.resolve({ status: TaskStatus.TASK_SUCCEEDED } as Task);
+  }),
+} as never);
+jest
+  .spyOn(fakeClient, 'swapIndexes')
+  .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
+jest
+  .spyOn(fakeClient, 'waitForTask')
+  .mockResolvedValue({ status: TaskStatus.TASK_SUCCEEDED } as Task);
+
+const itemPublishedRepository = new ItemPublishedRepository();
+const meilisearchWrapper = {
+  index: jest.fn(),
+} as unknown as MeiliSearchWrapper;
+
+const meilisearch = new SearchIndexService(
+  fakeClient,
+  itemPublishedRepository,
+  meilisearchWrapper,
+  MOCK_LOGGER,
+);
+
+describe('SearchIndexService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('builds index', () => {
+    it('index all items', async () => {
+      jest.spyOn(db, 'transaction').mockImplementation(async (fn) => await fn({} as never));
+      const publishedItemsInDb = Array.from({ length: 13 }, (_, index) => {
+        return mockItemPublished({ id: index.toString(), path: index.toString() });
+      });
+      // fake pagination
+      jest
+        .spyOn(itemPublishedRepository, 'getPaginatedItems')
+        .mockImplementation(async (_db, page, _) => {
+          if (page === 1) {
+            return [publishedItemsInDb.slice(0, 10), publishedItemsInDb.length];
+          } else if (page === 2) {
+            return [publishedItemsInDb.slice(10), publishedItemsInDb.length];
+          } else {
+            throw new Error();
+          }
+        });
+      const indexSpy = jest
+        .spyOn(meilisearchWrapper, 'index')
+        .mockResolvedValue({ taskUid: '1' } as unknown as EnqueuedTask);
+
+      await meilisearch.buildIndex(10);
+
+      expect(meilisearchWrapper.index).toHaveBeenCalledTimes(2);
+      expect(indexSpy.mock.calls[0][1]).toEqual(publishedItemsInDb.slice(0, 10));
+      expect(indexSpy.mock.calls[1][1]).toEqual(publishedItemsInDb.slice(10));
+    });
+  });
+});

--- a/src/workers/searchIndex.service.ts
+++ b/src/workers/searchIndex.service.ts
@@ -1,7 +1,7 @@
 import {
   EnqueuedTask,
   Index,
-  type MeiliSearch,
+  MeiliSearch,
   MeiliSearchApiError,
   MeiliSearchTimeOutError,
   TypoTolerance,

--- a/src/workers/searchIndex.service.ts
+++ b/src/workers/searchIndex.service.ts
@@ -85,7 +85,7 @@ export class SearchIndexService {
   }
 
   // to be executed by async job runner when desired
-  async buildIndex(pageSize: number = 10) {
+  async buildIndex({ pageSize = 10 }: { pageSize?: number } = {}) {
     // Ensure that there is an active index before rebuilding
     try {
       await this.meilisearchClient.getIndex(ACTIVE_INDEX);

--- a/src/workers/searchIndex.service.ts
+++ b/src/workers/searchIndex.service.ts
@@ -68,8 +68,8 @@ const TYPO_TOLERANCE: TypoTolerance = {
 export class SearchIndexService {
   private readonly meilisearchClient: MeiliSearch;
   private readonly meilisearchWrapper: MeiliSearchWrapper;
-  private logger: BaseLogger;
   private readonly itemPublishedRepository: ItemPublishedRepository;
+  private readonly logger: BaseLogger;
 
   constructor(
     meilisearchConnection: MeiliSearch,

--- a/src/workers/searchIndex.service.ts
+++ b/src/workers/searchIndex.service.ts
@@ -1,0 +1,228 @@
+import {
+  EnqueuedTask,
+  Index,
+  type MeiliSearch,
+  MeiliSearchApiError,
+  MeiliSearchTimeOutError,
+  TypoTolerance,
+} from 'meilisearch';
+import { singleton } from 'tsyringe';
+
+import { IndexItem } from '@graasp/sdk';
+
+import { db } from '../drizzle/db';
+import { BaseLogger } from '../logger';
+import { ItemPublishedRepository } from '../services/item/plugins/publication/published/itemPublished.repository';
+import {
+  ACTIVE_INDEX,
+  AllowedIndices,
+  MeiliSearchWrapper,
+  ROTATING_INDEX,
+} from '../services/item/plugins/publication/published/plugins/search/meilisearch';
+import { FILTERABLE_ATTRIBUTES } from '../services/item/plugins/publication/published/plugins/search/search.constants';
+import { TagCategory } from '../services/tag/tag.schemas';
+
+// Make index configuration typesafe
+const SEARCHABLE_ATTRIBUTES: (keyof IndexItem)[] = [
+  'name',
+  'description',
+  'content',
+  'creator',
+  ...Object.values(TagCategory),
+];
+const SORT_ATTRIBUTES: (keyof IndexItem)[] = [
+  'name',
+  'updatedAt',
+  'createdAt',
+  'publicationUpdatedAt',
+  'likes',
+];
+const DISPLAY_ATTRIBUTES: (keyof IndexItem)[] = [
+  'id',
+  'name',
+  'creator',
+  'description',
+  'type',
+  'content',
+  'createdAt',
+  'updatedAt',
+  'publicationUpdatedAt',
+  'isPublishedRoot',
+  'isHidden',
+  'lang',
+  'likes',
+  TagCategory.Level,
+  TagCategory.Discipline,
+  TagCategory.ResourceType,
+];
+
+const TYPO_TOLERANCE: TypoTolerance = {
+  enabled: true,
+  minWordSizeForTypos: {
+    oneTypo: 4,
+    twoTypos: 6,
+  },
+};
+
+@singleton()
+export class SearchIndexService {
+  private readonly meilisearchClient: MeiliSearch;
+  private readonly meilisearchWrapper: MeiliSearchWrapper;
+  private logger: BaseLogger;
+  private readonly itemPublishedRepository: ItemPublishedRepository;
+
+  constructor(
+    meilisearchConnection: MeiliSearch,
+    itemPublishedRepository: ItemPublishedRepository,
+    meilisearchWrapper: MeiliSearchWrapper,
+    logger: BaseLogger,
+  ) {
+    this.meilisearchClient = meilisearchConnection;
+    this.itemPublishedRepository = itemPublishedRepository;
+    // TODO: remove once indexing a single item is a job
+    this.meilisearchWrapper = meilisearchWrapper;
+    this.logger = logger;
+  }
+
+  // to be executed by async job runner when desired
+  async buildIndex(pageSize: number = 10) {
+    // Ensure that there is an active index before rebuilding
+    try {
+      await this.meilisearchClient.getIndex(ACTIVE_INDEX);
+    } catch (err) {
+      if (err instanceof MeiliSearchApiError && err.code === 'index_not_found') {
+        const task = await this.meilisearchClient.createIndex(ACTIVE_INDEX);
+        await this.meilisearchClient.waitForTask(task.taskUid);
+      }
+      throw err;
+    }
+
+    this.logger.info('REBUILD INDEX: Starting index rebuild...');
+    const tmpIndex = await this.getOrCreateIndex(ROTATING_INDEX);
+
+    // Delete existing document if any
+    this.logger.info('REBUILD INDEX: Cleaning temporary index...');
+    await tmpIndex.waitForTask((await tmpIndex.deleteAllDocuments()).taskUid);
+
+    await this.updateIndexSettings(ROTATING_INDEX);
+
+    this.logger.info('REBUILD INDEX: Starting indexation...');
+
+    // Paginate with cursor through DB items (serializable transaction)
+    // This is not executed in a HTTP request context so we can't rely on fastify to create a transaction at the controller level
+    // SERIALIZABLE because we don't want other transaction to affect this one while it goes through the pages.
+    await db.transaction(
+      async (tx) => {
+        const tasks: EnqueuedTask[] = [];
+
+        // instanciate the itempublished repository to use the provided transaction manager
+        let currentPage = 1;
+        let total = 0;
+        while (currentPage === 1 || (currentPage - 1) * pageSize < total) {
+          // Retrieve a page (i.e. 20 items)
+          const [published, totalCount] = await this.itemPublishedRepository.getPaginatedItems(
+            tx,
+            currentPage,
+            pageSize,
+          );
+          this.logger.info(
+            `REBUILD INDEX: Page ${currentPage} - ${published.length} items - total count: ${totalCount}`,
+          );
+          total = totalCount;
+
+          // Index items (1 task per page)
+          try {
+            // TODO: transform index into a job
+            const task = await this.meilisearchWrapper.index(tx, published, ROTATING_INDEX);
+            this.logger.info(
+              `REBUILD INDEX: Pushing indexing task ${task.taskUid} (page ${currentPage})`,
+            );
+            tasks.push(task);
+          } catch (e) {
+            this.logger.error(`REBUILD INDEX: Error during one rebuild index task: ${e}`);
+          }
+
+          currentPage++;
+        }
+        this.logger.info(`REBUILD INDEX: Waiting for ${tasks.length} tasks to terminate...`);
+        // Wait to be sure that everything is indexed
+        // We don't use `waitForTasks` directly because we want to be able to handle error
+        // for one task and still be able to await other tasks
+        for (const taskUid of tasks.map((t) => t.taskUid)) {
+          try {
+            await tmpIndex.waitForTask(taskUid, { timeOutMs: 60_000, intervalMs: 1000 });
+          } catch (e) {
+            if (e instanceof MeiliSearchTimeOutError) {
+              this.logger.info(
+                `REBUILD INDEX: timeout from MeiliSearch while waiting for task ${taskUid}`,
+              );
+            } else {
+              this.logger.warn(e);
+            }
+          }
+        }
+      },
+      { isolationLevel: 'serializable' },
+    );
+
+    // Swap tmp index with actual index
+    this.logger.info(`REBUILD INDEX: Swapping indexes...`);
+    const swapTask = await this.meilisearchClient.swapIndexes([
+      { indexes: [ACTIVE_INDEX, ROTATING_INDEX] },
+    ]);
+    await this.meilisearchClient.waitForTask(swapTask.taskUid);
+
+    this.logger.info(`REBUILD INDEX: Index rebuild successful!`);
+
+    await this.updateFacetSettings(ACTIVE_INDEX);
+    await this.updateIndexSettings(ACTIVE_INDEX);
+
+    this.logger.info(`REBUILD INDEX: Index settings and facets configuration successful!`);
+
+    // Retry if the rebuild fail? Or let retry by a Bull task
+  }
+
+  /* return meilisearch index or create it
+   */
+  private async getOrCreateIndex(name: AllowedIndices): Promise<Index<IndexItem>> {
+    try {
+      const index = await this.meilisearchClient.getIndex(name);
+      return index;
+    } catch (err) {
+      if (err instanceof MeiliSearchApiError && err.code === 'index_not_found') {
+        const task = await this.meilisearchClient.createIndex(name);
+        await this.meilisearchClient.waitForTask(task.taskUid);
+
+        return await this.meilisearchClient.getIndex(name);
+      }
+
+      throw err;
+    }
+  }
+
+  private async updateIndexSettings(indexName: AllowedIndices) {
+    const index = this.meilisearchClient.index(indexName);
+    // Update index config
+    const updateSettingsTask = await index.updateSettings({
+      searchableAttributes: SEARCHABLE_ATTRIBUTES,
+      displayedAttributes: DISPLAY_ATTRIBUTES,
+      filterableAttributes: [...FILTERABLE_ATTRIBUTES], // make a shallow copy because the initial parameter is readonly,
+      sortableAttributes: SORT_ATTRIBUTES,
+      typoTolerance: TYPO_TOLERANCE,
+    });
+    await index.waitForTask(updateSettingsTask.taskUid);
+  }
+
+  /**
+   * Update facet settings for active index
+   */
+  private async updateFacetSettings(indexName: AllowedIndices) {
+    // set facetting order to count for tag categories
+    await this.meilisearchClient.index(indexName).updateFaceting({
+      // return max 50 values per facet for facet distribution
+      // it is interesting to receive a lot of values for listing
+      maxValuesPerFacet: 50,
+      sortFacetValuesBy: Object.fromEntries(Object.values(TagCategory).map((c) => [c, 'count'])),
+    });
+  }
+}

--- a/src/workers/searchIndex.worker.spec.ts
+++ b/src/workers/searchIndex.worker.spec.ts
@@ -8,6 +8,7 @@ import { SearchIndexWorker } from './searchIndex.worker';
 
 // mock for the SearchIndexService
 const SearchIndexServiceMock = vi.fn();
+SearchIndexServiceMock.prototype.buildIndex = vi.fn();
 
 // logger mock
 const BaseLogger = vi.fn();

--- a/src/workers/searchIndex.worker.spec.ts
+++ b/src/workers/searchIndex.worker.spec.ts
@@ -1,0 +1,66 @@
+import { Queue } from 'bullmq';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { REDIS_CONNECTION } from '../config/redis';
+import { Queues } from './config';
+import { SearchIndexService } from './searchIndex.service';
+import { SearchIndexWorker } from './searchIndex.worker';
+
+// mock for the SearchIndexService
+const SearchIndexServiceMock = vi.fn();
+
+// logger mock
+const BaseLogger = vi.fn();
+BaseLogger.prototype.debug = vi.fn();
+BaseLogger.prototype.info = vi.fn();
+BaseLogger.prototype.warning = vi.fn();
+BaseLogger.prototype.error = vi.fn();
+
+describe('SearchIndex worker', { sequential: true }, () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  it('handles job', async () => {
+    const searchIndexService: SearchIndexService = new SearchIndexServiceMock();
+    const _worker = new SearchIndexWorker(searchIndexService, new BaseLogger());
+    const queue = new Queue(Queues.SearchIndex.queueName, {
+      connection: { url: REDIS_CONNECTION },
+    });
+    const job = await queue.add(Queues.SearchIndex.jobs.buildIndex, {});
+
+    await expect
+      .poll(async () => {
+        const jobs = await queue.getCompleted();
+        const job = jobs.find((job) => job.name === Queues.SearchIndex.jobs.buildIndex);
+        return job;
+      })
+      .toBeTruthy();
+    expect(job.isCompleted).toBeTruthy();
+
+    // expect the exportFolder to have been called
+    expect(searchIndexService.buildIndex).toHaveBeenCalled();
+  });
+
+  it('fail if processing throws', async () => {
+    const searchIndexService: SearchIndexService = new SearchIndexServiceMock();
+    // make the export processing fail
+    vi.mocked(searchIndexService).buildIndex.mockRejectedValueOnce(
+      new Error('unexpected precessing error'),
+    );
+    const _worker = new SearchIndexWorker(searchIndexService, new BaseLogger());
+    const queue = new Queue(Queues.SearchIndex.queueName, {
+      connection: { url: REDIS_CONNECTION },
+    });
+    await queue.add(Queues.SearchIndex.jobs.buildIndex, {});
+
+    await expect
+      .poll(async () => {
+        const failedJobs = await queue.getFailed();
+        const job = failedJobs.find((job) => job.name === Queues.SearchIndex.jobs.buildIndex);
+        return job;
+      })
+      .toBeTruthy();
+    // expect the exportFolder to have been called
+    expect(searchIndexService.buildIndex).toHaveBeenCalled();
+  });
+});

--- a/src/workers/searchIndex.worker.ts
+++ b/src/workers/searchIndex.worker.ts
@@ -1,7 +1,7 @@
 import { type Job, Worker } from 'bullmq';
 
 import { REDIS_CONNECTION } from '../config/redis';
-import { BaseLogger } from '../logger';
+import { type BaseLogger } from '../logger';
 import { Queues } from './config';
 import { SearchIndexService } from './searchIndex.service';
 

--- a/src/workers/searchIndex.worker.ts
+++ b/src/workers/searchIndex.worker.ts
@@ -1,0 +1,57 @@
+import { type Job, Worker } from 'bullmq';
+
+import { REDIS_CONNECTION } from '../config/redis';
+import { BaseLogger } from '../logger';
+import { Queues } from './config';
+import { SearchIndexService } from './searchIndex.service';
+
+type BuildIndexJob = Job;
+
+// define a local alias
+const JobTypes = Queues.SearchIndex.jobs;
+
+export class SearchIndexWorker {
+  private readonly SearchIndexService: SearchIndexService;
+  private readonly logger: BaseLogger;
+  private worker: Worker;
+
+  constructor(SearchIndexService: SearchIndexService, logger: BaseLogger) {
+    this.logger = logger;
+    this.SearchIndexService = SearchIndexService;
+
+    this.worker = new Worker(
+      Queues.SearchIndex.queueName,
+      async (job: BuildIndexJob) => {
+        switch (job.name) {
+          case JobTypes.buildIndex: {
+            await this.SearchIndexService.buildIndex();
+            return 'success';
+          }
+          // other job type this worker can handle
+        }
+      },
+      {
+        connection: { url: REDIS_CONNECTION },
+        removeOnComplete: { count: 30 },
+        removeOnFail: { count: 100 },
+      },
+    );
+
+    this.worker.on('completed', (job) => {
+      this.logger.info(`${job.id} has completed!`);
+    });
+
+    this.worker.on('active', (job) => {
+      this.logger.info(`${job.id} is now active!`);
+    });
+
+    this.worker.on('failed', (job, err) => {
+      this.logger.info(`${job?.id ?? 'unknown job'} has failed with ${err.message}`);
+    });
+
+    this.worker.on('error', (err) => {
+      // log the error
+      this.logger.error(err);
+    });
+  }
+}

--- a/src/workers/searchIndex.worker.ts
+++ b/src/workers/searchIndex.worker.ts
@@ -42,11 +42,13 @@ export class SearchIndexWorker {
     });
 
     this.worker.on('active', (job) => {
-      this.logger.info(`${job.id} is now active!`);
+      this.logger.info(`${job.queueName}'s ${job.id} is now active!`);
     });
 
     this.worker.on('failed', (job, err) => {
-      this.logger.info(`${job?.id ?? 'unknown job'} has failed with ${err.message}`);
+      this.logger.info(
+        `${job?.queueName}'s ${job?.id ?? 'unknown job'} has failed with ${err.message}`,
+      );
     });
 
     this.worker.on('error', (err) => {

--- a/src/workers/searchIndex.worker.ts
+++ b/src/workers/searchIndex.worker.ts
@@ -13,7 +13,7 @@ const JobTypes = Queues.SearchIndex.jobs;
 export class SearchIndexWorker {
   private readonly SearchIndexService: SearchIndexService;
   private readonly logger: BaseLogger;
-  private worker: Worker;
+  private readonly worker: Worker;
 
   constructor(SearchIndexService: SearchIndexService, logger: BaseLogger) {
     this.logger = logger;
@@ -38,7 +38,7 @@ export class SearchIndexWorker {
     );
 
     this.worker.on('completed', (job) => {
-      this.logger.info(`${job.id} has completed!`);
+      this.logger.info(`${job.queueName}'s ${job.id} has completed!`);
     });
 
     this.worker.on('active', (job) => {


### PR DESCRIPTION
Create a new worker to handle build index task.
Remove pre-task of fetching pdf content, as we do it on upload.

For now, it uses `MeilisearchWrapper` as dependency to index items. In the next PR, indexing item should be a job as well.

close #1927 