### PR TITLE
fix: replace nginx proxy with caddy

### DIFF
--- a/.devcontainer/caddy/Caddyfile
+++ b/.devcontainer/caddy/Caddyfile
@@ -1,0 +1,4 @@
+:3000 {
+    rewrite * /api{uri}
+    reverse_proxy core:3000
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -185,15 +185,15 @@ services:
     ports:
       - "1080:1080"
 
-  nginx:
-    image: nginx:1.25-alpine
-    hostname: nginx
+  caddy:
+    image: caddy:2
+    hostname: caddy
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+    ports:
+      - "3000:3000"
     depends_on:
       - core
-    ports:
-      - "3000:3000" # expose nginx on localhost:3000
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     restart: unless-stopped
 
 volumes:

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -75,7 +75,7 @@ export const CORS_ORIGIN_REGEX = process.env.CORS_ORIGIN_REGEX;
  * }
  * >
  */
-export const PUBLIC_URL = new URL(process.env.PUBLIC_URL ?? HOST);
+export const PUBLIC_URL = new URL(process.env.CLIENT_HOST ?? HOST);
 
 /**
  * GRAASP FILE STORAGE CONFIG


### PR DESCRIPTION
In this PR:
- replace nginx proxy with caddy
- set the PUBLIC_URL to the client value in docker_compose
- default to the client Host for the public_url (used in auth only to deliver the auth URL