### PR TITLE
fix: ensure required env var can't be an empty string

### DIFF
--- a/src/config/helpers.ts
+++ b/src/config/helpers.ts
@@ -13,7 +13,7 @@ export class ExpectedEnvVariable extends Error {
  */
 export function requiredEnvVar(name: string) {
   const varValue = process.env[name];
-  if (varValue === undefined) {
+  if (varValue === undefined || varValue === '') {
     throw new ExpectedEnvVariable(name);
   }
   return varValue;


### PR DESCRIPTION
Related to https://github.com/graasp/graasp-infrastructure/pull/82 the value of the env var would actually be `''` and the start would not fail, failing only much later when we actually tried to use the env var in question. And there it failed with a validation error from Postgres...

I am not sure how to test this function correctly, any ideas ?