### PR TITLE
feat(password): set login session in password login

### DIFF
--- a/src/services/auth/plugins/magicLink/magicLink.controller.test.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.controller.test.ts
@@ -220,10 +220,10 @@ describe('Auth routes tests', () => {
     });
   });
 
-  describe('GET /logout', () => {
+  describe('POST /logout', () => {
     it('Authenticate successfully', async () => {
       const response = await app.inject({
-        method: HttpMethod.Get,
+        method: HttpMethod.Post,
         url: '/logout',
       });
       expect(response.statusCode).toEqual(StatusCodes.NO_CONTENT);

--- a/src/services/auth/plugins/magicLink/magicLink.controller.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.controller.ts
@@ -18,7 +18,7 @@ import { getRedirectionLink } from '../../utils';
 import captchaPreHandler from '../captcha/captcha';
 import { PassportStrategy } from '../passport/strategies';
 import type { PassportInfo } from '../passport/types';
-import { auth, login, register } from './magicLink.schemas';
+import { auth, login, register, signOut } from './magicLink.schemas';
 import { MagicLinkService } from './magicLink.service';
 
 const ERROR_SEARCH_PARAM = 'error';
@@ -119,7 +119,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   );
 
   // logout
-  fastify.get('/logout', async (request, reply) => {
+  fastify.post('/logout', { schema: signOut }, async (request, reply) => {
     // logout user, so subsequent calls can not make use of the current user.
     request.logout();
     // remove session so the cookie is removed by the browser

--- a/src/services/auth/plugins/magicLink/magicLink.schemas.ts
+++ b/src/services/auth/plugins/magicLink/magicLink.schemas.ts
@@ -63,3 +63,15 @@ export const auth = {
     '4xx': errorSchemaRef,
   },
 } as const satisfies FastifySchema;
+
+export const signOut = {
+  operationId: 'signOut',
+  tags: ['authentication'],
+  summary: 'Log out',
+  description: 'Log out from current session',
+
+  response: {
+    [StatusCodes.NO_CONTENT]: Type.Null({ description: 'Successful Response' }),
+    '4xx': errorSchemaRef,
+  },
+} as const satisfies FastifySchema;

--- a/src/services/auth/plugins/password/password.controller.test.ts
+++ b/src/services/auth/plugins/password/password.controller.test.ts
@@ -99,7 +99,7 @@ describe('Password', () => {
 
       // last authenticated at should be updated
       const m = await db.query.accountsTable.findFirst({
-        where: eq(accountsTable.email, actor.email),
+        where: eq(accountsTable.email, actor.email!),
       });
       expect(m?.lastAuthenticatedAt).not.toEqual(actor.lastAuthenticatedAt);
     });

--- a/src/services/auth/plugins/password/password.schemas.ts
+++ b/src/services/auth/plugins/password/password.schemas.ts
@@ -22,9 +22,7 @@ export const signInWithPassword = {
     lang: Type.Optional(Type.String()),
   }),
   response: {
-    [StatusCodes.OK]: customType.StrictObject({
-      resource: Type.String({ description: 'Redirection link' }),
-    }),
+    [StatusCodes.NO_CONTENT]: Type.Null({ description: 'Successful Response' }),
     '4xx': errorSchemaRef,
     '5xx': errorSchemaRef,
   },

--- a/src/services/auth/plugins/password/password.schemas.ts
+++ b/src/services/auth/plugins/password/password.schemas.ts
@@ -16,7 +16,6 @@ export const signInWithPassword = {
     email: Type.String({ format: 'email' }),
     password: Type.String(),
     captcha: Type.String(),
-    url: Type.Optional(Type.String({ format: 'uri' })),
   }),
   querystring: customType.StrictObject({
     lang: Type.Optional(Type.String()),


### PR DESCRIPTION
On password login, the `/auth` redirection link was returned as a string so the frontend could redirect manually.

Instead, we directly sign in the user in the `/login-password`. The redirection to some interface will happen in the frontend.