### PR TITLE
feat: create page endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "5.1.0",
     "@fastify/websocket": "11.0.2",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "5.14.0",
+    "@graasp/sdk": "github:graasp/graasp-sdk#page",
     "@graasp/translations": "1.44.0",
     "@rapideditor/country-coder": "5.4.0",
     "@sentry/node": "7.119.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@fastify/type-provider-typebox": "5.1.0",
     "@fastify/websocket": "11.0.2",
     "@graasp/etherpad-api": "2.1.1",
-    "@graasp/sdk": "github:graasp/graasp-sdk#page",
+    "@graasp/sdk": "5.15.0",
     "@graasp/translations": "1.44.0",
     "@rapideditor/country-coder": "5.4.0",
     "@sentry/node": "7.119.2",

--- a/src/drizzle/0008_page.sql
+++ b/src/drizzle/0008_page.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "page" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"item_id" uuid NOT NULL,
+	"content" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "page" ADD CONSTRAINT "FK_page_item_id" FOREIGN KEY ("item_id") REFERENCES "public"."item"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/drizzle/0008_page.sql
+++ b/src/drizzle/0008_page.sql
@@ -1,9 +1,0 @@
-CREATE TABLE "page" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"item_id" uuid NOT NULL,
-	"content" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
-);
---> statement-breakpoint
-ALTER TABLE "page" ADD CONSTRAINT "FK_page_item_id" FOREIGN KEY ("item_id") REFERENCES "public"."item"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/drizzle/0009_page.sql
+++ b/src/drizzle/0009_page.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "page" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"item_id" uuid NOT NULL,
+	"content" jsonb DEFAULT '{}' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "page" ADD CONSTRAINT "FK_page_item_id" FOREIGN KEY ("item_id") REFERENCES "public"."item"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "IDX_page_item_id" ON "page" USING btree ("item_id" uuid_ops);

--- a/src/drizzle/meta/0008_snapshot.json
+++ b/src/drizzle/meta/0008_snapshot.json
@@ -112,12 +112,8 @@
           "name": "account_item_login_schema_id_item_login_schema_id_fk",
           "tableFrom": "account",
           "tableTo": "item_login_schema",
-          "columnsFrom": [
-            "item_login_schema_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_login_schema_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -127,17 +123,12 @@
         "UQ_account_name_item_login_schema_id": {
           "name": "UQ_account_name_item_login_schema_id",
           "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "item_login_schema_id"
-          ]
+          "columns": ["name", "item_login_schema_id"]
         },
         "member_email_key1": {
           "name": "member_email_key1",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -206,12 +197,8 @@
           "name": "FK_fea823c4374f507a68cf8f926a4",
           "tableFrom": "action_request_export",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -219,12 +206,8 @@
           "name": "FK_bc85ef3298df8c7974b33081b47",
           "tableFrom": "action_request_export",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -332,12 +315,8 @@
           "name": "FK_1214f6f4d832c402751617361c0",
           "tableFrom": "action",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -345,12 +324,8 @@
           "name": "FK_action_account_id",
           "tableFrom": "action",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -411,12 +386,8 @@
           "name": "FK_c415fc186dda51fa260d338d776",
           "tableFrom": "app_action",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -424,12 +395,8 @@
           "name": "FK_app_action_account_id",
           "tableFrom": "app_action",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -526,12 +493,8 @@
           "name": "FK_8c3e2463c67d9865658941c9e2d",
           "tableFrom": "app_data",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -539,12 +502,8 @@
           "name": "FK_27cb180cb3f372e4cf55302644a",
           "tableFrom": "app_data",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -552,12 +511,8 @@
           "name": "FK_app_data_account_id",
           "tableFrom": "app_data",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -649,12 +604,8 @@
           "name": "FK_f5922b885e2680beab8add96008",
           "tableFrom": "app_setting",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -662,12 +613,8 @@
           "name": "FK_22d3d051ee6f94932c1373a3d09",
           "tableFrom": "app_setting",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -748,12 +695,8 @@
           "name": "FK_37eb7baab82e11150157ec0b5a6",
           "tableFrom": "app",
           "tableTo": "publisher",
-          "columnsFrom": [
-            "publisher_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["publisher_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -763,23 +706,17 @@
         "app_key_key": {
           "name": "app_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "key"
-          ]
+          "columns": ["key"]
         },
         "UQ_f36adbb7b096ceeb6f3e80ad14c": {
           "name": "UQ_f36adbb7b096ceeb6f3e80ad14c",
           "nullsNotDistinct": false,
-          "columns": [
-            "name"
-          ]
+          "columns": ["name"]
         },
         "app_url_key": {
           "name": "app_url_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "url"
-          ]
+          "columns": ["url"]
         }
       },
       "policies": {},
@@ -817,10 +754,7 @@
         "category-name-type": {
           "name": "category-name-type",
           "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "type"
-          ]
+          "columns": ["name", "type"]
         }
       },
       "policies": {},
@@ -879,12 +813,8 @@
           "name": "chat_mention_message_id_chat_message_id_fk",
           "tableFrom": "chat_mention",
           "tableTo": "chat_message",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -892,12 +822,8 @@
           "name": "chat_mention_account_id_account_id_fk",
           "tableFrom": "chat_mention",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -905,12 +831,8 @@
           "name": "FK_e5199951167b722215127651e7c",
           "tableFrom": "chat_mention",
           "tableTo": "chat_message",
-          "columnsFrom": [
-            "message_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -918,12 +840,8 @@
           "name": "FK_chat_mention_account_id",
           "tableFrom": "chat_mention",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -984,12 +902,8 @@
           "name": "FK_b31e627ea7a4787672e265a1579",
           "tableFrom": "chat_message",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -997,12 +911,8 @@
           "name": "FK_71fdcb9038eca1b903102bdfd17",
           "tableFrom": "chat_message",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1057,12 +967,8 @@
           "name": "FK_guest_password_guest_id",
           "tableFrom": "guest_password",
           "tableTo": "account",
-          "columnsFrom": [
-            "guest_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1072,9 +978,7 @@
         "UQ_guest_password_guest_id": {
           "name": "UQ_guest_password_guest_id",
           "nullsNotDistinct": false,
-          "columns": [
-            "guest_id"
-          ]
+          "columns": ["guest_id"]
         }
       },
       "policies": {},
@@ -1145,12 +1049,8 @@
           "name": "invitation_creator_id_account_id_fk",
           "tableFrom": "invitation",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1158,12 +1058,8 @@
           "name": "invitation_item_path_item_path_fk",
           "tableFrom": "invitation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1171,12 +1067,8 @@
           "name": "FK_7ad4a490d5b9f79a677827b641c",
           "tableFrom": "invitation",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1184,12 +1076,8 @@
           "name": "FK_dc1d92accde1c2fbb7e729e4dcc",
           "tableFrom": "invitation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1199,10 +1087,7 @@
         "item-email": {
           "name": "item-email",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path",
-            "email"
-          ]
+          "columns": ["item_path", "email"]
         }
       },
       "policies": {},
@@ -1246,12 +1131,8 @@
           "name": "FK_a169d350392956511697f7e7d38",
           "tableFrom": "item_favorite",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1259,12 +1140,8 @@
           "name": "FK_10ea93bde287762010695378f94",
           "tableFrom": "item_favorite",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1274,10 +1151,7 @@
         "favorite_key": {
           "name": "favorite_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id",
-            "item_id"
-          ]
+          "columns": ["member_id", "item_id"]
         }
       },
       "policies": {},
@@ -1327,12 +1201,8 @@
           "name": "FK_638552fc7d9a2035c2b53182d8a",
           "tableFrom": "item_category",
           "tableTo": "category",
-          "columnsFrom": [
-            "category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1340,12 +1210,8 @@
           "name": "FK_9a34a079b5b24f4396462546d26",
           "tableFrom": "item_category",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1353,12 +1219,8 @@
           "name": "FK_5681d1785eea699e9cae8818fe0",
           "tableFrom": "item_category",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1368,10 +1230,7 @@
         "category-item": {
           "name": "category-item",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path",
-            "category_id"
-          ]
+          "columns": ["item_path", "category_id"]
         }
       },
       "policies": {},
@@ -1422,12 +1281,8 @@
           "name": "item_export_request_member_id_account_id_fk",
           "tableFrom": "item_export_request",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1435,12 +1290,8 @@
           "name": "item_export_request_item_id_item_id_fk",
           "tableFrom": "item_export_request",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1494,12 +1345,8 @@
           "name": "FK_b04d0adf4b73d82537c92fa55ea",
           "tableFrom": "item_flag",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1507,12 +1354,8 @@
           "name": "FK_bde9b9ab1da1483a71c9b916dd2",
           "tableFrom": "item_flag",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1522,11 +1365,7 @@
         "item-flag-creator": {
           "name": "item-flag-creator",
           "nullsNotDistinct": false,
-          "columns": [
-            "type",
-            "creator_id",
-            "item_id"
-          ]
+          "columns": ["type", "creator_id", "item_id"]
         }
       },
       "policies": {},
@@ -1601,12 +1440,8 @@
           "name": "FK_66d4b13df4e7765068c8268d719",
           "tableFrom": "item_geolocation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1616,9 +1451,7 @@
         "item_geolocation_unique_item": {
           "name": "item_geolocation_unique_item",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -1679,12 +1512,8 @@
           "name": "FK_4a56eba1ce30dc93f118a51ff26",
           "tableFrom": "item_like",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1692,12 +1521,8 @@
           "name": "FK_159827eb667d019dc71372d7463",
           "tableFrom": "item_like",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1707,10 +1532,7 @@
         "id": {
           "name": "id",
           "nullsNotDistinct": false,
-          "columns": [
-            "creator_id",
-            "item_id"
-          ]
+          "columns": ["creator_id", "item_id"]
         }
       },
       "policies": {},
@@ -1770,12 +1592,8 @@
           "name": "item_login_schema_item_path_item_path_fk",
           "tableFrom": "item_login_schema",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1785,9 +1603,7 @@
         "item-login-schema": {
           "name": "item-login-schema",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -1939,12 +1755,8 @@
           "name": "item_membership_item_path_item_path_fk",
           "tableFrom": "item_membership",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1952,12 +1764,8 @@
           "name": "item_membership_creator_id_account_id_fk",
           "tableFrom": "item_membership",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1965,12 +1773,8 @@
           "name": "item_membership_account_id_account_id_fk",
           "tableFrom": "item_membership",
           "tableTo": "account",
-          "columnsFrom": [
-            "account_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1980,10 +1784,7 @@
         "item_membership-item-member": {
           "name": "item_membership-item-member",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path",
-            "account_id"
-          ]
+          "columns": ["item_path", "account_id"]
         }
       },
       "policies": {},
@@ -2030,12 +1831,8 @@
           "name": "FK_16ab8afb42f763f7cbaa4bff66a",
           "tableFrom": "item_tag",
           "tableTo": "tag",
-          "columnsFrom": [
-            "tag_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2043,12 +1840,8 @@
           "name": "FK_39b492fda03c7ac846afe164b58",
           "tableFrom": "item_tag",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2056,20 +1849,14 @@
       "compositePrimaryKeys": {
         "PK_a04bb2298e37d95233a0c92347e": {
           "name": "PK_a04bb2298e37d95233a0c92347e",
-          "columns": [
-            "tag_id",
-            "item_id"
-          ]
+          "columns": ["tag_id", "item_id"]
         }
       },
       "uniqueConstraints": {
         "UQ_item_tag": {
           "name": "UQ_item_tag",
           "nullsNotDistinct": false,
-          "columns": [
-            "tag_id",
-            "item_id"
-          ]
+          "columns": ["tag_id", "item_id"]
         }
       },
       "policies": {},
@@ -2107,12 +1894,8 @@
           "name": "FK_a9e83cf5f53c026b774b53d3c60",
           "tableFrom": "item_validation_group",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2179,12 +1962,8 @@
           "name": "FK_59fd000835c70c728e525d82950",
           "tableFrom": "item_validation_review",
           "tableTo": "item_validation",
-          "columnsFrom": [
-            "item_validation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_validation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2192,12 +1971,8 @@
           "name": "FK_44bf14fee580ae08702d70e622e",
           "tableFrom": "item_validation_review",
           "tableTo": "account",
-          "columnsFrom": [
-            "reviewer_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["reviewer_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2272,12 +2047,8 @@
           "name": "FK_d60969d5e478e7c844532ac4e7f",
           "tableFrom": "item_validation",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2285,12 +2056,8 @@
           "name": "FK_e92da280941f666acf87baedc65",
           "tableFrom": "item_validation",
           "tableTo": "item_validation_group",
-          "columnsFrom": [
-            "item_validation_group_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_validation_group_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2362,12 +2129,8 @@
           "name": "FK_item_visibility_creator",
           "tableFrom": "item_visibility",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -2375,12 +2138,8 @@
           "name": "FK_item_visibility_item",
           "tableFrom": "item_visibility",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2390,10 +2149,7 @@
         "UQ_item_visibility_item_type": {
           "name": "UQ_item_visibility_item_type",
           "nullsNotDistinct": false,
-          "columns": [
-            "type",
-            "item_path"
-          ]
+          "columns": ["type", "item_path"]
         }
       },
       "policies": {},
@@ -2545,12 +2301,8 @@
           "name": "FK_bdc46717fadc2f04f3093e51fd5",
           "tableFrom": "item",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -2560,9 +2312,7 @@
         "item_path_key1": {
           "name": "item_path_key1",
           "nullsNotDistinct": false,
-          "columns": [
-            "path"
-          ]
+          "columns": ["path"]
         }
       },
       "policies": {},
@@ -2599,9 +2349,7 @@
         "UQ_maintenance_slug": {
           "name": "UQ_maintenance_slug",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -2652,12 +2400,8 @@
           "name": "member_password_member_id_account_id_fk",
           "tableFrom": "member_password",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2667,9 +2411,7 @@
         "member-password": {
           "name": "member-password",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id"
-          ]
+          "columns": ["member_id"]
         }
       },
       "policies": {},
@@ -2762,12 +2504,8 @@
           "name": "member_profile_member_id_account_id_fk",
           "tableFrom": "member_profile",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2775,12 +2513,8 @@
           "name": "FK_91fa43bc5482dc6b00892baf016",
           "tableFrom": "member_profile",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2790,9 +2524,7 @@
         "member-profile": {
           "name": "member-profile",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id"
-          ]
+          "columns": ["member_id"]
         }
       },
       "policies": {},
@@ -2836,12 +2568,8 @@
           "name": "FK_membership_request_member_id",
           "tableFrom": "membership_request",
           "tableTo": "account",
-          "columnsFrom": [
-            "member_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2849,12 +2577,8 @@
           "name": "FK_membership_request_item_id",
           "tableFrom": "membership_request",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2864,10 +2588,7 @@
         "UQ_membership_request_item-member": {
           "name": "UQ_membership_request_item-member",
           "nullsNotDistinct": false,
-          "columns": [
-            "member_id",
-            "item_id"
-          ]
+          "columns": ["member_id", "item_id"]
         }
       },
       "policies": {},
@@ -2935,12 +2656,8 @@
           "name": "item_published_creator_id_account_id_fk",
           "tableFrom": "item_published",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -2948,12 +2665,8 @@
           "name": "item_published_item_path_item_path_fk",
           "tableFrom": "item_published",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2963,9 +2676,7 @@
         "published-item": {
           "name": "published-item",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -3017,9 +2728,7 @@
         "publisher_name_key": {
           "name": "publisher_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "name"
-          ]
+          "columns": ["name"]
         }
       },
       "policies": {},
@@ -3080,12 +2789,8 @@
           "name": "FK_3e3650ebd5c49843013429d510a",
           "tableFrom": "recycled_item_data",
           "tableTo": "account",
-          "columnsFrom": [
-            "creator_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -3093,12 +2798,8 @@
           "name": "FK_f8a4db4476e3d81e18de5d63c42",
           "tableFrom": "recycled_item_data",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_path"
-          ],
-          "columnsTo": [
-            "path"
-          ],
+          "columnsFrom": ["item_path"],
+          "columnsTo": ["path"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -3108,9 +2809,7 @@
         "recycled-item-data": {
           "name": "recycled-item-data",
           "nullsNotDistinct": false,
-          "columns": [
-            "item_path"
-          ]
+          "columns": ["item_path"]
         }
       },
       "policies": {},
@@ -3171,12 +2870,8 @@
           "name": "FK_43c8a0471d5e58f99fc9c36b991",
           "tableFrom": "short_link",
           "tableTo": "item",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -3186,10 +2881,7 @@
         "UQ_859a3384cadaa460b84e04e5375": {
           "name": "UQ_859a3384cadaa460b84e04e5375",
           "nullsNotDistinct": false,
-          "columns": [
-            "platform",
-            "item_id"
-          ]
+          "columns": ["platform", "item_id"]
         }
       },
       "policies": {},
@@ -3233,10 +2925,7 @@
         "UQ_tag_name_category": {
           "name": "UQ_tag_name_category",
           "nullsNotDistinct": false,
-          "columns": [
-            "name",
-            "category"
-          ]
+          "columns": ["name", "category"]
         }
       },
       "policies": {},
@@ -3248,120 +2937,67 @@
     "public.account_type_enum": {
       "name": "account_type_enum",
       "schema": "public",
-      "values": [
-        "individual",
-        "guest"
-      ]
+      "values": ["individual", "guest"]
     },
     "public.action_request_export_format_enum": {
       "name": "action_request_export_format_enum",
       "schema": "public",
-      "values": [
-        "json",
-        "csv"
-      ]
+      "values": ["json", "csv"]
     },
     "public.action_view_enum": {
       "name": "action_view_enum",
       "schema": "public",
-      "values": [
-        "builder",
-        "player",
-        "library",
-        "account",
-        "analytics",
-        "home",
-        "auth",
-        "unknown"
-      ]
+      "values": ["builder", "player", "library", "account", "analytics", "home", "auth", "unknown"]
     },
     "public.chat_mention_status_enum": {
       "name": "chat_mention_status_enum",
       "schema": "public",
-      "values": [
-        "unread",
-        "read"
-      ]
+      "values": ["unread", "read"]
     },
     "public.item_export_request_type_enum": {
       "name": "item_export_request_type_enum",
       "schema": "public",
-      "values": [
-        "raw",
-        "graasp"
-      ]
+      "values": ["raw", "graasp"]
     },
     "public.item_login_schema_status": {
       "name": "item_login_schema_status",
       "schema": "public",
-      "values": [
-        "active",
-        "freeze",
-        "disabled"
-      ]
+      "values": ["active", "freeze", "disabled"]
     },
     "public.item_login_schema_type": {
       "name": "item_login_schema_type",
       "schema": "public",
-      "values": [
-        "username",
-        "username+password",
-        "anonymous",
-        "anonymous+password"
-      ]
+      "values": ["username", "username+password", "anonymous", "anonymous+password"]
     },
     "public.item_validation_process": {
       "name": "item_validation_process",
       "schema": "public",
-      "values": [
-        "bad-words-detection",
-        "image-classification"
-      ]
+      "values": ["bad-words-detection", "image-classification"]
     },
     "public.item_validation_status": {
       "name": "item_validation_status",
       "schema": "public",
-      "values": [
-        "success",
-        "failure",
-        "pending",
-        "pending-manual"
-      ]
+      "values": ["success", "failure", "pending", "pending-manual"]
     },
     "public.item_visibility_type": {
       "name": "item_visibility_type",
       "schema": "public",
-      "values": [
-        "public",
-        "hidden"
-      ]
+      "values": ["public", "hidden"]
     },
     "public.permission_enum": {
       "name": "permission_enum",
       "schema": "public",
-      "values": [
-        "read",
-        "write",
-        "admin"
-      ]
+      "values": ["read", "write", "admin"]
     },
     "public.short_link_platform_enum": {
       "name": "short_link_platform_enum",
       "schema": "public",
-      "values": [
-        "builder",
-        "player",
-        "library"
-      ]
+      "values": ["builder", "player", "library"]
     },
     "public.tag_category_enum": {
       "name": "tag_category_enum",
       "schema": "public",
-      "values": [
-        "level",
-        "discipline",
-        "resource-type"
-      ]
+      "values": ["level", "discipline", "resource-type"]
     }
   },
   "schemas": {},

--- a/src/drizzle/meta/0009_snapshot.json
+++ b/src/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,3696 @@
+{
+  "id": "15821580-853d-4b5c-ad14-e2a75a735339",
+  "prevId": "9f3a4322-8b69-4173-910b-6ed30209017e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agreements_date": {
+          "name": "user_agreements_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_save_actions": {
+          "name": "enable_save_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "item_login_schema_id": {
+          "name": "item_login_schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_account_type": {
+          "name": "IDX_account_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "enum_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_item_login_schema_id_item_login_schema_id_fk": {
+          "name": "account_item_login_schema_id_item_login_schema_id_fk",
+          "tableFrom": "account",
+          "tableTo": "item_login_schema",
+          "columnsFrom": [
+            "item_login_schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_account_name_item_login_schema_id": {
+          "name": "UQ_account_name_item_login_schema_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "item_login_schema_id"
+          ]
+        },
+        "member_email_key1": {
+          "name": "member_email_key1",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "CHK_account_is_validated": {
+          "name": "CHK_account_is_validated",
+          "value": "(is_validated IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        },
+        "CHK_account_email": {
+          "name": "CHK_account_email",
+          "value": "(email IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        },
+        "CHK_account_extra": {
+          "name": "CHK_account_extra",
+          "value": "(extra IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        },
+        "CHK_account_enable_save_actions": {
+          "name": "CHK_account_enable_save_actions",
+          "value": "(enable_save_actions IS NOT NULL) OR ((type)::text <> 'individual'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.action_request_export": {
+      "name": "action_request_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "action_request_export_format_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_fea823c4374f507a68cf8f926a4": {
+          "name": "FK_fea823c4374f507a68cf8f926a4",
+          "tableFrom": "action_request_export",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FK_bc85ef3298df8c7974b33081b47": {
+          "name": "FK_bc85ef3298df8c7974b33081b47",
+          "tableFrom": "action_request_export",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action": {
+      "name": "action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "view": {
+          "name": "view",
+          "type": "action_view_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "geolocation": {
+          "name": "geolocation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_1214f6f4d832c402751617361c": {
+          "name": "IDX_1214f6f4d832c402751617361c",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_action_account_id": {
+          "name": "IDX_action_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_1214f6f4d832c402751617361c0": {
+          "name": "FK_1214f6f4d832c402751617361c0",
+          "tableFrom": "action",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_action_account_id": {
+          "name": "FK_action_account_id",
+          "tableFrom": "action",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_action": {
+      "name": "app_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_c415fc186dda51fa260d338d776": {
+          "name": "FK_c415fc186dda51fa260d338d776",
+          "tableFrom": "app_action",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_app_action_account_id": {
+          "name": "FK_app_action_account_id",
+          "tableFrom": "app_action",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_data": {
+      "name": "app_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_6079b3bb63c13f815f7dd8d8a2": {
+          "name": "IDX_6079b3bb63c13f815f7dd8d8a2",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_8c3e2463c67d9865658941c9e2d": {
+          "name": "FK_8c3e2463c67d9865658941c9e2d",
+          "tableFrom": "app_data",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_27cb180cb3f372e4cf55302644a": {
+          "name": "FK_27cb180cb3f372e4cf55302644a",
+          "tableFrom": "app_data",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_app_data_account_id": {
+          "name": "FK_app_data_account_id",
+          "tableFrom": "app_data",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_setting": {
+      "name": "app_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_61546c650608c1e68789c64915": {
+          "name": "IDX_61546c650608c1e68789c64915",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_f5922b885e2680beab8add96008": {
+          "name": "FK_f5922b885e2680beab8add96008",
+          "tableFrom": "app_setting",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_22d3d051ee6f94932c1373a3d09": {
+          "name": "FK_22d3d051ee6f94932c1373a3d09",
+          "tableFrom": "app_setting",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app": {
+      "name": "app",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_37eb7baab82e11150157ec0b5a6": {
+          "name": "FK_37eb7baab82e11150157ec0b5a6",
+          "tableFrom": "app",
+          "tableTo": "publisher",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_key_key": {
+          "name": "app_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "UQ_f36adbb7b096ceeb6f3e80ad14c": {
+          "name": "UQ_f36adbb7b096ceeb6f3e80ad14c",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "app_url_key": {
+          "name": "app_url_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category-name-type": {
+          "name": "category-name-type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_mention": {
+      "name": "chat_mention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "chat_mention_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unread'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_mention_message_id_chat_message_id_fk": {
+          "name": "chat_mention_message_id_chat_message_id_fk",
+          "tableFrom": "chat_mention",
+          "tableTo": "chat_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_mention_account_id_account_id_fk": {
+          "name": "chat_mention_account_id_account_id_fk",
+          "tableFrom": "chat_mention",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "FK_e5199951167b722215127651e7c": {
+          "name": "FK_e5199951167b722215127651e7c",
+          "tableFrom": "chat_mention",
+          "tableTo": "chat_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_chat_mention_account_id": {
+          "name": "FK_chat_mention_account_id",
+          "tableFrom": "chat_mention",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_b31e627ea7a4787672e265a1579": {
+          "name": "FK_b31e627ea7a4787672e265a1579",
+          "tableFrom": "chat_message",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_71fdcb9038eca1b903102bdfd17": {
+          "name": "FK_71fdcb9038eca1b903102bdfd17",
+          "tableFrom": "chat_message",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guest_password": {
+      "name": "guest_password",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_guest_password_guest_id": {
+          "name": "FK_guest_password_guest_id",
+          "tableFrom": "guest_password",
+          "tableTo": "account",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_guest_password_guest_id": {
+          "name": "UQ_guest_password_guest_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_creator_id_account_id_fk": {
+          "name": "invitation_creator_id_account_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_item_path_item_path_fk": {
+          "name": "invitation_item_path_item_path_fk",
+          "tableFrom": "invitation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "FK_7ad4a490d5b9f79a677827b641c": {
+          "name": "FK_7ad4a490d5b9f79a677827b641c",
+          "tableFrom": "invitation",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_dc1d92accde1c2fbb7e729e4dcc": {
+          "name": "FK_dc1d92accde1c2fbb7e729e4dcc",
+          "tableFrom": "invitation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item-email": {
+          "name": "item-email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_favorite": {
+      "name": "item_favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_a169d350392956511697f7e7d38": {
+          "name": "FK_a169d350392956511697f7e7d38",
+          "tableFrom": "item_favorite",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_10ea93bde287762010695378f94": {
+          "name": "FK_10ea93bde287762010695378f94",
+          "tableFrom": "item_favorite",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "favorite_key": {
+          "name": "favorite_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_category": {
+      "name": "item_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_638552fc7d9a2035c2b53182d8a": {
+          "name": "FK_638552fc7d9a2035c2b53182d8a",
+          "tableFrom": "item_category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_9a34a079b5b24f4396462546d26": {
+          "name": "FK_9a34a079b5b24f4396462546d26",
+          "tableFrom": "item_category",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_5681d1785eea699e9cae8818fe0": {
+          "name": "FK_5681d1785eea699e9cae8818fe0",
+          "tableFrom": "item_category",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "category-item": {
+          "name": "category-item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path",
+            "category_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_export_request": {
+      "name": "item_export_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "item_export_request_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_export_request_member_id_account_id_fk": {
+          "name": "item_export_request_member_id_account_id_fk",
+          "tableFrom": "item_export_request",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_export_request_item_id_item_id_fk": {
+          "name": "item_export_request_item_id_item_id_fk",
+          "tableFrom": "item_export_request",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_flag": {
+      "name": "item_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_b04d0adf4b73d82537c92fa55ea": {
+          "name": "FK_b04d0adf4b73d82537c92fa55ea",
+          "tableFrom": "item_flag",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_bde9b9ab1da1483a71c9b916dd2": {
+          "name": "FK_bde9b9ab1da1483a71c9b916dd2",
+          "tableFrom": "item_flag",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item-flag-creator": {
+          "name": "item-flag-creator",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "creator_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_geolocation": {
+      "name": "item_geolocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addressLabel": {
+          "name": "addressLabel",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "helperLabel": {
+          "name": "helperLabel",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_66d4b13df4e7765068c8268d719": {
+          "name": "FK_66d4b13df4e7765068c8268d719",
+          "tableFrom": "item_geolocation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_geolocation_unique_item": {
+          "name": "item_geolocation_unique_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_like": {
+      "name": "item_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_item_like_item": {
+          "name": "IDX_item_like_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_4a56eba1ce30dc93f118a51ff26": {
+          "name": "FK_4a56eba1ce30dc93f118a51ff26",
+          "tableFrom": "item_like",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_159827eb667d019dc71372d7463": {
+          "name": "FK_159827eb667d019dc71372d7463",
+          "tableFrom": "item_like",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id": {
+          "name": "id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_login_schema": {
+      "name": "item_login_schema",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "item_login_schema_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "item_login_schema_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_login_schema_item_path_item_path_fk": {
+          "name": "item_login_schema_item_path_item_path_fk",
+          "tableFrom": "item_login_schema",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item-login-schema": {
+          "name": "item-login-schema",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_membership": {
+      "name": "item_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "permission": {
+          "name": "permission",
+          "type": "permission_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_5ac5bdde333fca6bbeaf177ef9": {
+          "name": "IDX_5ac5bdde333fca6bbeaf177ef9",
+          "columns": [
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_d935785e7ecc015ed3ca048ff0": {
+          "name": "IDX_d935785e7ecc015ed3ca048ff0",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_gist_item_membership_path": {
+          "name": "IDX_gist_item_membership_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "IDX_item_membership_account_id": {
+          "name": "IDX_item_membership_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_item_membership_account_id_permission": {
+          "name": "IDX_item_membership_account_id_permission",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_membership_item_path_item_path_fk": {
+          "name": "item_membership_item_path_item_path_fk",
+          "tableFrom": "item_membership",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "item_membership_creator_id_account_id_fk": {
+          "name": "item_membership_creator_id_account_id_fk",
+          "tableFrom": "item_membership",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "item_membership_account_id_account_id_fk": {
+          "name": "item_membership_account_id_account_id_fk",
+          "tableFrom": "item_membership",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_membership-item-member": {
+          "name": "item_membership-item-member",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_tag": {
+      "name": "item_tag",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_item_tag_item": {
+          "name": "IDX_item_tag_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_16ab8afb42f763f7cbaa4bff66a": {
+          "name": "FK_16ab8afb42f763f7cbaa4bff66a",
+          "tableFrom": "item_tag",
+          "tableTo": "tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_39b492fda03c7ac846afe164b58": {
+          "name": "FK_39b492fda03c7ac846afe164b58",
+          "tableFrom": "item_tag",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "PK_a04bb2298e37d95233a0c92347e": {
+          "name": "PK_a04bb2298e37d95233a0c92347e",
+          "columns": [
+            "tag_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "UQ_item_tag": {
+          "name": "UQ_item_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tag_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_validation_group": {
+      "name": "item_validation_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_a9e83cf5f53c026b774b53d3c60": {
+          "name": "FK_a9e83cf5f53c026b774b53d3c60",
+          "tableFrom": "item_validation_group",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_validation_review": {
+      "name": "item_validation_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_validation_id": {
+          "name": "item_validation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_59fd000835c70c728e525d82950": {
+          "name": "FK_59fd000835c70c728e525d82950",
+          "tableFrom": "item_validation_review",
+          "tableTo": "item_validation",
+          "columnsFrom": [
+            "item_validation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_44bf14fee580ae08702d70e622e": {
+          "name": "FK_44bf14fee580ae08702d70e622e",
+          "tableFrom": "item_validation_review",
+          "tableTo": "account",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_validation": {
+      "name": "item_validation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process": {
+          "name": "process",
+          "type": "item_validation_process",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "item_validation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_validation_group_id": {
+          "name": "item_validation_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_d60969d5e478e7c844532ac4e7f": {
+          "name": "FK_d60969d5e478e7c844532ac4e7f",
+          "tableFrom": "item_validation",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_e92da280941f666acf87baedc65": {
+          "name": "FK_e92da280941f666acf87baedc65",
+          "tableFrom": "item_validation",
+          "tableTo": "item_validation_group",
+          "columnsFrom": [
+            "item_validation_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_visibility": {
+      "name": "item_visibility",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "item_visibility_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_gist_item_visibility_path": {
+          "name": "IDX_gist_item_visibility_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_item_visibility_creator": {
+          "name": "FK_item_visibility_creator",
+          "tableFrom": "item_visibility",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_item_visibility_item": {
+          "name": "FK_item_visibility_item",
+          "tableFrom": "item_visibility",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_item_visibility_item_type": {
+          "name": "UQ_item_visibility_item_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item": {
+      "name": "item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_bdc46717fadc2f04f3093e51fd": {
+          "name": "IDX_bdc46717fadc2f04f3093e51fd",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_gist_item_path": {
+          "name": "IDX_gist_item_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "IDX_gist_item_path_deleted_at": {
+          "name": "IDX_gist_item_path_deleted_at",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"item\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_bdc46717fadc2f04f3093e51fd5": {
+          "name": "FK_bdc46717fadc2f04f3093e51fd5",
+          "tableFrom": "item",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_path_key1": {
+          "name": "item_path_key1",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance": {
+      "name": "maintenance",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_maintenance_slug": {
+          "name": "UQ_maintenance_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_password": {
+      "name": "member_password",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_password_member_id_account_id_fk": {
+          "name": "member_password_member_id_account_id_fk",
+          "tableFrom": "member_password",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member-password": {
+          "name": "member-password",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_profile": {
+      "name": "member_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "facebookId": {
+          "name": "facebookId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedinId": {
+          "name": "linkedinId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterId": {
+          "name": "twitterId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_91fa43bc5482dc6b00892baf01": {
+          "name": "IDX_91fa43bc5482dc6b00892baf01",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_profile_member_id_account_id_fk": {
+          "name": "member_profile_member_id_account_id_fk",
+          "tableFrom": "member_profile",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "FK_91fa43bc5482dc6b00892baf016": {
+          "name": "FK_91fa43bc5482dc6b00892baf016",
+          "tableFrom": "member_profile",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member-profile": {
+          "name": "member-profile",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_request": {
+      "name": "membership_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "FK_membership_request_member_id": {
+          "name": "FK_membership_request_member_id",
+          "tableFrom": "membership_request",
+          "tableTo": "account",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FK_membership_request_item_id": {
+          "name": "FK_membership_request_item_id",
+          "tableFrom": "membership_request",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_membership_request_item-member": {
+          "name": "UQ_membership_request_item-member",
+          "nullsNotDistinct": false,
+          "columns": [
+            "member_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page": {
+      "name": "page",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_page_item_id": {
+          "name": "IDX_page_item_id",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_page_item_id": {
+          "name": "FK_page_item_id",
+          "tableFrom": "page",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item_published": {
+      "name": "item_published",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_gist_item_published_path": {
+          "name": "IDX_gist_item_published_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "item_published_creator_id_account_id_fk": {
+          "name": "item_published_creator_id_account_id_fk",
+          "tableFrom": "item_published",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "item_published_item_path_item_path_fk": {
+          "name": "item_published_item_path_item_path_fk",
+          "tableFrom": "item_published",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published-item": {
+          "name": "published-item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publisher": {
+      "name": "publisher",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origins": {
+          "name": "origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "publisher_name_key": {
+          "name": "publisher_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recycled_item_data": {
+      "name": "recycled_item_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_path": {
+          "name": "item_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_recycled_item_data_item_path": {
+          "name": "IDX_recycled_item_data_item_path",
+          "columns": [
+            {
+              "expression": "item_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_ltree_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_3e3650ebd5c49843013429d510a": {
+          "name": "FK_3e3650ebd5c49843013429d510a",
+          "tableFrom": "recycled_item_data",
+          "tableTo": "account",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FK_f8a4db4476e3d81e18de5d63c42": {
+          "name": "FK_f8a4db4476e3d81e18de5d63c42",
+          "tableFrom": "recycled_item_data",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recycled-item-data": {
+          "name": "recycled-item-data",
+          "nullsNotDistinct": false,
+          "columns": [
+            "item_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.short_link": {
+      "name": "short_link",
+      "schema": "",
+      "columns": {
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "short_link_platform_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_43c8a0471d5e58f99fc9c36b99": {
+          "name": "IDX_43c8a0471d5e58f99fc9c36b99",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FK_43c8a0471d5e58f99fc9c36b991": {
+          "name": "FK_43c8a0471d5e58f99fc9c36b991",
+          "tableFrom": "short_link",
+          "tableTo": "item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_859a3384cadaa460b84e04e5375": {
+          "name": "UQ_859a3384cadaa460b84e04e5375",
+          "nullsNotDistinct": false,
+          "columns": [
+            "platform",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "CHK_200ef28b2168aaf1e36b6896fc": {
+          "name": "CHK_200ef28b2168aaf1e36b6896fc",
+          "value": "(length((alias)::text) >= 6) AND (length((alias)::text) <= 255) AND ((alias)::text ~ '^[a-zA-Z0-9-]*$'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "tag_category_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_tag_name_category": {
+          "name": "UQ_tag_name_category",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type_enum": {
+      "name": "account_type_enum",
+      "schema": "public",
+      "values": [
+        "individual",
+        "guest"
+      ]
+    },
+    "public.action_request_export_format_enum": {
+      "name": "action_request_export_format_enum",
+      "schema": "public",
+      "values": [
+        "json",
+        "csv"
+      ]
+    },
+    "public.action_view_enum": {
+      "name": "action_view_enum",
+      "schema": "public",
+      "values": [
+        "builder",
+        "player",
+        "library",
+        "account",
+        "analytics",
+        "home",
+        "auth",
+        "unknown"
+      ]
+    },
+    "public.chat_mention_status_enum": {
+      "name": "chat_mention_status_enum",
+      "schema": "public",
+      "values": [
+        "unread",
+        "read"
+      ]
+    },
+    "public.item_export_request_type_enum": {
+      "name": "item_export_request_type_enum",
+      "schema": "public",
+      "values": [
+        "raw",
+        "graasp"
+      ]
+    },
+    "public.item_login_schema_status": {
+      "name": "item_login_schema_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "freeze",
+        "disabled"
+      ]
+    },
+    "public.item_login_schema_type": {
+      "name": "item_login_schema_type",
+      "schema": "public",
+      "values": [
+        "username",
+        "username+password",
+        "anonymous",
+        "anonymous+password"
+      ]
+    },
+    "public.item_validation_process": {
+      "name": "item_validation_process",
+      "schema": "public",
+      "values": [
+        "bad-words-detection",
+        "image-classification"
+      ]
+    },
+    "public.item_validation_status": {
+      "name": "item_validation_status",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure",
+        "pending",
+        "pending-manual"
+      ]
+    },
+    "public.item_visibility_type": {
+      "name": "item_visibility_type",
+      "schema": "public",
+      "values": [
+        "public",
+        "hidden"
+      ]
+    },
+    "public.permission_enum": {
+      "name": "permission_enum",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "admin"
+      ]
+    },
+    "public.short_link_platform_enum": {
+      "name": "short_link_platform_enum",
+      "schema": "public",
+      "values": [
+        "builder",
+        "player",
+        "library"
+      ]
+    },
+    "public.tag_category_enum": {
+      "name": "tag_category_enum",
+      "schema": "public",
+      "values": [
+        "level",
+        "discipline",
+        "resource-type"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.guests_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "item_login_schema_id": {
+          "name": "item_login_schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"extra\", \"type\", \"created_at\", \"updated_at\", \"last_authenticated_at\", \"is_validated\", \"item_login_schema_id\" from \"account\" where (\"account\".\"type\" = 'guest' and \"account\".\"item_login_schema_id\" is not null)",
+      "name": "guests_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.item_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(5000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lang": {
+          "name": "lang",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"type\", \"description\", \"path\", \"creator_id\", \"extra\", \"settings\", \"created_at\", \"updated_at\", \"lang\", \"order\" from \"item\" where \"item\".\"deleted_at\" is null",
+      "name": "item_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.members_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agreements_date": {
+          "name": "user_agreements_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_save_actions": {
+          "name": "enable_save_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"email\", \"extra\", \"type\", \"created_at\", \"updated_at\", \"user_agreements_date\", \"enable_save_actions\", \"last_authenticated_at\", \"is_validated\" from \"account\" where (\"account\".\"type\" = 'individual' and \"account\".\"email\" is not null)",
+      "name": "members_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1753258732200,
       "tag": "0008_recycled-item-data-index",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1753260966712,
+      "tag": "0009_page",
+      "breakpoints": true
     }
   ]
 }

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -1106,6 +1106,7 @@ export const pageTable = pgTable(
       .$onUpdate(() => sql.raw('DEFAULT')),
   },
   (table) => [
+    index('IDX_page_item_id').using('btree', table.itemId.asc().nullsLast().op('uuid_ops')),
     foreignKey({
       columns: [table.itemId],
       foreignColumns: [itemsRawTable.id],

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -1090,3 +1090,26 @@ export const maintenanceTable = pgTable('maintenance', {
   startAt: timestamp('start_at', { withTimezone: true, mode: 'string' }).notNull(),
   endAt: timestamp('end_at', { withTimezone: true, mode: 'string' }).notNull(),
 });
+
+export const pageTable = pgTable(
+  'page',
+  {
+    id: uuid().primaryKey().defaultRandom().notNull(),
+    itemId: uuid('item_id').notNull(),
+    content: jsonb().$type<string>().default('{}').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => sql.raw('DEFAULT')),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.itemId],
+      foreignColumns: [itemsRawTable.id],
+      name: 'FK_page_item_id',
+    }).onDelete('cascade'),
+  ],
+);

--- a/src/drizzle/types.ts
+++ b/src/drizzle/types.ts
@@ -120,6 +120,7 @@ export type ItemExtraMap = {
   [ItemType.LINK]: LinkItemExtra;
   [ItemType.FILE]: FileItemExtra;
   [ItemType.SHORTCUT]: ShortcutItemExtra;
+  [ItemType.PAGE]: never;
 };
 
 export type ItemSettingsMap = {
@@ -131,6 +132,7 @@ export type ItemSettingsMap = {
   [ItemType.LINK]: LinkItemSettings;
   [ItemType.FILE]: ItemSettings;
   [ItemType.SHORTCUT]: ItemSettings;
+  [ItemType.PAGE]: ItemSettings;
 };
 
 // local type alias to simplify the notation

--- a/src/drizzle/types.ts
+++ b/src/drizzle/types.ts
@@ -107,6 +107,7 @@ export const ItemType = {
   SHORTCUT: 'shortcut',
   H5P: 'h5p',
   ETHERPAD: 'etherpad',
+  PAGE: 'page',
 } as const;
 export type ItemTypeUnion = UnionOfConst<typeof ItemType>;
 

--- a/src/services/item/discrimination.ts
+++ b/src/services/item/discrimination.ts
@@ -6,6 +6,7 @@ export type AppItem = ItemWithType<typeof ItemType.APP>;
 export type DocumentItem = ItemWithType<typeof ItemType.DOCUMENT>;
 export type EtherpadItem = ItemWithType<typeof ItemType.ETHERPAD>;
 export type FolderItem = ItemWithType<typeof ItemType.FOLDER>;
+export type PageItem = ItemWithType<typeof ItemType.PAGE>;
 export type H5PItem = ItemWithType<typeof ItemType.H5P>;
 export type EmbeddedLinkItem = ItemWithType<typeof ItemType.LINK>;
 export type FileItem = ItemWithType<typeof ItemType.FILE>;

--- a/src/services/item/index.ts
+++ b/src/services/item/index.ts
@@ -27,6 +27,7 @@ import graaspFavoritePlugin from './plugins/itemBookmark/itemBookmark.controller
 import graaspItemFlags from './plugins/itemFlag/itemFlag.controller';
 import graaspItemLikes from './plugins/itemLike/itemLike.controller';
 import graaspItemVisibility from './plugins/itemVisibility/itemVisibility.controller';
+import { pageItemPlugin } from './plugins/page/page.controller';
 import graaspItemPublicationState from './plugins/publication/publicationState/publication.controller';
 import graaspItemPublish from './plugins/publication/published/itemPublished.controller';
 import graaspValidationPlugin from './plugins/publication/validation/itemValidation.controller';
@@ -117,6 +118,8 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         fastify.register(itemGeolocationPlugin);
 
         fastify.register(graaspItemTagPlugin);
+
+        fastify.register(pageItemPlugin);
 
         fastify.register(itemController);
       });

--- a/src/services/item/plugins/page/page.controller.test.ts
+++ b/src/services/item/plugins/page/page.controller.test.ts
@@ -1,0 +1,75 @@
+import { eq } from 'drizzle-orm';
+import { StatusCodes } from 'http-status-codes';
+
+import type { FastifyInstance } from 'fastify';
+
+import { FolderItemFactory, HttpMethod } from '@graasp/sdk';
+
+import build, {
+  clearDatabase,
+  mockAuthenticate,
+  unmockAuthenticate,
+} from '../../../../../test/app';
+import { seedFromJson } from '../../../../../test/mocks/seed';
+import { db } from '../../../../drizzle/db';
+import { itemsRawTable, pageTable } from '../../../../drizzle/schema';
+import { assertIsDefined } from '../../../../utils/assertions';
+import { assertIsMemberForTest } from '../../../authentication';
+
+describe('Page routes tests', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    ({ app } = await build());
+  });
+
+  afterAll(async () => {
+    await clearDatabase(db);
+    app.close();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    unmockAuthenticate();
+  });
+
+  describe('POST /items/pages', () => {
+    it('Throws if signed out', async () => {
+      const payload = FolderItemFactory();
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: '/items/pages',
+        payload,
+      });
+
+      expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    });
+
+    describe('Signed In', () => {
+      it('Create successfully', async () => {
+        const { actor } = await seedFromJson();
+        assertIsDefined(actor);
+        assertIsMemberForTest(actor);
+        mockAuthenticate(actor);
+
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: '/items/pages',
+          payload: { name: 'my page' },
+        });
+        expect(response.statusCode).toBe(StatusCodes.CREATED);
+
+        // check response value
+        const itemId = response.json().id;
+        const newItem = await db.query.itemsRawTable.findFirst({
+          where: eq(itemsRawTable.id, itemId),
+        });
+        expect(newItem).toBeDefined();
+        const newContent = await db.query.pageTable.findFirst({
+          where: eq(pageTable.itemId, itemId),
+        });
+        expect(newContent).toBeDefined();
+      });
+    });
+  });
+});

--- a/src/services/item/plugins/page/page.controller.ts
+++ b/src/services/item/plugins/page/page.controller.ts
@@ -1,0 +1,45 @@
+import { StatusCodes } from 'http-status-codes';
+
+import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
+
+import { resolveDependency } from '../../../../di/utils';
+import { db } from '../../../../drizzle/db';
+import { asDefined } from '../../../../utils/assertions';
+import { isAuthenticated, matchOne } from '../../../auth/plugins/passport';
+import { assertIsMember } from '../../../authentication';
+import { validatedMemberAccountRole } from '../../../member/strategies/validatedMemberAccountRole';
+import { createPage } from './page.schemas';
+import { PageItemService } from './page.service';
+
+export const pageItemPlugin: FastifyPluginAsyncTypebox = async (fastify) => {
+  const pageItemService = resolveDependency(PageItemService);
+
+  fastify.post(
+    '/pages',
+    {
+      schema: createPage,
+      preHandler: [isAuthenticated, matchOne(validatedMemberAccountRole)],
+    },
+    async (request, reply) => {
+      const {
+        user,
+        query: { parentId, previousItemId },
+        body: data,
+      } = request;
+      const member = asDefined(user?.account);
+      assertIsMember(member);
+
+      const item = await db.transaction(async (tx) => {
+        return await pageItemService.create(tx, member, {
+          item: data,
+          previousItemId,
+          parentId,
+          geolocation: data.geolocation,
+        });
+      });
+
+      reply.code(StatusCodes.CREATED);
+      reply.send(item);
+    },
+  );
+};

--- a/src/services/item/plugins/page/page.repository.ts
+++ b/src/services/item/plugins/page/page.repository.ts
@@ -1,0 +1,15 @@
+import { singleton } from 'tsyringe';
+
+import { DBConnection } from '../../../../drizzle/db';
+import { pageTable } from '../../../../drizzle/schema';
+
+@singleton()
+export class PageRepository {
+  async createContent(dbConnection: DBConnection, itemId: string): Promise<void> {
+    await dbConnection.insert(pageTable).values({ itemId });
+  }
+
+  async updateContent(dbConnection: DBConnection, content: string): Promise<void> {
+    await dbConnection.update(pageTable).set({ content });
+  }
+}

--- a/src/services/item/plugins/page/page.schemas.ts
+++ b/src/services/item/plugins/page/page.schemas.ts
@@ -1,0 +1,41 @@
+import { Type } from '@sinclair/typebox';
+import { StatusCodes } from 'http-status-codes';
+
+import type { FastifySchema } from 'fastify';
+
+import { customType } from '../../../../plugins/typebox';
+import { errorSchemaRef } from '../../../../schemas/global';
+import { itemSchema } from '../../item.schemas';
+import { geoCoordinateSchemaRef } from '../geolocation/itemGeolocation.schemas';
+
+export const pageSchema = Type.Composite([
+  itemSchema,
+  customType.StrictObject(
+    {
+      extra: customType.StrictObject({}),
+    },
+    {
+      title: 'Page',
+      description: 'Item of type page.',
+    },
+  ),
+]);
+
+export const createPage = {
+  operationId: 'createPage',
+  tags: ['item', 'page'],
+  summary: 'Create page',
+  description: 'Create page and its content.',
+
+  querystring: Type.Partial(
+    customType.StrictObject({ parentId: customType.UUID(), previousItemId: customType.UUID() }),
+  ),
+  body: Type.Composite([
+    Type.Pick(pageSchema, ['name']),
+    Type.Partial(Type.Pick(pageSchema, ['lang', 'settings'])),
+    customType.StrictObject({
+      geolocation: Type.Optional(geoCoordinateSchemaRef),
+    }),
+  ]),
+  response: { [StatusCodes.CREATED]: pageSchema, '4xx': errorSchemaRef },
+} as const satisfies FastifySchema;

--- a/src/services/item/plugins/page/page.service.ts
+++ b/src/services/item/plugins/page/page.service.ts
@@ -9,25 +9,21 @@ import type { MinimalMember } from '../../../../types';
 import { AuthorizedItemService } from '../../../authorizedItem.service';
 import { PageItem } from '../../discrimination';
 import { WrongItemTypeError } from '../../errors';
-import { ItemRepository } from '../../item.repository';
 import { ItemService } from '../../item.service';
 import { PageRepository } from './page.repository';
 
 @singleton()
 export class PageItemService {
   private readonly itemService: ItemService;
-  private readonly itemRepository: ItemRepository;
   private readonly pageRepository: PageRepository;
   private readonly authorizedItemService: AuthorizedItemService;
 
   constructor(
     itemService: ItemService,
     pageRepository: PageRepository,
-    itemRepository: ItemRepository,
     authorizedItemService: AuthorizedItemService,
   ) {
     this.itemService = itemService;
-    this.itemRepository = itemRepository;
     this.pageRepository = pageRepository;
     this.authorizedItemService = authorizedItemService;
   }
@@ -52,7 +48,7 @@ export class PageItemService {
     // create page properties row
     await this.pageRepository.createContent(dbConnection, newItem.id);
 
-    return newItem;
+    return newItem as PageItem;
   }
 
   async updateContent(

--- a/src/services/item/plugins/page/page.service.ts
+++ b/src/services/item/plugins/page/page.service.ts
@@ -1,0 +1,77 @@
+import { Readable } from 'node:stream';
+import { singleton } from 'tsyringe';
+
+import { type ItemGeolocation, ItemType, PermissionLevel, type UUID } from '@graasp/sdk';
+
+import { type DBConnection } from '../../../../drizzle/db';
+import { type ItemRaw } from '../../../../drizzle/types';
+import type { MinimalMember } from '../../../../types';
+import { AuthorizedItemService } from '../../../authorizedItem.service';
+import { PageItem } from '../../discrimination';
+import { WrongItemTypeError } from '../../errors';
+import { ItemRepository } from '../../item.repository';
+import { ItemService } from '../../item.service';
+import { PageRepository } from './page.repository';
+
+@singleton()
+export class PageItemService {
+  private readonly itemService: ItemService;
+  private readonly itemRepository: ItemRepository;
+  private readonly pageRepository: PageRepository;
+  private readonly authorizedItemService: AuthorizedItemService;
+
+  constructor(
+    itemService: ItemService,
+    pageRepository: PageRepository,
+    itemRepository: ItemRepository,
+    authorizedItemService: AuthorizedItemService,
+  ) {
+    this.itemService = itemService;
+    this.itemRepository = itemRepository;
+    this.pageRepository = pageRepository;
+    this.authorizedItemService = authorizedItemService;
+  }
+
+  async create(
+    dbConnection: DBConnection,
+    member: MinimalMember,
+    args: {
+      item: Partial<Pick<ItemRaw, 'settings' | 'lang'>> & Pick<ItemRaw, 'name'>;
+      parentId?: string;
+      geolocation?: Pick<ItemGeolocation, 'lat' | 'lng'>;
+      thumbnail?: Readable;
+      previousItemId?: ItemRaw['id'];
+    },
+  ): Promise<PageItem> {
+    // create item
+    const newItem = await this.itemService.post(dbConnection, member, {
+      ...args,
+      item: { ...args.item, type: ItemType.PAGE, extra: {} },
+    });
+
+    // create page properties row
+    await this.pageRepository.createContent(dbConnection, newItem.id);
+
+    return newItem;
+  }
+
+  async updateContent(
+    dbConnection: DBConnection,
+    member: MinimalMember,
+    itemId: UUID,
+    content: string,
+  ): Promise<void> {
+    const item = await this.authorizedItemService.getItemById(dbConnection, {
+      permission: PermissionLevel.Write,
+      accountId: member.id,
+      itemId,
+    });
+
+    // check item is page
+    if (item.type !== ItemType.PAGE) {
+      throw new WrongItemTypeError(item.type);
+    }
+
+    await this.pageRepository.updateContent(dbConnection, content);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,9 +2592,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:5.14.0":
-  version: 5.14.0
-  resolution: "@graasp/sdk@npm:5.14.0"
+"@graasp/sdk@github:graasp/graasp-sdk#page":
+  version: 5.14.1
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=67f352b1d4384744624f77dbff32e919865ad23b"
   dependencies:
     "@faker-js/faker": "npm:9.7.0"
     filesize: "npm:10.1.6"
@@ -2602,7 +2602,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/59245e47486117fe2906a1e0f3a3f493b40157e05b34a637aa4d6b9d9ea2b2067d4b25ffb22ac9f34de1150953663bb7d1479d9fa8792406ddfcd90ce306c029
+  checksum: 10/408790d6dba388bbaf3cc521b448a61c5b446185045231221ca057109ac6e129367ef85689a4bf82206a277d00cb65a3e685965a0b9f889d76fe7f3c6a626d92
   languageName: node
   linkType: hard
 
@@ -8652,7 +8652,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:5.1.0"
     "@fastify/websocket": "npm:11.0.2"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "npm:5.14.0"
+    "@graasp/sdk": "github:graasp/graasp-sdk#page"
     "@graasp/translations": "npm:1.44.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.17.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,9 +2592,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@github:graasp/graasp-sdk#page":
-  version: 5.14.1
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=67f352b1d4384744624f77dbff32e919865ad23b"
+"@graasp/sdk@npm:5.15.0":
+  version: 5.15.0
+  resolution: "@graasp/sdk@npm:5.15.0"
   dependencies:
     "@faker-js/faker": "npm:9.7.0"
     filesize: "npm:10.1.6"
@@ -2602,7 +2602,7 @@ __metadata:
   peerDependencies:
     date-fns: ^3 || ^4.0.0
     uuid: ^9 || ^10 || ^11.0.0
-  checksum: 10/408790d6dba388bbaf3cc521b448a61c5b446185045231221ca057109ac6e129367ef85689a4bf82206a277d00cb65a3e685965a0b9f889d76fe7f3c6a626d92
+  checksum: 10/ec0508f68b4414fb9ae5f5f0b91fb3eeb6f333c83110e3d2bc689e9b4883f63f013cd74da8d64907200e67d8cf45731033a8861ca625a861a5e54ec684b8c2f9
   languageName: node
   linkType: hard
 
@@ -8652,7 +8652,7 @@ __metadata:
     "@fastify/type-provider-typebox": "npm:5.1.0"
     "@fastify/websocket": "npm:11.0.2"
     "@graasp/etherpad-api": "npm:2.1.1"
-    "@graasp/sdk": "github:graasp/graasp-sdk#page"
+    "@graasp/sdk": "npm:5.15.0"
     "@graasp/translations": "npm:1.44.0"
     "@jest/globals": "npm:29.7.0"
     "@quobix/vacuum": "npm:0.17.0"


### PR DESCRIPTION
Add entity and creation endpoint for a page.

A page is an item (type = 'page'). It has a dedicated table `page` that contains it's content. For now content is a jsonb column, but it can change depending on the yjs implementation.

close #1946 