### PR TITLE
ci: stop workflow on docker build error

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -13,7 +13,7 @@ function show_help() {
     echo "Usage: bash docker/build.sh ECR_URI VERSION"
     echo "Arguments:"
     echo "  ECR_URI      URI of the ECR in AWS, example: public.ecr.aws/qzuer78 or a private ECR XXXXXXXX.dkr.ecr.region.amazonaws.com/repo."
-    echo "  VERSION      The version that is deployed, should be a semantic version i.e 1.45.8"
+    echo "  VERSION      The version that is deployed, should be a semantic version i.e v1.45.8"
 }
 
 # Check if no arguments are provided


### PR DESCRIPTION
Building images might fail for one of the images, but will not stop the process, leading the workflow to be successful.

With the change, if one of the image fails to build, the workflow will fail.