### PR TITLE
1921 smtp secure

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -29,6 +29,8 @@ x-core_environment: &core_environment
 
   # the Mailer config is set by the "mailer" service below
   MAILER_CONNECTION: smtp://docker:docker@mailer:1025
+  # disable ssl for emails, in production the default is to enable SSL.
+  MAILER_USE_SSL: false
   # Redis
   REDIS_CONNECTION: redis://redis:6379
 

--- a/src/config/helpers.spec.ts
+++ b/src/config/helpers.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { toBoolean } from './helpers';
+
+describe('toBoolean', () => {
+  it('undefined value', () => {
+    expect(toBoolean(undefined, { default: true })).toEqual(true);
+    expect(toBoolean(undefined, { default: false })).toEqual(false);
+    expect(toBoolean(undefined)).toEqual(false);
+  });
+  it('string boolean value', () => {
+    expect(toBoolean('true')).toEqual(true);
+    expect(toBoolean('false')).toEqual(false);
+    expect(toBoolean('toto')).toEqual(false);
+  });
+  it('number value', () => {
+    expect(toBoolean('1')).toEqual(true);
+    expect(toBoolean('0')).toEqual(false);
+    expect(toBoolean('4')).toEqual(false);
+  });
+});

--- a/src/config/helpers.ts
+++ b/src/config/helpers.ts
@@ -18,3 +18,13 @@ export function requiredEnvVar(name: string) {
   }
   return varValue;
 }
+
+export function toBoolean(value: string | undefined, options?: { default: boolean }) {
+  if (value == undefined) {
+    return options?.default ?? false;
+  }
+  if (value === 'true' || value === '1') {
+    return true;
+  }
+  return false;
+}

--- a/src/config/mailer.ts
+++ b/src/config/mailer.ts
@@ -1,8 +1,9 @@
 import { getEnv } from './env';
-import { requiredEnvVar } from './helpers';
+import { requiredEnvVar, toBoolean } from './helpers';
 
 getEnv();
 
 export const MAILER_CONNECTION = requiredEnvVar('MAILER_CONNECTION');
+export const MAILER_USE_SSL = toBoolean(process.env.MAILER_USE_SSL, { default: true });
 export const MAILER_CONFIG_FROM_EMAIL =
   process.env.MAILER_CONFIG_FROM_EMAIL ?? 'no-reply@graasp.org';

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -5,7 +5,8 @@ import type { FastifyBaseLogger } from 'fastify';
 
 import Etherpad from '@graasp/etherpad-api';
 
-import { MAILER_CONFIG_FROM_EMAIL, MAILER_CONNECTION } from '../config/mailer';
+import { DEV } from '../config/env';
+import { MAILER_CONFIG_FROM_EMAIL, MAILER_CONNECTION, MAILER_USE_SSL } from '../config/mailer';
 import { REDIS_CONNECTION } from '../config/redis';
 import { BaseLogger } from '../logger';
 import { MailerService } from '../plugins/mailer/mailer.service';
@@ -103,6 +104,7 @@ export const registerDependencies = (log: FastifyBaseLogger) => {
     MailerService,
     new MailerService({
       connection: MAILER_CONNECTION,
+      useSSL: DEV ? false : MAILER_USE_SSL,
       fromEmail: MAILER_CONFIG_FROM_EMAIL,
     }),
   );

--- a/src/plugins/mailer/mailer.service.ts
+++ b/src/plugins/mailer/mailer.service.ts
@@ -12,6 +12,7 @@ export interface Mail {
 
 export interface MailerOptions {
   connection: string;
+  useSSL: boolean;
   fromEmail: string;
 }
 
@@ -20,9 +21,9 @@ export class MailerService {
   private readonly fromEmail: string;
   private readonly transporter: Transporter;
 
-  constructor({ connection, fromEmail }: MailerOptions) {
+  constructor({ connection, useSSL, fromEmail }: MailerOptions) {
     this.fromEmail = fromEmail;
-    this.transporter = createTransport(connection);
+    this.transporter = createTransport(connection, { secure: useSSL });
   }
 
   /**


### PR DESCRIPTION
In this PR:
- fix #1921 
   - add a `MAILER_USE_SSL` env var to control the use of SSL with the mailer. By default the value is to disable SSL in DEV and enable in PROD.
- update the compose file for self hosted services to disable SSL (most likely that we will run in PROD but we do not have support for SSL. 
- add a helper function to convert an env var to a boolean value. it accepts `true` and `1` as truthy values any other value is considered false. We can provide a default value, when no default is provided, it is `false`.