### PR TITLE
fix: validation thumbnails

### DIFF
--- a/src/services/item/plugins/publication/validation/moderators/itemValidationModerator.ts
+++ b/src/services/item/plugins/publication/validation/moderators/itemValidationModerator.ts
@@ -74,6 +74,10 @@ export class ItemValidationModerator {
     } catch (error) {
       // if some error happend during the execution of a process, it is counted as failure
       status = ItemValidationStatus.Failure;
+      // in the case of a missing s3 file, we count it as OK
+      if (error.message == 'S3_FILE_NOT_FOUND') {
+        status = ItemValidationStatus.Success;
+      }
       if (error instanceof Error) {
         result = error.message;
       }

--- a/src/services/item/plugins/publication/validation/moderators/thumbnailValidationStrategy.ts
+++ b/src/services/item/plugins/publication/validation/moderators/thumbnailValidationStrategy.ts
@@ -38,8 +38,10 @@ export class ThumbnailValidationStrategy implements ValidationStrategy {
       id: item.id,
     });
 
-    const isSafe = await classifyImage(this.imageClassifierApi, url);
+    const classes = await classifyImage(this.imageClassifierApi, url);
+    const isSafe = classes.length === 0;
+    const result = classes.map((c) => `${c.class}: ${c.score}`).join(' | ');
     const status = isSafe ? ItemValidationStatus.Success : ItemValidationStatus.Failure;
-    return { status };
+    return { status, result };
   }
 }

--- a/src/services/item/plugins/publication/validation/processes/imageClassification.ts
+++ b/src/services/item/plugins/publication/validation/processes/imageClassification.ts
@@ -10,7 +10,7 @@ type ClassPrediction = {
   box: [number, number, number, number];
 };
 type ClassificationResponse = {
-  prediction?: ClassPrediction[][];
+  prediction?: (ClassPrediction[] | { success: false; reason: string })[];
   success: boolean;
 };
 
@@ -83,6 +83,10 @@ export const classifyImage = async (
   const prediction = response?.prediction?.at(0);
   if (!prediction) {
     throw new FailedImageClassificationRequestError('Invalid Response');
+  }
+  if (!Array.isArray(prediction)) {
+    // there was nothing to predict on, so there are no nudity labels
+    return [];
   }
 
   const nudityLabels = prediction.filter(


### PR DESCRIPTION
In this PR I fix afew things wrong with the validation

The thumbnail validation was wrong, it was always giving success results when we got an array back from the classifier.
For missing s3 files, the validation would fail. This is not correct as if we have no file, there will be nothing to show, so I think we should treat it as success.

I also detected that the API would sometimes return a response like:

```
[
  { success: false, reason: 'NoneType' does not have property "shape"' }
]
```

Which could happen if we send an invalid image. This is now handled by checking that the prediction is an array, if it is not an array we consider it as passing (returning an empty array). 