### PR TITLE
fix: add item id in current guest itemloginSchema

### DIFF
--- a/src/services/member/member.controller.test.ts
+++ b/src/services/member/member.controller.test.ts
@@ -91,6 +91,11 @@ describe('Member routes tests', () => {
       expect(m.password).toBeUndefined();
       expect(m.lang).toEqual(item.lang);
       expect(m.itemLoginSchema).toBeDefined();
+      expect(m.itemLoginSchema.item).toMatchObject({
+        id: item.id,
+        name: item.name,
+        path: item.path,
+      });
     });
     it('Throws if signed out', async () => {
       const response = await app.inject({

--- a/src/services/member/member.controller.ts
+++ b/src/services/member/member.controller.ts
@@ -67,7 +67,11 @@ const controller: FastifyPluginAsyncTypebox = async (fastify) => {
             ...currentAccount,
             lang: itemLoginSchema.item.lang,
             itemLoginSchema: {
-              item: { name: itemLoginSchema.item.name, path: itemLoginSchema.item.path },
+              item: {
+                id: itemLoginSchema.item.id,
+                name: itemLoginSchema.item.name,
+                path: itemLoginSchema.item.path,
+              },
             },
           };
 

--- a/src/services/member/member.schemas.ts
+++ b/src/services/member/member.schemas.ts
@@ -80,6 +80,7 @@ const compositeCurrentGuestSchema = Type.Composite([
       type: accountTypeGuestRef,
       itemLoginSchema: Type.Object({
         item: Type.Object({
+          id: customType.UUID(),
           name: Type.String(),
           path: Type.String(),
         }),


### PR DESCRIPTION
To navigate to the item the guest has access to, we need the item id. This was forgotten when we added the item login properties to the current.