### PR TITLE
fix: add bust-cache on dev startup

### DIFF
--- a/src/bustCache.ts
+++ b/src/bustCache.ts
@@ -1,0 +1,15 @@
+import { Redis } from 'ioredis';
+
+import { REDIS_CONNECTION } from './config/redis';
+
+export async function bustFileCache() {
+  const redis = new Redis(REDIS_CONNECTION);
+
+  console.debug('DEV: Busting Redis cache for file urls');
+  const cache_keys = await redis.keys('file_service_url_caching*');
+  console.debug(`DEV: Removing ${cache_keys.length} keys`);
+  cache_keys.forEach((key) => {
+    redis.expire(key, 0);
+  });
+  console.debug('DEV: Done busting cache');
+}

--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -3,6 +3,7 @@ import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { fastify } from 'fastify';
 
 import registerAppPlugins from './app';
+import { bustFileCache } from './bustCache';
 import { DEV, NODE_ENV, PROD } from './config/env';
 import { client } from './drizzle/db';
 import ajvFormats from './schemas/ajvFormats';
@@ -66,6 +67,7 @@ const start = async () => {
       // greet the world
       // eslint-disable-next-line no-console
       console.log(`${GREETING}`);
+      await bustFileCache();
     }
   } catch (err) {
     instance.log.error(err);


### PR DESCRIPTION
In this PR I propose a simple addition to bust the file url cache when starting up in DEV.

This should remove the issues where we get stale URLs from the cache. A simple restart of the server should be enough to be sure the cache is clean.