### PR TITLE
fix: make single client changes

### DIFF
--- a/src/plugins/swagger.ts
+++ b/src/plugins/swagger.ts
@@ -82,6 +82,11 @@ export default async function (instance: FastifyInstance): Promise<void> {
         return json.$id?.toString() ?? `my-fragment-${i}`;
       },
     },
+
+    transform: ({ schema, url }) => {
+      const transformedUrl = url.startsWith('/api') ? url : `/api${url}`;
+      return { schema, url: transformedUrl };
+    },
   });
 
   await instance.register(swaggerUiPlugin, {

--- a/src/services/member/plugins/action/memberAction.schemas.ts
+++ b/src/services/member/plugins/action/memberAction.schemas.ts
@@ -14,6 +14,7 @@ export const deleteAllById = {
 } as const satisfies FastifySchema;
 
 export const getMemberFilteredActions = {
+  operationId: 'getMembersActions',
   querystring: customType.StrictObject({
     startDate: Type.Optional(Type.String({ format: 'date-time' })),
     endDate: Type.Optional(Type.String({ format: 'date-time' })),


### PR DESCRIPTION
In this PR I propose changes that help with the migration to the single client:

- expose the api routes on the `/api` path prefix in the swagger documentation -> this is so that the generation can pick them up
- add the `operationId` to the member actions call, to make it stable when we change the paths exposed
