### PR TITLE
refactor: remove permissionlevel dependency and use strings

### DIFF
--- a/src/services/authorization.utils.spec.ts
+++ b/src/services/authorization.utils.spec.ts
@@ -1,18 +1,13 @@
 import { v4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  ItemVisibilityType,
-  PackedFolderItemFactory,
-  PermissionLevel,
-  type PermissionLevelOptions,
-} from '@graasp/sdk';
+import { ItemVisibilityType, PackedFolderItemFactory } from '@graasp/sdk';
 
 import { ItemFactory } from '../../test/factories/item.factory';
 import { MemberFactory } from '../../test/factories/member.factory';
 import type { DBConnection } from '../drizzle/db';
 import type { ItemRaw, ItemVisibilityRaw, ItemVisibilityWithItem } from '../drizzle/types';
-import { AccountType, MinimalMember } from '../types';
+import { AccountType, MinimalMember, PermissionLevel } from '../types';
 import { filterOutPackedDescendants } from './authorization.utils';
 import type { PackedItem } from './item/ItemWrapper';
 import { ItemVisibilityRepository } from './item/plugins/itemVisibility/itemVisibility.repository';
@@ -46,7 +41,7 @@ const hiddenVisibility = {
  * types don't play nicely because factory does not use the same types as the backend
  */
 const buildPackedDescendants = (
-  permission: PermissionLevelOptions | null,
+  permission: PermissionLevel | null,
   hiddenVisibility: ItemVisibilityWithItem,
 ): PackedItem[] => {
   const arr = descendants.map((descendant) =>
@@ -95,7 +90,7 @@ describe('filterOutPackedDescendants', () => {
 
   it('Admin returns all', async () => {
     // one parent membership
-    const memberships = [{ item, member: OWNER, permission: PermissionLevel.Admin }];
+    const memberships = [{ item, member: OWNER, permission: 'admin' as const }];
     // packed descendants for expect
     // one item is hidden but this item should be returned
     const packedDescendants = buildPackedDescendants(memberships[0].permission, hiddenVisibility);
@@ -125,7 +120,7 @@ describe('filterOutPackedDescendants', () => {
 
   it('Writer returns all', async () => {
     // one parent membership
-    const memberships = [{ item, member: OWNER, permission: PermissionLevel.Write }];
+    const memberships = [{ item, member: OWNER, permission: 'write' as const }];
     // packed descendants for expect
     // one item is hidden but this item should be returned
     const packedDescendants = buildPackedDescendants(memberships[0].permission, hiddenVisibility);
@@ -155,7 +150,7 @@ describe('filterOutPackedDescendants', () => {
 
   it('Reader does not return hidden', async () => {
     // one parent membership
-    const memberships = [{ item, member: OWNER, permission: PermissionLevel.Read }];
+    const memberships = [{ item, member: OWNER, permission: 'read' as const }];
     // packed descendants for expect
     // one item is hidden, this item should not be returned!
     const packedDescendants = buildPackedDescendants(memberships[0].permission, hiddenVisibility);

--- a/src/services/authorization.utils.ts
+++ b/src/services/authorization.utils.ts
@@ -1,4 +1,4 @@
-import { ItemVisibilityType, PermissionLevel, PermissionLevelCompare } from '@graasp/sdk';
+import { ItemVisibilityType, PermissionLevelCompare } from '@graasp/sdk';
 
 import type { DBConnection } from '../drizzle/db';
 import type { ItemRaw, ItemWithCreator } from '../drizzle/types';
@@ -50,9 +50,7 @@ const _filterOutItems = async (
     );
 
     // return item if has at least write permission or is not hidden
-    return (
-      (permission && PermissionLevelCompare.gte(permission, PermissionLevel.Write)) || !isHidden
-    );
+    return (permission && PermissionLevelCompare.gte(permission, 'write')) || !isHidden;
   });
   return { items: filteredItems, memberships, visibilities };
 };
@@ -180,10 +178,7 @@ export const filterOutPackedDescendants = async (
         }
 
         // return item if has at least write permission or is not hidden
-        return (
-          (i.permission && PermissionLevelCompare.gte(i.permission, PermissionLevel.Write)) ||
-          !i.hidden
-        );
+        return (i.permission && PermissionLevelCompare.gte(i.permission, 'write')) || !i.hidden;
       })
   );
 };

--- a/src/services/chat/chatMessage.controller.test.ts
+++ b/src/services/chat/chatMessage.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
 import { seedFromJson } from '../../../test/mocks/seed';
@@ -685,7 +685,7 @@ describe('Chat Message tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               chatMessages: [
                 { creator: { name: 'bob' } },
                 { creator: { name: 'cedric' } },

--- a/src/services/chat/chatMessage.service.ts
+++ b/src/services/chat/chatMessage.service.ts
@@ -1,7 +1,5 @@
 import { singleton } from 'tsyringe';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { type DBConnection } from '../../drizzle/db';
 import type { AuthenticatedUser, MaybeUser } from '../../types';
 import { AuthorizedItemService } from '../authorizedItem.service';
@@ -134,7 +132,7 @@ export class ChatMessageService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: authenticatedUser.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     await this.chatMessageRepository.deleteByItem(dbConnection, itemId);

--- a/src/services/chat/plugins/mentions/chatMention.service.ts
+++ b/src/services/chat/plugins/mentions/chatMention.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { ClientManager, Context, MentionStatus, PermissionLevel } from '@graasp/sdk';
+import { ClientManager, Context, MentionStatus } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import { type ChatMessageRaw, type ItemRaw } from '../../../../drizzle/types';
@@ -74,7 +74,7 @@ export class MentionService {
     mentionedMembers: string[],
   ) {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
-      permission: PermissionLevel.Read,
+      permission: 'read',
       accountId: account.id,
       itemId: message.itemId,
     });

--- a/src/services/item/item.controller.read.test.ts
+++ b/src/services/item/item.controller.read.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
 import { seedFromJson } from '../../../test/mocks/seed';
@@ -100,7 +100,7 @@ describe('Item routes tests', () => {
           items: [item],
           itemMemberships: [itemMembership],
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
         });
         assertIsDefined(actor);
         assertIsMemberForTest(actor);
@@ -130,7 +130,7 @@ describe('Item routes tests', () => {
           items: [
             {
               settings: { hasThumbnail: true },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -163,7 +163,7 @@ describe('Item routes tests', () => {
           items: [
             {
               settings: { hasThumbnail: true },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -248,7 +248,7 @@ describe('Item routes tests', () => {
           items: [
             {
               isPublic: true,
-              memberships: [{ permission: PermissionLevel.Write, account: 'actor' }],
+              memberships: [{ permission: 'write', account: 'actor' }],
             },
           ],
         });
@@ -262,13 +262,9 @@ describe('Item routes tests', () => {
         });
 
         const returnedItem = response.json();
-        expectPackedItem(
-          returnedItem,
-          { ...item, permission: PermissionLevel.Write },
-          actor,
-          undefined,
-          [publicVisibility],
-        );
+        expectPackedItem(returnedItem, { ...item, permission: 'write' }, actor, undefined, [
+          publicVisibility,
+        ]);
         expect(response.statusCode).toBe(StatusCodes.OK);
       });
     });
@@ -297,24 +293,24 @@ describe('Item routes tests', () => {
             {
               name: 'parentItem1',
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ name: 'should-not-return' }],
             },
             {
               name: 'item2',
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               name: 'item3',
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             // shared
             {
               name: 'parentItem4',
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ name: 'should-not-return' }],
             },
             {
@@ -322,7 +318,7 @@ describe('Item routes tests', () => {
               creator: { name: 'bob' },
               children: [
                 {
-                  memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                  memberships: [{ account: 'actor', permission: 'admin' }],
                   name: 'item6',
                   creator: { name: 'bob' },
                 },
@@ -373,25 +369,25 @@ describe('Item routes tests', () => {
             // own items
             {
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: 'actor',
               settings: { hasThumbnail: true },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             // shared items
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 {
                   creator: { name: 'bob' },
                   settings: { hasThumbnail: true },
-                  memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                  memberships: [{ account: 'actor', permission: 'admin' }],
                 },
               ],
             },
@@ -430,15 +426,15 @@ describe('Item routes tests', () => {
           items: [
             {
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             // noise
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -454,7 +450,7 @@ describe('Item routes tests', () => {
         expect(response.statusCode).toBe(StatusCodes.OK);
 
         const packedItems = [item1, item2].map((i) =>
-          new ItemWrapper({ ...i, creator: bob }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: bob }, { permission: 'admin' }).packed(),
         );
         const { data } = response.json();
         expect(data).toHaveLength(packedItems.length);
@@ -469,15 +465,15 @@ describe('Item routes tests', () => {
           items: [
             {
               name: '2',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               name: '3',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               name: '1',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -492,7 +488,7 @@ describe('Item routes tests', () => {
         expect(response.statusCode).toBe(StatusCodes.OK);
 
         const packedItems = [item3, item1, item2].map((i) =>
-          new ItemWrapper({ ...i, creator: actor }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: actor }, { permission: 'admin' }).packed(),
         );
         const { data } = response.json();
         expect(data).toHaveLength(packedItems.length);
@@ -509,15 +505,15 @@ describe('Item routes tests', () => {
           items: [
             {
               type: ItemType.DOCUMENT,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               type: ItemType.FOLDER,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               type: ItemType.APP,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -533,7 +529,7 @@ describe('Item routes tests', () => {
         expect(response.statusCode).toBe(StatusCodes.OK);
 
         const packedItems = [item2, item1, item3].map((i) =>
-          new ItemWrapper({ ...i, creator: actor }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: actor }, { permission: 'admin' }).packed(),
         );
         const { data } = response.json();
         expect(data).toHaveLength(packedItems.length);
@@ -550,15 +546,15 @@ describe('Item routes tests', () => {
           items: [
             {
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: { name: 'anna' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: { name: 'cedric' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -574,7 +570,7 @@ describe('Item routes tests', () => {
         expect(response.statusCode).toBe(StatusCodes.OK);
 
         const packedItems = [item2, item1, item3].map((i) =>
-          new ItemWrapper({ ...i, creator: actor }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: actor }, { permission: 'admin' }).packed(),
         );
         const { data } = response.json();
         expect(data).toHaveLength(packedItems.length);
@@ -592,17 +588,17 @@ describe('Item routes tests', () => {
             {
               name: 'dog',
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               name: 'dog',
               creator: { name: 'anna' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               name: 'cat',
               creator: { name: 'cedric' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               name: 'dog',
@@ -626,7 +622,7 @@ describe('Item routes tests', () => {
         expect(data).toHaveLength(2);
         expectManyPackedItems(
           data,
-          [item1, item2].map((i) => ({ ...i, permission: PermissionLevel.Admin })),
+          [item1, item2].map((i) => ({ ...i, permission: 'admin' })),
         );
       });
 
@@ -637,14 +633,14 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
             // noise
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });
@@ -658,7 +654,7 @@ describe('Item routes tests', () => {
           query: {
             sortBy: SortBy.ItemCreatorName,
             ordering: 'asc',
-            permissions: [PermissionLevel.Read],
+            permissions: ['read'],
           },
         });
 
@@ -677,13 +673,13 @@ describe('Item routes tests', () => {
           items: [
             {
               name: 'noise',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });
@@ -695,7 +691,7 @@ describe('Item routes tests', () => {
           method: HttpMethod.Get,
           url: '/api/items/accessible',
           query: {
-            permissions: [PermissionLevel.Write, PermissionLevel.Admin],
+            permissions: ['write', 'admin'],
           },
         });
 
@@ -714,16 +710,16 @@ describe('Item routes tests', () => {
           items: [
             {
               type: ItemType.FOLDER,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               type: ItemType.FOLDER,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             // noise
             {
               type: ItemType.APP,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -734,12 +730,7 @@ describe('Item routes tests', () => {
         const sortByName = (a, b) => a.name.localeCompare(b.name);
 
         const folders = [item1, item2]
-          .map((i) =>
-            new ItemWrapper(
-              { ...i, creator: actor },
-              { permission: PermissionLevel.Admin },
-            ).packed(),
-          )
+          .map((i) => new ItemWrapper({ ...i, creator: actor }, { permission: 'admin' }).packed())
           .sort(sortByName);
 
         const response = await app.inject({
@@ -764,10 +755,10 @@ describe('Item routes tests', () => {
         const { actor } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -791,10 +782,10 @@ describe('Item routes tests', () => {
         const { actor } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -818,10 +809,10 @@ describe('Item routes tests', () => {
         const { actor } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -848,10 +839,10 @@ describe('Item routes tests', () => {
           items: [
             {
               name: '2',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
-            { name: '1', memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-            { name: '3', memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+            { name: '1', memberships: [{ account: 'actor', permission: 'admin' }] },
+            { name: '3', memberships: [{ account: 'actor', permission: 'admin' }] },
           ],
         });
         assertIsDefined(actor);
@@ -895,7 +886,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 {},
                 {
@@ -917,7 +908,7 @@ describe('Item routes tests', () => {
 
         const data = response.json<PackedItem[]>();
         const children = [child1, child2].map((i) =>
-          new ItemWrapper({ ...i, creator: actor }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: actor }, { permission: 'admin' }).packed(),
         );
         expect(data).toHaveLength(children.length);
         expectManyPackedItems(data, children);
@@ -933,7 +924,7 @@ describe('Item routes tests', () => {
           items: [
             {
               settings: { hasThumbnail: true },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 { settings: { hasThumbnail: true } },
                 { settings: { hasThumbnail: true }, children: [{ name: 'noise' }] },
@@ -946,7 +937,7 @@ describe('Item routes tests', () => {
         mockAuthenticate(actor);
 
         const children = [child1, child2].map((i) =>
-          new ItemWrapper({ ...i, creator: actor }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: actor }, { permission: 'admin' }).packed(),
         );
 
         const response = await app.inject({
@@ -968,7 +959,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               children: [{ isHidden: true }, { children: [{ name: 'noise' }] }],
             },
           ],
@@ -990,7 +981,7 @@ describe('Item routes tests', () => {
           new ItemWrapper(
             { ...child2, creator: null },
             {
-              permission: PermissionLevel.Read,
+              permission: 'read',
             },
           ).packed(),
         );
@@ -1004,7 +995,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 { type: ItemType.DOCUMENT },
                 { type: ItemType.FOLDER },
@@ -1024,7 +1015,7 @@ describe('Item routes tests', () => {
 
         expect(response.statusCode).toBe(StatusCodes.OK);
         const children = [child2, child3].map((i) =>
-          new ItemWrapper({ ...i, creator: null }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: null }, { permission: 'admin' }).packed(),
         );
         const data = response.json();
         expect(data).toHaveLength(children.length);
@@ -1039,7 +1030,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 {
                   name: 'dog',
@@ -1080,7 +1071,7 @@ describe('Item routes tests', () => {
         expect(data).toHaveLength(2);
         expectManyPackedItems(
           data,
-          [item1, item2].map((i) => ({ ...i, permission: PermissionLevel.Admin })),
+          [item1, item2].map((i) => ({ ...i, permission: 'admin' })),
         );
       });
 
@@ -1129,7 +1120,7 @@ describe('Item routes tests', () => {
             {
               creator: 'actor',
               isPublic: true,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 {
                   creator: 'actor',
@@ -1160,7 +1151,7 @@ describe('Item routes tests', () => {
         const children = [child1, child2, child3].map((i) =>
           new ItemWrapper(
             { ...i, creator: actor },
-            { permission: PermissionLevel.Admin },
+            { permission: 'admin' },
             itemVisibilities,
           ).packed(),
         );
@@ -1195,7 +1186,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ children: [{}] }, {}],
             },
           ],
@@ -1205,7 +1196,7 @@ describe('Item routes tests', () => {
         mockAuthenticate(actor);
 
         const descendants = [child1, child2, childOfChild].map((i) =>
-          new ItemWrapper({ ...i, creator: null }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: null }, { permission: 'admin' }).packed(),
         );
 
         const response = await app.inject({
@@ -1227,7 +1218,7 @@ describe('Item routes tests', () => {
           items: [
             {
               settings: { hasThumbnail: true },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [
                 {
                   settings: { hasThumbnail: true },
@@ -1249,7 +1240,7 @@ describe('Item routes tests', () => {
 
         const data = response.json<PackedItem[]>();
         const descendants = [child1, child2, childOfChild].map((i) =>
-          new ItemWrapper({ ...i, creator: null }, { permission: PermissionLevel.Admin }).packed(),
+          new ItemWrapper({ ...i, creator: null }, { permission: 'admin' }).packed(),
         );
         expect(data).toHaveLength(descendants.length);
         expectManyPackedItems(data, descendants);
@@ -1263,7 +1254,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               children: [{ isHidden: true, children: [{}] }, {}],
             },
           ],
@@ -1281,10 +1272,7 @@ describe('Item routes tests', () => {
         expect(result).toHaveLength(1);
         expectPackedItem(
           result[0],
-          new ItemWrapper(
-            { ...child2, creator: null },
-            { permission: PermissionLevel.Read },
-          ).packed(),
+          new ItemWrapper({ ...child2, creator: null }, { permission: 'read' }).packed(),
         );
         expect(response.statusCode).toBe(StatusCodes.OK);
       });
@@ -1367,7 +1355,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ children: [{}] }],
             },
             {},
@@ -1435,7 +1423,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               children: [
                 {
                   isHidden: true,

--- a/src/services/item/item.controller.s3.regression.test.ts
+++ b/src/services/item/item.controller.s3.regression.test.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
 import { seedFromJson } from '../../../test/mocks/seed';
@@ -68,7 +68,7 @@ describe('Item routes tests', () => {
     } = await seedFromJson({
       items: [
         {
-          memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+          memberships: [{ account: 'actor', permission: 'admin' }],
           children: [{ settings: { hasThumbnail: true }, children: [{}] }],
         },
         {},

--- a/src/services/item/item.controller.test.ts
+++ b/src/services/item/item.controller.test.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate } from '../../../test/app';
 import { seedFromJson } from '../../../test/mocks/seed';
@@ -30,7 +30,7 @@ describe('Item controller', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             children: [{}, { isHidden: true }, { isPublic: true }],
           },
         ],
@@ -57,7 +57,7 @@ describe('Item controller', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             children: [
               { type: ItemType.FOLDER },
               { isHidden: true, type: ItemType.DOCUMENT },
@@ -86,7 +86,7 @@ describe('Item controller', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             children: [
               {},
               { isHidden: true, type: ItemType.APP },
@@ -116,7 +116,7 @@ describe('Item controller', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             children: [{}, { isHidden: true }, { isPublic: true }],
           },
         ],

--- a/src/services/item/item.controller.update.test.ts
+++ b/src/services/item/item.controller.update.test.ts
@@ -18,7 +18,6 @@ import {
   MAX_NUMBER_OF_CHILDREN,
   MAX_TARGETS_FOR_MODIFY_REQUEST,
   MAX_TREE_LEVELS,
-  PermissionLevel,
 } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
@@ -247,7 +246,7 @@ describe('Item routes tests', () => {
           where: eq(itemMembershipsTable.itemPath, newItem.path),
         });
         expect(membership).toBeDefined();
-        expect(membership!.permission).toEqual(PermissionLevel.Admin);
+        expect(membership!.permission).toEqual('admin');
       });
 
       it('Create successfully in parent item', async () => {
@@ -257,7 +256,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 3 }],
             },
           ],
@@ -298,7 +297,7 @@ describe('Item routes tests', () => {
           items: [
             {
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });
@@ -379,7 +378,7 @@ describe('Item routes tests', () => {
           actor,
           items: [parentItem],
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }], lang }],
+          items: [{ memberships: [{ account: 'actor', permission: 'admin' }], lang }],
         });
         assertIsDefined(actor);
         assertIsMemberForTest(actor);
@@ -457,7 +456,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 1 }, { order: 2 }],
             },
           ],
@@ -491,7 +490,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 1 }, { order: 2 }],
             },
           ],
@@ -524,7 +523,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 1 }, { order: 30 }],
             },
             { children: [{ order: 100 }] },
@@ -596,7 +595,7 @@ describe('Item routes tests', () => {
           actor,
           items: [parent],
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         assertIsMemberForTest(actor);
@@ -619,7 +618,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: Array.from({ length: MAX_NUMBER_OF_CHILDREN }, () => ({})),
             },
           ],
@@ -644,7 +643,7 @@ describe('Item routes tests', () => {
           items: [
             {
               ...getItemWithDepth(MAX_TREE_LEVELS + 1),
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -672,7 +671,7 @@ describe('Item routes tests', () => {
           items: [
             {
               type: ItemType.DOCUMENT,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -750,7 +749,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.DOCUMENT,
               extra: {
                 [ItemType.DOCUMENT]: {
@@ -802,7 +801,7 @@ describe('Item routes tests', () => {
           items: [
             {
               lang: 'en',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -832,7 +831,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -868,7 +867,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -904,7 +903,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1014,7 +1013,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -1053,10 +1052,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1091,7 +1090,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1126,8 +1125,8 @@ describe('Item routes tests', () => {
           items: [
             {
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Admin },
-                { account: { name: 'bob' }, permission: PermissionLevel.Admin },
+                { account: 'actor', permission: 'admin' },
+                { account: { name: 'bob' }, permission: 'admin' },
               ],
               children: [{ children: [{ memberships: [{ account: { name: 'bob' } }] }] }],
             },
@@ -1177,11 +1176,11 @@ describe('Item routes tests', () => {
           items: [
             {
               isDeleted: true,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               isDeleted: true,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1216,11 +1215,11 @@ describe('Item routes tests', () => {
           items: [
             {
               isDeleted: true,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
             {
               isDeleted: true,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1253,7 +1252,7 @@ describe('Item routes tests', () => {
         const { actor, items } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {},
           ],
@@ -1274,7 +1273,7 @@ describe('Item routes tests', () => {
         const { actor, items } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {},
           ],
@@ -1324,7 +1323,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 10 }, { order: 5 }],
             },
           ],
@@ -1353,7 +1352,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 10 }, { order: 5 }],
             },
           ],
@@ -1383,7 +1382,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 10 }, { order: 5 }, { order: 15 }],
             },
           ],
@@ -1412,7 +1411,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{ order: 20 }, { order: 5 }, { order: 15 }],
             },
           ],
@@ -1444,10 +1443,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1495,10 +1494,10 @@ describe('Item routes tests', () => {
           itemMemberships: [_parentIm, im1],
         } = await seedFromJson({
           items: [
-            { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-            { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-            { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-            { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+            { memberships: [{ account: 'actor', permission: 'admin' }] },
+            { memberships: [{ account: 'actor', permission: 'admin' }] },
+            { memberships: [{ account: 'actor', permission: 'admin' }] },
+            { memberships: [{ account: 'actor', permission: 'admin' }] },
           ],
         });
         assertIsDefined(actor);
@@ -1544,7 +1543,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{}, {}, {}],
             },
           ],
@@ -1583,7 +1582,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{}],
             },
           ],
@@ -1622,10 +1621,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1663,10 +1662,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{}, {}, {}],
             },
           ],
@@ -1705,10 +1704,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' as const }],
             },
             ...Array.from({ length: MAX_TARGETS_FOR_MODIFY_REQUEST }, () => ({
-              memberships: [{ account: 'actor' as SeedActor, permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor' as SeedActor, permission: 'admin' as const }],
             })),
           ],
         });
@@ -1760,7 +1759,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1814,19 +1813,19 @@ describe('Item routes tests', () => {
               creator: { name: 'bob' },
               lang: 'fr',
               settings,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: { name: 'bob' },
               lang: 'fr',
               settings,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: { name: 'bob' },
               lang: 'fr',
               settings,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1886,16 +1885,16 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -1948,16 +1947,16 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -2006,15 +2005,15 @@ describe('Item routes tests', () => {
           items: [
             {
               name: commonName,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             {
               creator: { name: 'bob' },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               children: [
                 {
                   name: commonName,
-                  memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                  memberships: [{ account: 'actor', permission: 'admin' }],
                 },
               ],
             },
@@ -2057,13 +2056,13 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               children: [
                 {
-                  memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                  memberships: [{ account: 'actor', permission: 'admin' }],
                 },
                 {
-                  memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                  memberships: [{ account: 'actor', permission: 'admin' }],
                 },
               ],
             },
@@ -2110,10 +2109,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
             ...Array.from({ length: MAX_TARGETS_FOR_MODIFY_REQUEST }, () => ({
-              memberships: [{ account: 'actor' as SeedActor, permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor' as SeedActor, permission: 'admin' as const }],
             })),
           ],
         });
@@ -2149,10 +2148,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               geolocation: { lat: 1, lng: 22 },
             },
           ],
@@ -2193,10 +2192,10 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               children: [
                 { order: 20, createdAt: '2012-10-05T14:48:00.000Z' },
                 { order: 20, createdAt: '2011-10-05T14:48:00.000Z' },
@@ -2243,7 +2242,7 @@ describe('Item routes tests', () => {
         const { actor, items } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });
@@ -2266,7 +2265,7 @@ describe('Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               creator: 'actor',
             },
             {},
@@ -2308,11 +2307,11 @@ describe('Item routes tests', () => {
             {
               creator: 'actor',
               type: ItemType.DOCUMENT,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
             {
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });

--- a/src/services/item/item.repository.spec.ts
+++ b/src/services/item/item.repository.spec.ts
@@ -5,13 +5,7 @@ import { eq, inArray } from 'drizzle-orm/sql';
 import { v4 } from 'uuid';
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  ItemType,
-  MAX_ITEM_NAME_LENGTH,
-  MAX_TREE_LEVELS,
-  PermissionLevel,
-  buildPathFromIds,
-} from '@graasp/sdk';
+import { ItemType, MAX_ITEM_NAME_LENGTH, MAX_TREE_LEVELS, buildPathFromIds } from '@graasp/sdk';
 
 import { ItemFactory } from '../../../test/factories/item.factory';
 import { buildFile, seedFromJson } from '../../../test/mocks/seed';
@@ -46,17 +40,17 @@ const saveCollections = async () => {
       {
         isPublic: true,
         creator: { name: 'bob' },
-        memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+        memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
       },
       {
         isPublic: true,
         creator: { name: 'bob' },
-        memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+        memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
       },
       {
         isPublic: true,
         creator: { name: 'bob' },
-        memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+        memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
       },
     ],
   });
@@ -1622,7 +1616,7 @@ describe('Item Repository', () => {
           {
             children: [
               {
-                memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+                memberships: [{ permission: 'admin', account: 'actor' }],
                 children: [{}],
               },
             ],
@@ -1644,7 +1638,7 @@ describe('Item Repository', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ permission: PermissionLevel.Read, account: 'actor' }],
+            memberships: [{ permission: 'read', account: 'actor' }],
             children: [{ children: [{}] }],
           },
         ],
@@ -1665,10 +1659,10 @@ describe('Item Repository', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ permission: PermissionLevel.Read, account: 'actor' }],
+            memberships: [{ permission: 'read', account: 'actor' }],
             children: [
               {
-                memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+                memberships: [{ permission: 'admin', account: 'actor' }],
                 children: [{}],
               },
             ],

--- a/src/services/item/item.repository.ts
+++ b/src/services/item/item.repository.ts
@@ -28,7 +28,6 @@ import {
   MAX_TREE_LEVELS,
   type Paginated,
   type Pagination,
-  PermissionLevel,
   buildPathFromIds,
   getChildFromPath,
   getParentFromPath,
@@ -590,7 +589,7 @@ export class ItemRepository {
       .where(
         and(
           eq(items.creatorId, memberId),
-          eq(itemMembershipsTable.permission, PermissionLevel.Admin),
+          eq(itemMembershipsTable.permission, 'admin'),
           eq(sql`nlevel(${items.path})`, 1),
         ),
       )
@@ -975,7 +974,7 @@ export class ItemRepository {
         itemMembershipsTable,
         and(
           isAncestorOrSelf(itemMembershipsTable.itemPath, items.path),
-          inArray(itemMembershipsTable.permission, [PermissionLevel.Admin, PermissionLevel.Write]),
+          inArray(itemMembershipsTable.permission, ['admin', 'write']),
         ),
       )
       .innerJoin(

--- a/src/services/item/item.schemas.packed.ts
+++ b/src/services/item/item.schemas.packed.ts
@@ -3,10 +3,11 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifySchema } from 'fastify';
 
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType } from '@graasp/sdk';
 
 import { customType, registerSchemaAsRef } from '../../plugins/typebox';
 import { errorSchemaRef } from '../../schemas/global';
+import { permissionLevelSchemaRef } from '../../types';
 import { nullableMemberSchemaRef } from '../member/member.schemas';
 import { ITEMS_PAGE_SIZE } from './constants';
 import { itemVisibilitySchemaRef } from './plugins/itemVisibility/itemVisibility.schemas';
@@ -28,7 +29,7 @@ export const packedItemSchemaRef = registerSchemaAsRef(
       creator: nullableMemberSchemaRef,
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
-      permission: customType.Nullable(customType.EnumString(Object.values(PermissionLevel))),
+      permission: Type.Union([permissionLevelSchemaRef, Type.Null()]),
       hidden: Type.Optional(itemVisibilitySchemaRef),
       public: Type.Optional(itemVisibilitySchemaRef),
       thumbnails: Type.Optional(
@@ -71,7 +72,7 @@ export const getAccessible = {
       Type.Partial(
         customType.StrictObject({
           creatorId: Type.String(),
-          permissions: Type.Array(Type.Enum(PermissionLevel)),
+          permissions: Type.Array(permissionLevelSchemaRef),
           types: Type.Array(Type.Enum(ItemType)),
           keywords: Type.Array(Type.String()),
           sortBy: Type.Enum(SortBy),

--- a/src/services/item/plugins/action/itemAction.controller.test.ts
+++ b/src/services/item/plugins/action/itemAction.controller.test.ts
@@ -6,7 +6,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { ClientManager, Context, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { ClientManager, Context, HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -114,7 +114,7 @@ describe('Action Plugin Tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -140,7 +140,7 @@ describe('Action Plugin Tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -167,7 +167,7 @@ describe('Action Plugin Tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -191,7 +191,7 @@ describe('Action Plugin Tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -246,7 +246,7 @@ describe('Action Plugin Tests', () => {
         items: [item],
         actor,
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -280,7 +280,7 @@ describe('Action Plugin Tests', () => {
             ],
             appSettings: [{ creator: 'actor' }, { creator: 'actor' }],
             appActions: [{ account: 'actor' }, { account: 'actor' }],
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -317,7 +317,7 @@ describe('Action Plugin Tests', () => {
             ],
             appSettings: [{ creator: 'actor' }, { creator: 'actor' }],
             appActions: [{ account: 'actor' }, { account: 'actor' }],
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             actionRequestExports: [
               {
                 member: 'actor',
@@ -352,7 +352,7 @@ describe('Action Plugin Tests', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             actionRequestExports: [
               {
                 member: 'actor',

--- a/src/services/item/plugins/action/itemAction.service.test.ts
+++ b/src/services/item/plugins/action/itemAction.service.test.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 
-import { Context, PermissionLevel } from '@graasp/sdk';
+import { Context } from '@graasp/sdk';
 
 import build, {
   MOCK_LOGGER,
@@ -136,7 +136,7 @@ describe('ItemActionService', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               actions: [
                 {
                   account: 'actor',
@@ -180,7 +180,7 @@ describe('ItemActionService', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               actions: [
                 {
                   account: { name: 'bob' },
@@ -217,7 +217,7 @@ describe('ItemActionService', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               actions: [
                 {
                   account: { name: 'bob' },
@@ -249,7 +249,7 @@ describe('ItemActionService', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               actions: [
                 { account: 'actor', view: Context.Player },
                 { account: 'actor', view: Context.Library },
@@ -322,8 +322,8 @@ describe('ItemActionService', () => {
         actor,
       } = await seedFromJson({
         items: [
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
         ],
       });
       assertIsDefined(actor);
@@ -353,7 +353,7 @@ describe('ItemActionService', () => {
         items: [item],
         actor,
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       const actionPostMany = jest.spyOn(actionService, 'postMany').mockResolvedValue();
       assertIsDefined(actor);

--- a/src/services/item/plugins/action/itemAction.service.ts
+++ b/src/services/item/plugins/action/itemAction.service.ts
@@ -3,8 +3,6 @@ import { singleton } from 'tsyringe';
 
 import type { FastifyRequest } from 'fastify';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { type DBConnection } from '../../../../drizzle/db';
 import { actionsTable } from '../../../../drizzle/schema';
 import type { ActionWithItem, ItemRaw } from '../../../../drizzle/types';
@@ -62,7 +60,7 @@ export class ItemActionService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: account.id,
       itemId,
-      permission: PermissionLevel.Read,
+      permission: 'read',
     });
 
     // check permission
@@ -86,7 +84,7 @@ export class ItemActionService {
     return this.actionRepository.getForItem(dbConnection, item.path, {
       sampleSize: size,
       view,
-      accountId: permission === PermissionLevel.Admin ? undefined : account.id,
+      accountId: permission === 'admin' ? undefined : account.id,
     });
   }
 

--- a/src/services/item/plugins/action/requestExport/itemAction.requestExport.service.ts
+++ b/src/services/item/plugins/action/requestExport/itemAction.requestExport.service.ts
@@ -5,12 +5,7 @@ import { pipeline } from 'stream/promises';
 import { singleton } from 'tsyringe';
 import { ZipFile } from 'yazl';
 
-import {
-  Context,
-  DEFAULT_EXPORT_ACTIONS_VALIDITY_IN_DAYS,
-  PermissionLevel,
-  type UUID,
-} from '@graasp/sdk';
+import { Context, DEFAULT_EXPORT_ACTIONS_VALIDITY_IN_DAYS, type UUID } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../../drizzle/db';
 import type {
@@ -75,7 +70,7 @@ export class ActionRequestExportService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: minimalMember.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     // get last export entry within interval

--- a/src/services/item/plugins/app/app.controller.test.ts
+++ b/src/services/item/plugins/app/app.controller.test.ts
@@ -5,7 +5,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -147,7 +147,7 @@ describe('Apps Plugin Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               extra: { app: { url: chosenApp.url } },
             },
@@ -174,7 +174,7 @@ describe('Apps Plugin Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               extra: { app: { url: chosenApp.url } },
             },
@@ -300,8 +300,8 @@ describe('Apps Plugin Tests', () => {
           items: [
             {
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Read },
-                { account: { name: 'bob' }, permission: PermissionLevel.Read },
+                { account: 'actor', permission: 'read' },
+                { account: { name: 'bob' }, permission: 'read' },
               ],
               type: ItemType.APP,
               extra: { app: { url: chosenApp.url } },
@@ -340,7 +340,7 @@ describe('Apps Plugin Tests', () => {
           actor: null,
           items: [
             {
-              memberships: [{ account: { name: 'anna' }, permission: PermissionLevel.Read }],
+              memberships: [{ account: { name: 'anna' }, permission: 'read' }],
               type: ItemType.APP,
               extra: { app: { url: chosenApp.url } },
               itemLoginSchema: { guests: [{}] },
@@ -376,8 +376,8 @@ describe('Apps Plugin Tests', () => {
           items: [
             {
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Read },
-                { account: { name: 'bob' }, permission: PermissionLevel.Read },
+                { account: 'actor', permission: 'read' },
+                { account: { name: 'bob' }, permission: 'read' },
               ],
               children: [
                 {

--- a/src/services/item/plugins/app/app.service.ts
+++ b/src/services/item/plugins/app/app.service.ts
@@ -2,7 +2,7 @@ import { sign } from 'jsonwebtoken';
 import uniqBy from 'lodash.uniqby';
 import { singleton } from 'tsyringe';
 
-import { type AuthTokenSubject, ItemType, PermissionLevel } from '@graasp/sdk';
+import { type AuthTokenSubject, ItemType } from '@graasp/sdk';
 
 import { APPS_JWT_SECRET } from '../../../../config/secrets';
 import { type DBConnection } from '../../../../drizzle/db';
@@ -61,7 +61,7 @@ export class AppService {
   ) {
     // check actor has access to item
     const item = await this.authorizedItemService.getItemById(dbConnection, {
-      permission: PermissionLevel.Read,
+      permission: 'read',
       accountId: maybeUser?.id,
       itemId,
     });

--- a/src/services/item/plugins/app/appAction/appAction.controller.test.ts
+++ b/src/services/item/plugins/app/appAction/appAction.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -79,7 +79,7 @@ describe('App Actions Tests', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
                 type: ItemType.APP,
                 appActions: [
                   { account: 'actor' },
@@ -143,7 +143,7 @@ describe('App Actions Tests', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+                memberships: [{ account: 'actor', permission: 'read' }],
                 type: ItemType.APP,
                 appActions: [
                   { account: 'actor' },
@@ -208,7 +208,7 @@ describe('App Actions Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appActions: [{ account: 'actor' }, { account: 'actor' }],
             },
@@ -240,7 +240,7 @@ describe('App Actions Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
             },
           ],

--- a/src/services/item/plugins/app/appAction/appAction.controller.ts
+++ b/src/services/item/plugins/app/appAction/appAction.controller.ts
@@ -2,8 +2,6 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { resolveDependency } from '../../../../../di/utils';
 import { db } from '../../../../../drizzle/db';
 import type { FastifyInstanceTypebox } from '../../../../../plugins/typebox';
@@ -30,7 +28,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       const item = await authorizedItemService.getItemById(db, {
         accountId: member?.id,
         itemId: id,
-        permission: PermissionLevel.Admin,
+        permission: 'admin',
       });
       checkItemIsApp(item);
     });

--- a/src/services/item/plugins/app/appAction/appAction.service.ts
+++ b/src/services/item/plugins/app/appAction/appAction.service.ts
@@ -1,8 +1,6 @@
 import { eq } from 'drizzle-orm/sql';
 import { singleton } from 'tsyringe';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { type DBConnection } from '../../../../../drizzle/db';
 import { appActionsTable } from '../../../../../drizzle/schema';
 import type { AppActionWithItemAndAccount } from '../../../../../drizzle/types';
@@ -44,7 +42,7 @@ export class AppActionService {
   ): Promise<AppActionWithItemAndAccount> {
     // posting an app action is allowed to readers
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
-      permission: PermissionLevel.Read,
+      permission: 'read',
       accountId: account.id,
       itemId,
     });
@@ -72,13 +70,13 @@ export class AppActionService {
     // posting an app action is allowed to readers
     const { itemMembership } = await this.authorizedItemService.getPropertiesForItemById(
       dbConnection,
-      { permission: PermissionLevel.Read, accountId: account.id, itemId },
+      { permission: 'read', accountId: account.id, itemId },
     );
     const permission = itemMembership?.permission;
     let { accountId: fMemberId } = filters;
 
     // can read only own app action if not admin
-    if (permission !== PermissionLevel.Admin) {
+    if (permission !== 'admin') {
       if (!fMemberId) {
         fMemberId = account.id;
       } else if (fMemberId !== account.id) {

--- a/src/services/item/plugins/app/appAction/test/legacy.test.ts
+++ b/src/services/item/plugins/app/appAction/test/legacy.test.ts
@@ -6,7 +6,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -46,7 +46,7 @@ describe('App Actions Tests', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             type: ItemType.APP,
             appActions: [
               { account: 'actor' },

--- a/src/services/item/plugins/app/appData/appData.controller.test.ts
+++ b/src/services/item/plugins/app/appData/appData.controller.test.ts
@@ -5,7 +5,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { AppDataVisibility, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { AppDataVisibility, HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -158,7 +158,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appData: [
                 { account: 'actor', creator: 'actor' },
@@ -194,7 +194,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appData: [
                 { account: 'actor', type, creator: 'actor' },
@@ -233,7 +233,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appData: [{ account: 'actor', creator: 'actor' }],
             },
@@ -293,7 +293,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 { account: 'actor', creator: 'actor' },
@@ -328,7 +328,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 { account: 'actor', creator: 'actor' },
@@ -406,7 +406,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -446,8 +446,8 @@ describe('App Data Tests', () => {
           items: [
             {
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Admin },
-                { account: { name: 'bob' }, permission: PermissionLevel.Read },
+                { account: 'actor', permission: 'admin' },
+                { account: { name: 'bob' }, permission: 'read' },
               ],
               type: ItemType.APP,
             },
@@ -486,7 +486,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -519,8 +519,8 @@ describe('App Data Tests', () => {
           items: [
             {
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Read },
-                { account: { name: 'bob' }, permission: PermissionLevel.Admin },
+                { account: 'actor', permission: 'read' },
+                { account: { name: 'bob' }, permission: 'admin' },
               ],
               type: ItemType.APP,
             },
@@ -573,7 +573,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 { account: 'actor', creator: 'actor', type: 'type', data: { foo: 'value' } },
@@ -614,7 +614,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 { account: 'actor', creator: 'actor', type: 'type', data: { foo: 'value' } },
@@ -648,7 +648,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
             },
           ],
@@ -679,7 +679,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [{ account: 'actor', creator: 'actor', ...buildAppDataFile() }],
             },
@@ -717,7 +717,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [{ account: 'actor', creator: 'actor', type: 'type', data: { foo: 'bar' } }],
             },
@@ -755,7 +755,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 {
@@ -817,7 +817,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 {
@@ -859,7 +859,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appData: [
                 {
@@ -895,7 +895,7 @@ describe('App Data Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
             },
           ],

--- a/src/services/item/plugins/app/appData/appData.repository.ts
+++ b/src/services/item/plugins/app/appData/appData.repository.ts
@@ -1,12 +1,7 @@
 import { SQL } from 'drizzle-orm';
 import { and, eq, or } from 'drizzle-orm/sql';
 
-import {
-  AppDataVisibility,
-  ItemType,
-  PermissionLevel,
-  type PermissionLevelOptions,
-} from '@graasp/sdk';
+import { AppDataVisibility, ItemType } from '@graasp/sdk';
 
 import type { DBConnection } from '../../../../../drizzle/db';
 import { appDataTable } from '../../../../../drizzle/schema';
@@ -15,6 +10,7 @@ import type {
   AppDataWithItemAndAccountAndCreator,
   MinimalAccount,
 } from '../../../../../drizzle/types';
+import { PermissionLevel } from '../../../../../types';
 import { AppDataNotFound, PreventUpdateAppDataFile } from './errors';
 
 export class AppDataRepository {
@@ -90,7 +86,7 @@ export class AppDataRepository {
       accountId?: MinimalAccount['id'];
       type?: string;
     } = {},
-    permission?: PermissionLevelOptions,
+    permission?: PermissionLevel,
   ): Promise<AppDataWithItemAndAccountAndCreator[]> {
     const { accountId, type } = filters;
 
@@ -102,7 +98,7 @@ export class AppDataRepository {
     }
 
     // restrict app data access if user is not an admin
-    if (permission !== PermissionLevel.Admin) {
+    if (permission !== 'admin') {
       const orConditions: (SQL | undefined)[] = [
         // - visibility: item
         eq(appDataTable.visibility, AppDataVisibility.Item),

--- a/src/services/item/plugins/app/appData/test/legacy.test.ts
+++ b/src/services/item/plugins/app/appData/test/legacy.test.ts
@@ -6,7 +6,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -47,7 +47,7 @@ describe('App Data Tests - Legacy', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             type: ItemType.APP,
             appData: [
               { account: 'actor', creator: 'actor' },
@@ -87,7 +87,7 @@ describe('App Data Tests - Legacy', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             type: ItemType.APP,
             appData: [{ account: { name: 'bob' }, creator: 'actor' }],
           },
@@ -125,7 +125,7 @@ describe('App Data Tests - Legacy', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             type: ItemType.APP,
             appData: [{ account: 'actor', creator: 'actor' }],
           },

--- a/src/services/item/plugins/app/appItem.controller.test.ts
+++ b/src/services/item/plugins/app/appItem.controller.test.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import { AppItemFactory, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { AppItemFactory, HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -89,7 +89,7 @@ describe('App Item tests', () => {
         const membership = await db.query.itemMembershipsTable.findFirst({
           where: eq(itemMembershipsTable.itemPath, newItem.path),
         });
-        expect(membership?.permission).toEqual(PermissionLevel.Admin);
+        expect(membership?.permission).toEqual('admin');
       });
 
       it('Fail to create if payload is invalid', async () => {
@@ -157,7 +157,7 @@ describe('App Item tests', () => {
           items: [
             {
               ...AppItemFactory(),
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });

--- a/src/services/item/plugins/app/appSetting/appSetting.controller.test.ts
+++ b/src/services/item/plugins/app/appSetting/appSetting.controller.test.ts
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -142,7 +142,7 @@ describe('Apps Settings Tests', () => {
           items: [
             {
               type: ItemType.APP,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               appSettings: [{ creator: { name: 'bob' } }, { creator: { name: 'alice' } }],
             },
           ],
@@ -174,7 +174,7 @@ describe('Apps Settings Tests', () => {
           items: [
             {
               type: ItemType.APP,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               appSettings: [
                 { creator: { name: 'bob' }, name: 'new-setting' },
                 { creator: { name: 'bob' }, name: 'new-setting' },
@@ -209,7 +209,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appSettings: [
                 { creator: { name: 'bob' } },
@@ -248,7 +248,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -300,7 +300,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -338,7 +338,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
             },
           ],
@@ -368,7 +368,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               type: ItemType.APP,
             },
           ],
@@ -398,7 +398,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -443,7 +443,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -476,7 +476,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -508,7 +508,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -538,7 +538,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -564,7 +564,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -619,7 +619,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -653,7 +653,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -682,7 +682,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.APP,
             },
           ],
@@ -711,7 +711,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -741,7 +741,7 @@ describe('Apps Settings Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               type: ItemType.APP,
               appSettings: [{ creator: 'actor' }],
             },
@@ -772,7 +772,7 @@ describe('Apps Settings Tests', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
             type: ItemType.APP,
             appSettings: [{ creator: 'actor' }],
           },
@@ -820,7 +820,7 @@ describe('Apps Settings Tests', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
             children: [
               {
                 type: ItemType.APP,

--- a/src/services/item/plugins/app/appSetting/appSetting.service.ts
+++ b/src/services/item/plugins/app/appSetting/appSetting.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { PermissionLevel, type UUID } from '@graasp/sdk';
+import { type UUID } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../../drizzle/db';
 import type { AppSettingInsertDTO, AppSettingRaw, ItemRaw } from '../../../../../drizzle/types';
@@ -56,7 +56,7 @@ export class AppSettingService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     const appSetting = await this.appSettingRepository.addOne(dbConnection, {
@@ -79,7 +79,7 @@ export class AppSettingService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     await this.hooks.runPreHooks('patch', member, dbConnection, {
@@ -105,7 +105,7 @@ export class AppSettingService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     const appSetting = await this.appSettingRepository.getOneOrThrow(dbConnection, appSettingId);

--- a/src/services/item/plugins/app/chatBot/chatBot.service.ts
+++ b/src/services/item/plugins/app/chatBot/chatBot.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { type ChatBotMessage, type GPTVersionType, PermissionLevel } from '@graasp/sdk';
+import { type ChatBotMessage, type GPTVersionType } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../../drizzle/db';
 import type { AuthenticatedUser } from '../../../../../types';
@@ -25,7 +25,7 @@ export class ChatBotService {
   ) {
     // check that the member can read the item to be allowed to interact with the chat
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
-      permission: PermissionLevel.Read,
+      permission: 'read',
       accountId: account.id,
       itemId,
     });

--- a/src/services/item/plugins/capsule/capsule.controller.test.ts
+++ b/src/services/item/plugins/capsule/capsule.controller.test.ts
@@ -12,7 +12,6 @@ import {
   HttpMethod,
   ItemType,
   MAX_NUMBER_OF_CHILDREN,
-  PermissionLevel,
 } from '@graasp/sdk';
 
 import build, {
@@ -114,7 +113,7 @@ describe('Capsule routes tests', () => {
         const membership = await db.query.itemMembershipsTable.findFirst({
           where: eq(itemMembershipsTable.itemPath, newItem.path),
         });
-        expect(membership?.permission).toEqual(PermissionLevel.Admin);
+        expect(membership?.permission).toEqual('admin');
 
         // order is null for root
         const savedItem = await db.query.itemsRawTable.findFirst({
@@ -163,7 +162,7 @@ describe('Capsule routes tests', () => {
           items: [parent],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'write' }] }],
         });
         assertIsDefined(actor);
         assertIsMember(actor);
@@ -189,7 +188,7 @@ describe('Capsule routes tests', () => {
           await db.query.itemMembershipsTable.findMany({
             where: and(
               eq(itemMembershipsTable.itemPath, newItem.path),
-              eq(itemMembershipsTable.permission, PermissionLevel.Admin),
+              eq(itemMembershipsTable.permission, 'admin'),
               eq(itemMembershipsTable.accountId, actor.id),
             ),
           }),
@@ -471,7 +470,7 @@ describe('Capsule routes tests', () => {
           items: [parent],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -646,7 +645,7 @@ describe('Capsule routes tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);

--- a/src/services/item/plugins/document/document.legacy.test.ts
+++ b/src/services/item/plugins/document/document.legacy.test.ts
@@ -3,13 +3,7 @@ import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import {
-  DocumentItemExtraFlavor,
-  DocumentItemFactory,
-  HttpMethod,
-  ItemType,
-  PermissionLevel,
-} from '@graasp/sdk';
+import { DocumentItemExtraFlavor, DocumentItemFactory, HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -85,7 +79,7 @@ describe('Document Item tests', () => {
         const membership = await db.query.itemMembershipsTable.findFirst({
           where: eq(itemMembershipsTable.itemPath, newItem.path),
         });
-        expect(membership?.permission).toEqual(PermissionLevel.Admin);
+        expect(membership?.permission).toEqual('admin');
       });
 
       it('Fail to create if type does not match extra', async () => {
@@ -163,7 +157,7 @@ describe('Document Item tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.DOCUMENT,
               extra: {
                 [ItemType.DOCUMENT]: {

--- a/src/services/item/plugins/embeddedLink/link.controller.test.ts
+++ b/src/services/item/plugins/embeddedLink/link.controller.test.ts
@@ -6,7 +6,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -266,7 +266,7 @@ describe('Tests Embedded Link Controller', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{}],
             },
           ],
@@ -379,7 +379,7 @@ describe('Tests Embedded Link Controller', () => {
           {
             extra: { [ItemType.LINK]: { url: faker.internet.url() } },
             type: ItemType.LINK,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -406,7 +406,7 @@ describe('Tests Embedded Link Controller', () => {
             {
               type: ItemType.LINK,
               extra: { [ItemType.LINK]: { url: faker.internet.url() } },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -431,7 +431,7 @@ describe('Tests Embedded Link Controller', () => {
               settings: { isCollapsible: false },
               type: ItemType.LINK,
               extra: { [ItemType.LINK]: { url: faker.internet.url() } },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });

--- a/src/services/item/plugins/enroll/enroll.controller.test.ts
+++ b/src/services/item/plugins/enroll/enroll.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemLoginSchemaStatus, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemLoginSchemaStatus } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -66,7 +66,7 @@ describe('Enroll', () => {
       expectMembership(itemMembership as ItemMembershipWithItemAndAccountAndCreator, {
         creatorId: actor.id,
         itemPath: item.path,
-        permission: PermissionLevel.Read,
+        permission: 'read',
         accountId: actor.id,
       });
     });
@@ -181,7 +181,7 @@ describe('Enroll', () => {
       expectMembership(itemMembership as ItemMembershipWithItemAndAccountAndCreator, {
         creatorId: actor.id,
         itemPath: item.path,
-        permission: PermissionLevel.Read,
+        permission: 'read',
         accountId: actor.id,
       });
     });

--- a/src/services/item/plugins/enroll/enroll.service.ts
+++ b/src/services/item/plugins/enroll/enroll.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { ItemLoginSchemaStatus, PermissionLevel, type UUID } from '@graasp/sdk';
+import { ItemLoginSchemaStatus, type UUID } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import type { MinimalMember } from '../../../../types';
@@ -46,7 +46,7 @@ export class EnrollService {
     // Check if the member already has an permission over the item, if so, throw an error
     if (
       await this.authorizedItemService.hasPermission(dbConnection, {
-        permission: PermissionLevel.Read,
+        permission: 'read',
         accountId: member.id,
         item,
       })
@@ -56,7 +56,7 @@ export class EnrollService {
 
     await this.itemMembershipRepository.addOne(dbConnection, {
       itemPath: item.path,
-      permission: PermissionLevel.Read,
+      permission: 'read',
       accountId: member.id,
       creatorId: member.id,
     });

--- a/src/services/item/plugins/etherpad/etherpad.controller.test.ts
+++ b/src/services/item/plugins/etherpad/etherpad.controller.test.ts
@@ -7,7 +7,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { EtherpadPermission, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { EtherpadPermission, HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -406,7 +406,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -449,7 +449,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -527,7 +527,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -599,7 +599,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -694,7 +694,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -777,7 +777,7 @@ describe('Etherpad service API', () => {
           {
             name: "bob's test etherpad item",
             type: ItemType.ETHERPAD,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -836,7 +836,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -867,7 +867,7 @@ describe('Etherpad service API', () => {
               groupID: MOCK_GROUP_ID,
               padName: MOCK_PAD_NAME,
             }),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -900,7 +900,7 @@ describe('Etherpad service API', () => {
                 groupID: MOCK_GROUP_ID,
                 padName: MOCK_PAD_NAME,
               }),
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -950,7 +950,7 @@ describe('Etherpad service API', () => {
         actor,
         items: [parent],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -995,8 +995,8 @@ describe('Etherpad service API', () => {
         items: [parent, bogusItem],
       } = await seedFromJson({
         items: [
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
         ],
       });
       assertIsDefined(actor);
@@ -1038,7 +1038,7 @@ describe('Etherpad service API', () => {
         items: [
           {
             type: ItemType.ETHERPAD,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -1068,7 +1068,7 @@ describe('Etherpad service API', () => {
         items: [
           {
             type: ItemType.ETHERPAD,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });

--- a/src/services/item/plugins/etherpad/etherpad.service.test.ts
+++ b/src/services/item/plugins/etherpad/etherpad.service.test.ts
@@ -1,12 +1,7 @@
 import { v4 } from 'uuid';
 
 import Etherpad from '@graasp/etherpad-api';
-import {
-  EtherpadItemFactory,
-  EtherpadPermission,
-  FolderItemFactory,
-  PermissionLevel,
-} from '@graasp/sdk';
+import { EtherpadItemFactory, EtherpadPermission, FolderItemFactory } from '@graasp/sdk';
 
 import { MOCK_LOGGER } from '../../../../../test/app';
 import { resolveDependency } from '../../../../di/utils';
@@ -149,7 +144,7 @@ describe('Etherpad Service', () => {
 
     //   expect(MOCK_ITEM.extra.etherpad.readerPermission).toBeUndefined();
 
-    //   const readerPermission = PermissionLevel.Write;
+    //   const readerPermission = "write";
     //   await etherpadService.patchWithOptions(db, MOCK_MEMBER, MOCK_ITEM.id, {
     //     readerPermission,
     //   });
@@ -158,7 +153,7 @@ describe('Etherpad Service', () => {
     //   expect(itemServicePatchMock).toHaveBeenCalledWith(MOCK_MEMBER, repositories, MOCK_ITEM.id, {
     //     extra: {
     //       [ItemType.ETHERPAD]: {
-    //         readerPermission: PermissionLevel.Write,
+    //         readerPermission: "write",
     //         padID: MOCK_ITEM.extra.etherpad.padID,
     //         groupID: MOCK_ITEM.extra.etherpad.groupID,
     //       },
@@ -191,7 +186,7 @@ describe('Etherpad Service', () => {
 
       await expect(() =>
         etherpadService.patchWithOptions(db, MOCK_MEMBER, v4(), {
-          readerPermission: PermissionLevel.Write,
+          readerPermission: 'write',
         }),
       ).rejects.toThrow();
     });
@@ -210,7 +205,7 @@ describe('Etherpad Service', () => {
     //   jest.spyOn(itemService, 'get').mockResolvedValue({
     //     ...EtherpadItemFactory({
     //       extra: {
-    //         etherpad: { padID: v4(), groupID: v4(), readerPermission: PermissionLevel.Write },
+    //         etherpad: { padID: v4(), groupID: v4(), readerPermission: "write" },
     //       },
     //     }),
     //     creatorId: 'some',
@@ -219,7 +214,7 @@ describe('Etherpad Service', () => {
     //   });
     //   // actor has read permission
     //   jest.spyOn(repositories.itemMembershipRepository, 'getInherited').mockResolvedValue({
-    //     permission: PermissionLevel.Read,
+    //     permission: "read",
     //     item: {} as ItemRaw,
     //   } as ItemMembershipWithItemAndAccount);
     //   const getReadOnlyIDMock = jest.spyOn(etherpad, 'getReadOnlyID');
@@ -233,7 +228,7 @@ describe('Etherpad Service', () => {
     //   jest.spyOn(itemService, 'get').mockResolvedValue({
     //     ...EtherpadItemFactory({
     //       extra: {
-    //         etherpad: { padID: v4(), groupID: v4(), readerPermission: PermissionLevel.Read },
+    //         etherpad: { padID: v4(), groupID: v4(), readerPermission: "read" },
     //       },
     //     }),
     //     creatorId: 'some',
@@ -242,7 +237,7 @@ describe('Etherpad Service', () => {
     //   });
     //   // permission is read
     //   jest.spyOn(repositories.itemMembershipRepository, 'getInherited').mockResolvedValue({
-    //     permission: PermissionLevel.Read,
+    //     permission: "read",
     //   } as ItemMembershipWithItemAndAccount);
     //   const getReadOnlyIDMock = jest
     //     .spyOn(etherpad, 'getReadOnlyID')

--- a/src/services/item/plugins/etherpad/etherpad.service.ts
+++ b/src/services/item/plugins/etherpad/etherpad.service.ts
@@ -8,7 +8,6 @@ import {
   EtherpadPermission,
   type EtherpadPermissionType,
   ItemType,
-  PermissionLevel,
 } from '@graasp/sdk';
 
 import { ETHERPAD_NAME_FACTORY_DI_KEY } from '../../../../di/constants';
@@ -194,7 +193,7 @@ export class EtherpadItemService {
     item: EtherpadItem,
   ): Promise<'read' | 'write'> {
     // no specific check if read mode was requested
-    if (requestedMode === PermissionLevel.Read) {
+    if (requestedMode === 'read') {
       return 'read';
     }
     // if mode was write,
@@ -209,10 +208,9 @@ export class EtherpadItemService {
     // allow write for admin, writers, and readers if setting is enabled
     if (
       membership &&
-      (membership.permission == PermissionLevel.Write ||
-        membership.permission == PermissionLevel.Admin ||
-        (membership.permission == PermissionLevel.Read &&
-          item.extra.etherpad.readerPermission == PermissionLevel.Write))
+      (membership.permission == 'write' ||
+        membership.permission == 'admin' ||
+        (membership.permission == 'read' && item.extra.etherpad.readerPermission == 'write'))
     ) {
       return 'write';
     }

--- a/src/services/item/plugins/file/itemFile.controller.test.ts
+++ b/src/services/item/plugins/file/itemFile.controller.test.ts
@@ -14,7 +14,6 @@ import {
   HttpMethod,
   ItemType,
   MaxWidth,
-  PermissionLevel,
 } from '@graasp/sdk';
 
 import build, {
@@ -165,7 +164,7 @@ describe('File Item routes tests', () => {
 
           // a membership is created for this item
           const membership = await getItemMembershipByPath(item.path);
-          expect(membership?.permission).toEqual(PermissionLevel.Admin);
+          expect(membership?.permission).toEqual('admin');
         });
 
         it('Upload successfully one pdf file with thumbnail', async () => {
@@ -234,7 +233,7 @@ describe('File Item routes tests', () => {
             ),
           });
           for (const m of memberships) {
-            expect(m?.permission).toEqual(PermissionLevel.Admin);
+            expect(m?.permission).toEqual('admin');
           }
         });
 
@@ -243,7 +242,7 @@ describe('File Item routes tests', () => {
             actor,
             items: [parentItem],
           } = await seedFromJson({
-            items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+            items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
           });
           assertIsDefined(actor);
           mockAuthenticate(actor);
@@ -317,7 +316,7 @@ describe('File Item routes tests', () => {
             actor,
             items: [parentItem],
           } = await seedFromJson({
-            items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+            items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
           });
           assertIsDefined(actor);
           mockAuthenticate(actor);
@@ -530,7 +529,7 @@ describe('File Item routes tests', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+                memberships: [{ account: 'actor', permission: 'read' }],
               },
             ],
           });
@@ -606,7 +605,7 @@ describe('File Item routes tests', () => {
         items: [
           {
             ...buildFile('actor'),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -629,7 +628,7 @@ describe('File Item routes tests', () => {
         items: [
           {
             ...buildFile('actor'),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -652,7 +651,7 @@ describe('File Item routes tests', () => {
         items: [
           {
             ...buildFile('actor'),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -675,7 +674,7 @@ describe('File Item routes tests', () => {
         items: [
           {
             ...buildFile('actor'),
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -700,7 +699,7 @@ describe('File Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -728,7 +727,7 @@ describe('File Item routes tests', () => {
           items: [
             {
               ...buildFile({ name: 'bob' }),
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -758,7 +757,7 @@ describe('File Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{}],
             },
           ],
@@ -789,7 +788,7 @@ describe('File Item routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [buildFile('actor'), {}],
             },
           ],
@@ -842,7 +841,7 @@ describe('File Item routes tests', () => {
                       content: 'content',
                     },
                   },
-                  memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                  memberships: [{ account: 'actor', permission: 'admin' }],
                 },
               ],
             },
@@ -1082,7 +1081,7 @@ describe('File Item routes tests', () => {
           items: [
             {
               ...buildFile({ name: 'bob' }),
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });

--- a/src/services/item/plugins/file/itemFile.controller.ts
+++ b/src/services/item/plugins/file/itemFile.controller.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { fastifyMultipart } from '@fastify/multipart';
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { type FileItemProperties, ItemType, PermissionLevel, getFileExtension } from '@graasp/sdk';
+import { type FileItemProperties, ItemType, getFileExtension } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
@@ -107,7 +107,7 @@ const basePlugin: FastifyPluginAsyncTypebox = async (fastify) => {
       // check rights
       if (parentId) {
         await authorizedItemService.assertAccessForItemId(db, {
-          permission: PermissionLevel.Write,
+          permission: 'write',
           accountId: member.id,
           itemId: parentId,
         });

--- a/src/services/item/plugins/folder/folder.controller.test.ts
+++ b/src/services/item/plugins/folder/folder.controller.test.ts
@@ -15,7 +15,6 @@ import {
   HttpMethod,
   ItemType,
   MAX_NUMBER_OF_CHILDREN,
-  PermissionLevel,
 } from '@graasp/sdk';
 
 import build, {
@@ -155,7 +154,7 @@ describe('Folder routes tests', () => {
         const membership = await db.query.itemMembershipsTable.findFirst({
           where: eq(itemMembershipsTable.itemPath, newItem.path),
         });
-        expect(membership?.permission).toEqual(PermissionLevel.Admin);
+        expect(membership?.permission).toEqual('admin');
 
         // order is null for root
         const savedItem = await db.query.itemsRawTable.findFirst({
@@ -204,7 +203,7 @@ describe('Folder routes tests', () => {
           items: [parent],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'write' }] }],
         });
         assertIsDefined(actor);
         assertIsMember(actor);
@@ -230,7 +229,7 @@ describe('Folder routes tests', () => {
           await db.query.itemMembershipsTable.findMany({
             where: and(
               eq(itemMembershipsTable.itemPath, newItem.path),
-              eq(itemMembershipsTable.permission, PermissionLevel.Admin),
+              eq(itemMembershipsTable.permission, 'admin'),
               eq(itemMembershipsTable.accountId, actor.id),
             ),
           }),
@@ -568,7 +567,7 @@ describe('Folder routes tests', () => {
           items: [parent],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -900,7 +899,7 @@ describe('Folder routes tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -1024,7 +1023,7 @@ describe('Folder routes tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);

--- a/src/services/item/plugins/folder/folder.service.spec.ts
+++ b/src/services/item/plugins/folder/folder.service.spec.ts
@@ -78,7 +78,7 @@ describe('Folder Service', () => {
     // });
 
     // it('return folder for permission', async () => {
-    //   const permission = PermissionLevel.Write;
+    //   const permission = "write";
     //   const folderItem = FolderItemFactory() as ItemWithCreator;
     //   const itemServicePostMock = jest
     //     .spyOn(BasicItemService.prototype, 'get')

--- a/src/services/item/plugins/folder/folder.service.ts
+++ b/src/services/item/plugins/folder/folder.service.ts
@@ -1,17 +1,12 @@
 import { Readable } from 'node:stream';
 import { singleton } from 'tsyringe';
 
-import {
-  type ItemGeolocation,
-  ItemType,
-  type PermissionLevelOptions,
-  type UUID,
-} from '@graasp/sdk';
+import { type ItemGeolocation, ItemType, type UUID } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import { type ItemRaw } from '../../../../drizzle/types';
 import { BaseLogger } from '../../../../logger';
-import type { MaybeUser, MinimalMember } from '../../../../types';
+import type { MaybeUser, MinimalMember, PermissionLevel } from '../../../../types';
 import { ItemNotFolder } from '../../../../utils/errors';
 import { AuthorizedItemService } from '../../../authorizedItem.service';
 import { ItemMembershipRepository } from '../../../itemMembership/membership.repository';
@@ -64,7 +59,7 @@ export class FolderItemService extends ItemService {
     dbConnection: DBConnection,
     maybeUser: MaybeUser,
     itemId: ItemRaw['id'],
-    permission?: PermissionLevelOptions,
+    permission?: PermissionLevel,
   ): Promise<FolderItem> {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: maybeUser?.id,

--- a/src/services/item/plugins/geolocation/itemGeolocation.controller.test.ts
+++ b/src/services/item/plugins/geolocation/itemGeolocation.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -469,9 +469,9 @@ describe('Item Geolocation', () => {
         expect(res.statusCode).toBe(StatusCodes.OK);
         expect(res.json()).toHaveLength(3);
         expectPackedItemGeolocations(res.json(), [
-          { ...geoloc1, item: { ...item1, creator: null, permission: PermissionLevel.Admin } },
-          { ...geoloc2, item: { ...item2, creator: null, permission: PermissionLevel.Admin } },
-          { ...geoloc3, item: { ...item3, creator: null, permission: PermissionLevel.Admin } },
+          { ...geoloc1, item: { ...item1, creator: null, permission: 'admin' } },
+          { ...geoloc2, item: { ...item2, creator: null, permission: 'admin' } },
+          { ...geoloc3, item: { ...item3, creator: null, permission: 'admin' } },
         ]);
       });
       it('Get item geolocations within parent item', async () => {
@@ -638,7 +638,7 @@ describe('Item Geolocation', () => {
           actor,
           items: [item],
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -686,7 +686,7 @@ describe('Item Geolocation', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               geolocation: { lat: 1, lng: 2 },
             },
           ],

--- a/src/services/item/plugins/geolocation/itemGeolocation.service.spec.ts
+++ b/src/services/item/plugins/geolocation/itemGeolocation.service.spec.ts
@@ -1,8 +1,6 @@
 import { v4 } from 'uuid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { seedFromJson } from '../../../../../test/mocks/seed';
 import { db } from '../../../../drizzle/db';
 import { assertIsDefined } from '../../../../utils/assertions';
@@ -50,7 +48,7 @@ describe('ItemGeolocationService', () => {
         items: [
           {
             geolocation: { lat: 1, lng: 2, country: 'de' },
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -171,7 +169,7 @@ describe('ItemGeolocationService', () => {
       const { actor, items, geolocations, itemMemberships } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
             geolocation: {
               lat: 1,
               lng: 2,
@@ -179,7 +177,7 @@ describe('ItemGeolocationService', () => {
             },
           },
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
             geolocation: {
               lat: 1,
               lng: 2,
@@ -220,11 +218,11 @@ describe('ItemGeolocationService', () => {
       expectPackedItemGeolocations(res, [
         {
           ...geolocations[0],
-          item: { ...items[0], creator: actor, permission: PermissionLevel.Read },
+          item: { ...items[0], creator: actor, permission: 'read' },
         },
         {
           ...geolocations[1],
-          item: { ...items[1], creator: actor, permission: PermissionLevel.Read },
+          item: { ...items[1], creator: actor, permission: 'read' },
         },
       ]);
     });
@@ -240,7 +238,7 @@ describe('ItemGeolocationService', () => {
             },
           },
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
             geolocation: {
               lat: 1,
               lng: 2,
@@ -280,7 +278,7 @@ describe('ItemGeolocationService', () => {
       expectPackedItemGeolocations(res, [
         {
           ...geolocations[1],
-          item: { ...items[1], creator: actor, permission: PermissionLevel.Read },
+          item: { ...items[1], creator: actor, permission: 'read' },
         },
       ]);
     });
@@ -459,7 +457,7 @@ describe('ItemGeolocationService', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -480,7 +478,7 @@ describe('ItemGeolocationService', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -501,7 +499,7 @@ describe('ItemGeolocationService', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });

--- a/src/services/item/plugins/geolocation/itemGeolocation.service.ts
+++ b/src/services/item/plugins/geolocation/itemGeolocation.service.ts
@@ -1,7 +1,5 @@
 import { inject, singleton } from 'tsyringe';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { GEOLOCATION_API_KEY_DI_KEY } from '../../../../di/constants';
 import { type DBConnection } from '../../../../drizzle/db';
 import type { ItemGeolocationRaw, ItemRaw } from '../../../../drizzle/types';
@@ -40,7 +38,7 @@ export class ItemGeolocationService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Write,
+      permission: 'write',
     });
 
     return this.itemGeolocationRepository.delete(dbConnection, item);
@@ -93,7 +91,7 @@ export class ItemGeolocationService {
 
     const { itemMemberships, visibilities } =
       await this.authorizedItemService.getPropertiesForItems(dbConnection, {
-        permission: PermissionLevel.Read,
+        permission: 'read',
         accountId: maybeUser?.id,
         items: geoloc.map(({ item }) => item),
       });
@@ -141,7 +139,7 @@ export class ItemGeolocationService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Write,
+      permission: 'write',
     });
 
     return this.itemGeolocationRepository.put(dbConnection, item.path, geolocation);

--- a/src/services/item/plugins/html/h5p/h5p.controller.test.ts
+++ b/src/services/item/plugins/html/h5p/h5p.controller.test.ts
@@ -8,7 +8,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate } from '../../../../../../test/app';
 import { seedFromJson } from '../../../../../../test/mocks/seed';
@@ -77,7 +77,7 @@ describe('Service plugin', () => {
         actor,
         items: [parent],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -94,7 +94,7 @@ describe('Service plugin', () => {
         actor,
         items: [parent],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -113,7 +113,7 @@ describe('Service plugin', () => {
         actor,
         items: [parent],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -134,7 +134,7 @@ describe('Service plugin', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -172,10 +172,10 @@ describe('Service plugin', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -264,7 +264,7 @@ describe('Service plugin', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -286,7 +286,7 @@ describe('Service plugin', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -313,7 +313,7 @@ describe('Service plugin', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -380,7 +380,7 @@ describe('Service plugin', () => {
         items: [
           {
             children: [{ order: 30 }],
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });

--- a/src/services/item/plugins/html/h5p/h5p.controller.ts
+++ b/src/services/item/plugins/html/h5p/h5p.controller.ts
@@ -5,7 +5,7 @@ import { fastifyMultipart } from '@fastify/multipart';
 import { fastifyStatic } from '@fastify/static';
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../../di/utils';
 import { type DBConnection, db } from '../../../../../drizzle/db';
@@ -108,7 +108,7 @@ const plugin: FastifyPluginAsyncTypebox<H5PPluginOptions> = async (fastify) => {
         // validate write permission in parent if it exists
         if (parentId) {
           await authorizedItemService.assertAccessForItemId(tx, {
-            permission: PermissionLevel.Write,
+            permission: 'write',
             accountId: member.id,
             itemId: parentId,
           });

--- a/src/services/item/plugins/importExport/importExport.controller.test.ts
+++ b/src/services/item/plugins/importExport/importExport.controller.test.ts
@@ -15,7 +15,6 @@ import {
   HttpMethod,
   ItemType,
   MimeTypes,
-  PermissionLevel,
   ThumbnailSize,
 } from '@graasp/sdk';
 
@@ -548,7 +547,7 @@ describe('ZIP routes tests', () => {
             name: 'item-name',
             type: ItemType.DOCUMENT,
             extra: { document: { content: 'my text', isRaw: false } },
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -657,7 +656,7 @@ describe('ZIP routes tests', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);

--- a/src/services/item/plugins/invitation/invitation.schema.ts
+++ b/src/services/item/plugins/invitation/invitation.schema.ts
@@ -3,10 +3,9 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifySchema } from 'fastify';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { customType, registerSchemaAsRef } from '../../../../plugins/typebox';
 import { errorSchemaRef } from '../../../../schemas/global';
+import { permissionLevelSchemaRef } from '../../../../types';
 import { itemMembershipWithoutRelationsSchemaRef } from '../../../itemMembership/membership.schemas';
 import { itemSchemaRef } from '../../item.schemas';
 
@@ -18,7 +17,7 @@ export const invitationSchemaRef = registerSchemaAsRef(
       id: customType.UUID(),
       email: Type.String({ format: 'email' }),
       name: Type.Optional(customType.Nullable(Type.String())),
-      permission: customType.EnumString(Object.values(PermissionLevel)),
+      permission: permissionLevelSchemaRef,
       item: itemSchemaRef,
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
@@ -37,7 +36,7 @@ export const invitationWithoutRelationSchemaRef = registerSchemaAsRef(
       id: customType.UUID(),
       email: Type.String({ format: 'email' }),
       name: Type.Optional(customType.Nullable(Type.String())),
-      permission: customType.EnumString(Object.values(PermissionLevel)),
+      permission: permissionLevelSchemaRef,
       itemPath: Type.String(),
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
@@ -62,7 +61,7 @@ export const invite = {
     invitations: Type.Array(
       Type.Object({
         email: Type.String({ format: 'email' }),
-        permission: Type.Enum(PermissionLevel),
+        permission: permissionLevelSchemaRef,
       }),
     ),
   }),
@@ -154,7 +153,7 @@ export const updateOne = {
   body: customType.StrictObject(
     {
       name: Type.Optional(Type.String()),
-      permission: Type.Optional(Type.Enum(PermissionLevel)),
+      permission: Type.Optional(permissionLevelSchemaRef),
     },
     { minProperties: 1 },
   ),

--- a/src/services/item/plugins/invitation/invitation.service.ts
+++ b/src/services/item/plugins/invitation/invitation.service.ts
@@ -3,7 +3,7 @@ import { singleton } from 'tsyringe';
 
 import type { MultipartFile } from '@fastify/multipart';
 
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import type {
@@ -119,7 +119,7 @@ export class InvitationService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: authenticatedUser.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
     return this.invitationRepository.getManyByItem(dbConnection, item.path);
   }
@@ -133,7 +133,7 @@ export class InvitationService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     await this.invitationRepository.addMany(dbConnection, invitations, item.path, member);
@@ -163,7 +163,7 @@ export class InvitationService {
       throw new InvitationNotFound({ invitationId });
     }
     await this.authorizedItemService.assertAccess(dbConnection, {
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
       accountId: authenticatedUser.id,
       item: invitation.item,
     });
@@ -181,7 +181,7 @@ export class InvitationService {
       throw new Error('missing invitation');
     }
     await this.authorizedItemService.assertAccess(dbConnection, {
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
       accountId: authenticatedUser.id,
       item: invitation.item,
     });
@@ -197,7 +197,7 @@ export class InvitationService {
     }
 
     await this.authorizedItemService.assertAccess(dbConnection, {
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
       accountId: member.id,
       item: invitation.item,
     });
@@ -246,7 +246,7 @@ export class InvitationService {
     const membershipsToCreate = existingAccounts.map((account) => {
       const permission =
         // get the permission from the data, if it is not found or if it is an empty string, default to read
-        rows.find((r) => r.email === account.email)?.permission ?? PermissionLevel.Read;
+        rows.find((r) => r.email === account.email)?.permission ?? 'read';
       return { permission, accountId: account.id };
     });
     this.log.debug(`${JSON.stringify(membershipsToCreate)} memberships to create`);
@@ -265,7 +265,7 @@ export class InvitationService {
     // generate invitations to create
     const invitationsToCreate = newAccounts.map((email) => {
       // get the permission from the data, if it is not found or if it is an empty string, default to read
-      const permission = rows.find((r) => r.email === email)?.permission ?? PermissionLevel.Read;
+      const permission = rows.find((r) => r.email === email)?.permission ?? 'read';
       return { email, permission };
     });
     this.log.debug(`${JSON.stringify(invitationsToCreate)} invitations to create`);
@@ -297,7 +297,7 @@ export class InvitationService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: authenticatedUser.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     return this._createMembershipsAndInvitationsForUserList(
@@ -321,7 +321,7 @@ export class InvitationService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     // parse CSV file
@@ -365,7 +365,7 @@ export class InvitationService {
     const parentItem = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId: parentId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     // check that the template exists

--- a/src/services/item/plugins/invitation/utils/utils.ts
+++ b/src/services/item/plugins/invitation/utils/utils.ts
@@ -3,15 +3,14 @@ import { parse } from 'papaparse';
 
 import type { MultipartFile } from '@fastify/multipart';
 
-import type { PermissionLevelOptions } from '@graasp/sdk';
-
+import type { PermissionLevel } from '../../../../../types';
 import { CSV_MIMETYPE, EMAIL_COLUMN_NAME } from './constants';
 
 export type CSVInvite = {
   email: string;
   name?: string;
   group_name?: string;
-  permission?: PermissionLevelOptions;
+  permission?: PermissionLevel;
 };
 
 export const parseCSV = (stream: Readable): Promise<{ rows: CSVInvite[]; header: string[] }> => {

--- a/src/services/item/plugins/itemBookmark/itemBookmark.service.ts
+++ b/src/services/item/plugins/itemBookmark/itemBookmark.service.ts
@@ -1,7 +1,5 @@
 import { singleton } from 'tsyringe';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { type DBConnection } from '../../../../drizzle/db';
 import type { ItemBookmarkRaw } from '../../../../drizzle/types';
 import type { MinimalMember } from '../../../../types';
@@ -67,7 +65,7 @@ export class BookmarkService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Read,
+      permission: 'read',
     });
     await this.itemBookmarkRepository.post(dbConnection, item.id, member.id);
   }

--- a/src/services/item/plugins/itemFlag/itemFlag.controller.test.ts
+++ b/src/services/item/plugins/itemFlag/itemFlag.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { FlagType, HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { FlagType, HttpMethod } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -85,7 +85,7 @@ describe('Item Flag Tests', () => {
           actor,
           items: [item],
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);

--- a/src/services/item/plugins/itemLike/itemLike.controller.test.ts
+++ b/src/services/item/plugins/itemLike/itemLike.controller.test.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -199,11 +199,11 @@ describe('Item Like', () => {
           items: [
             {
               likes: ['actor'],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
             {
               likes: ['actor'],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -305,7 +305,7 @@ describe('Item Like', () => {
           items: [
             {
               likes: [{ name: 'bob' }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -334,7 +334,7 @@ describe('Item Like', () => {
           items: [
             {
               likes: ['actor'],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -417,7 +417,7 @@ describe('Item Like', () => {
           items: [
             {
               likes: ['actor'],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -467,7 +467,7 @@ describe('Item Like', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });

--- a/src/services/item/plugins/itemVisibility/itemVisibility.service.ts
+++ b/src/services/item/plugins/itemVisibility/itemVisibility.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { type ItemVisibilityOptionsType, PermissionLevel } from '@graasp/sdk';
+import { type ItemVisibilityOptionsType } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import { type ItemRaw } from '../../../../drizzle/types';
@@ -30,7 +30,7 @@ export class ItemVisibilityService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
     await this.itemVisibilityRepository.post(dbConnection, member.id, item.path, visibilityType);
   }
@@ -44,7 +44,7 @@ export class ItemVisibilityService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     await this.itemVisibilityRepository.deleteOne(dbConnection, item, visibilityType);

--- a/src/services/item/plugins/page/page.controller.test.ts
+++ b/src/services/item/plugins/page/page.controller.test.ts
@@ -18,7 +18,7 @@ import { Doc, encodeStateAsUpdate } from 'yjs';
 
 import type { FastifyInstance } from 'fastify';
 
-import { FolderItemFactory, HttpMethod, ItemType, PermissionLevel } from '@graasp/sdk';
+import { FolderItemFactory, HttpMethod, ItemType } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -152,7 +152,7 @@ describe('Page routes tests', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'write' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -176,7 +176,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -202,7 +202,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -234,7 +234,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -283,7 +283,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -317,7 +317,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -361,7 +361,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -398,7 +398,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -480,7 +480,7 @@ describe('Page routes tests', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'write' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -504,7 +504,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -610,7 +610,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -646,8 +646,8 @@ describe('Page routes tests', () => {
           {
             type: ItemType.PAGE,
             memberships: [
-              { account: 'actor', permission: PermissionLevel.Write },
-              { account: { name: 'reader' }, permission: PermissionLevel.Read },
+              { account: 'actor', permission: 'write' },
+              { account: { name: 'reader' }, permission: 'read' },
             ],
           },
         ],
@@ -700,7 +700,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -750,7 +750,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -786,7 +786,7 @@ describe('Page routes tests', () => {
         items: [
           {
             type: ItemType.PAGE,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -855,7 +855,7 @@ describe('Page routes tests', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
             children: [
               {
                 name,

--- a/src/services/item/plugins/page/page.controller.ts
+++ b/src/services/item/plugins/page/page.controller.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { ItemType, PermissionLevel } from '@graasp/sdk';
+import { ItemType } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
@@ -97,7 +97,7 @@ export const pageItemPlugin: FastifyPluginAsyncTypebox = async (fastify) => {
           const account = asDefined(user?.account);
           // check write permission
           const item = await authorizedItemService.getItemById(db, {
-            permission: PermissionLevel.Write,
+            permission: 'write',
             itemId: params.id,
             accountId: account.id,
           });

--- a/src/services/item/plugins/publication/publicationState/publication.controller.test.ts
+++ b/src/services/item/plugins/publication/publicationState/publication.controller.test.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate } from '../../../../../../test/app';
 import { seedFromJson } from '../../../../../../test/mocks/seed';
@@ -61,7 +61,7 @@ describe('Publication Controller', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);

--- a/src/services/item/plugins/publication/publicationState/publication.service.ts
+++ b/src/services/item/plugins/publication/publicationState/publication.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { ItemVisibilityType, PermissionLevel } from '@graasp/sdk';
+import { ItemVisibilityType } from '@graasp/sdk';
 
 import type { DBConnection } from '../../../../../drizzle/db';
 import type { AuthenticatedUser } from '../../../../../types';
@@ -47,7 +47,7 @@ export class PublicationService {
     await this.authorizedItemService.assertAccess(dbConnection, {
       accountId: member.id,
       item,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
     const publicVisibility = await this.itemVisibilityRepository.getType(
       dbConnection,

--- a/src/services/item/plugins/publication/published/itemPublished.controller.test.ts
+++ b/src/services/item/plugins/publication/published/itemPublished.controller.test.ts
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, ItemValidationStatus, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, ItemType, ItemValidationStatus } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -158,19 +158,19 @@ describe('Item Published', () => {
               isPublic: true,
               isPublished: true,
               creator: { name: 'bob' },
-              memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+              memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             },
             {
               isPublic: true,
               isPublished: true,
               creator: { name: 'bob' },
-              memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+              memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             },
             {
               isPublic: true,
               isPublished: true,
               creator: { name: 'bob' },
-              memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+              memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             },
           ],
         });
@@ -183,10 +183,7 @@ describe('Item Published', () => {
         expectManyPackedItems(
           res.json(),
           items.map((i) =>
-            new ItemWrapper(
-              { ...i, creator: member },
-              { permission: PermissionLevel.Admin },
-            ).packed(),
+            new ItemWrapper({ ...i, creator: member }, { permission: 'admin' }).packed(),
           ),
           undefined,
           undefined,
@@ -208,19 +205,19 @@ describe('Item Published', () => {
               isPublished: true,
               isPublic: true,
               creator: { name: 'bob' },
-              memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+              memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             },
             {
               isPublished: true,
               isPublic: true,
               creator: { name: 'bob' },
-              memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+              memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             },
             {
               isPublished: true,
               isPublic: true,
               creator: { name: 'bob' },
-              memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+              memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             },
           ],
         });
@@ -235,10 +232,7 @@ describe('Item Published', () => {
         expectManyPackedItems(
           res.json(),
           items.map((i) =>
-            new ItemWrapper(
-              { ...i, creator: member },
-              { permission: PermissionLevel.Admin },
-            ).packed(),
+            new ItemWrapper({ ...i, creator: member }, { permission: 'admin' }).packed(),
           ),
           member,
           undefined,
@@ -276,7 +270,7 @@ describe('Item Published', () => {
             {
               isPublic: true,
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Success }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -316,9 +310,9 @@ describe('Item Published', () => {
               isPublic: true,
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Success }],
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Admin },
-                { account: { name: 'anna' }, permission: PermissionLevel.Admin },
-                { account: { name: 'cedric' }, permission: PermissionLevel.Admin },
+                { account: 'actor', permission: 'admin' },
+                { account: { name: 'anna' }, permission: 'admin' },
+                { account: { name: 'cedric' }, permission: 'admin' },
               ],
             },
           ],
@@ -361,7 +355,7 @@ describe('Item Published', () => {
           items: [
             {
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Success }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -384,7 +378,7 @@ describe('Item Published', () => {
           items: [
             {
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Success }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });
@@ -406,7 +400,7 @@ describe('Item Published', () => {
           items: [
             {
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Success }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });
@@ -429,7 +423,7 @@ describe('Item Published', () => {
             {
               type: ItemType.DOCUMENT,
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Success }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -450,7 +444,7 @@ describe('Item Published', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -515,7 +509,7 @@ describe('Item Published', () => {
               isPublic: true,
               isPublished: true,
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -546,7 +540,7 @@ describe('Item Published', () => {
             {
               isPublic: true,
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -569,7 +563,7 @@ describe('Item Published', () => {
               isPublic: true,
               isPublished: true,
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
             },
           ],
         });
@@ -592,7 +586,7 @@ describe('Item Published', () => {
               isPublic: true,
               isPublished: true,
               creator: 'actor',
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });

--- a/src/services/item/plugins/publication/published/itemPublished.controller.ts
+++ b/src/services/item/plugins/publication/published/itemPublished.controller.ts
@@ -2,8 +2,6 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { resolveDependency } from '../../../../../di/utils';
 import { db } from '../../../../../drizzle/db';
 import { asDefined } from '../../../../../utils/assertions';
@@ -67,7 +65,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         const item = await authorizedItemService.getItemById(tx, {
           accountId: member.id,
           itemId: params.itemId,
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
         });
 
         const status = await publicationService.computeStateForItem(tx, member, item.id);

--- a/src/services/item/plugins/publication/published/itemPublished.service.ts
+++ b/src/services/item/plugins/publication/published/itemPublished.service.ts
@@ -4,7 +4,6 @@ import {
   ClientManager,
   Context,
   ItemVisibilityType,
-  PermissionLevel,
   PublicationStatus,
   type UUID,
 } from '@graasp/sdk';
@@ -90,10 +89,7 @@ export class ItemPublishedService {
     // send email to contributors except yourself
     const memberships = await this.itemMembershipRepository.getForItem(dbConnection, item);
     const contributors = memberships
-      .filter(
-        ({ permission, account }) =>
-          permission === PermissionLevel.Admin && account.id !== actor.id,
-      )
+      .filter(({ permission, account }) => permission === 'admin' && account.id !== actor.id)
       .map(({ account }) => account);
 
     const link = ClientManager.getInstance().getItemLink(Context.Library, item.id);
@@ -163,7 +159,7 @@ export class ItemPublishedService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     const itemPublished = await this.itemPublishedRepository.getForItem(dbConnection, item.path);
@@ -245,7 +241,7 @@ export class ItemPublishedService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     await this.hooks.runPreHooks('delete', member, dbConnection, { item });

--- a/src/services/item/plugins/publication/published/plugins/search/search.controller.test.ts
+++ b/src/services/item/plugins/publication/published/plugins/search/search.controller.test.ts
@@ -6,7 +6,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel, TagCategory } from '@graasp/sdk';
+import { HttpMethod, ItemType, TagCategory } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -235,7 +235,7 @@ describe('Collection Search endpoints', () => {
             {
               isPublic: true,
               isPublished: true,
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               type: ItemType.DOCUMENT,
               extra: {
                 [ItemType.DOCUMENT]: {
@@ -278,10 +278,10 @@ describe('Collection Search endpoints', () => {
               {
                 isPublic: true,
                 isPublished: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -318,12 +318,12 @@ describe('Collection Search endpoints', () => {
               {
                 isPublic: true,
                 isPublished: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isPublic: true,
                 isPublished: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -354,12 +354,12 @@ describe('Collection Search endpoints', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isPublic: true,
                 isPublished: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -389,13 +389,13 @@ describe('Collection Search endpoints', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
                 isPublic: true,
                 isPublished: true,
                 children: [{}],
               },
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });

--- a/src/services/item/plugins/publication/validation/itemValidation.controller.test.ts
+++ b/src/services/item/plugins/publication/validation/itemValidation.controller.test.ts
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemValidationStatus, PermissionLevel, PublicationStatus } from '@graasp/sdk';
+import { HttpMethod, ItemValidationStatus, PublicationStatus } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -82,7 +82,7 @@ describe('Item Validation Tests', () => {
           items: [
             {
               itemValidations: [{ groupName: 'group', status: ItemValidationStatus.Pending }],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -102,7 +102,7 @@ describe('Item Validation Tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'read' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -119,7 +119,7 @@ describe('Item Validation Tests', () => {
           items: [item],
           actor,
         } = await seedFromJson({
-          items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+          items: [{ memberships: [{ account: 'actor', permission: 'write' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -180,7 +180,7 @@ describe('Item Validation Tests', () => {
   //         items: [
   //           {
   //             itemValidations: [{ groupName: 'name', status: ItemValidationStatus.Failure }],
-  //             memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+  //             memberships: [{ account: 'actor', permission: "admin" }],
   //           },
   //         ],
   //       });
@@ -201,7 +201,7 @@ describe('Item Validation Tests', () => {
   //         actor,
   //         itemValidationGroups: [itemValidationGroup],
   //       } = await seedFromJson({
-  //         items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Read }] }],
+  //         items: [{ memberships: [{ account: 'actor', permission: "read" }] }],
   //       });
   //       assertIsDefined(actor);
   //       mockAuthenticate(actor);
@@ -220,7 +220,7 @@ describe('Item Validation Tests', () => {
   //         actor,
   //         itemValidationGroups: [itemValidationGroup],
   //       } = await seedFromJson({
-  //         items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+  //         items: [{ memberships: [{ account: 'actor', permission: "write" }] }],
   //       });
   //       assertIsDefined(actor);
   //       mockAuthenticate(actor);
@@ -304,7 +304,7 @@ describe('Item Validation Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemValidations: [{ groupName: 'name', status: ItemValidationStatus.Success }],
             },
           ],
@@ -344,7 +344,7 @@ describe('Item Validation Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               children: [{}],
             },
           ],
@@ -389,7 +389,7 @@ describe('Item Validation Tests', () => {
           actor,
           items: [item],
         } = await seedFromJson({
-          items: [{ memberships: [{ permission: PermissionLevel.Read, account: 'actor' }] }],
+          items: [{ memberships: [{ permission: 'read', account: 'actor' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);
@@ -419,7 +419,7 @@ describe('Item Validation Tests', () => {
           actor,
           items: [item],
         } = await seedFromJson({
-          items: [{ memberships: [{ permission: PermissionLevel.Write, account: 'actor' }] }],
+          items: [{ memberships: [{ permission: 'write', account: 'actor' }] }],
         });
         assertIsDefined(actor);
         mockAuthenticate(actor);

--- a/src/services/item/plugins/publication/validation/itemValidation.controller.ts
+++ b/src/services/item/plugins/publication/validation/itemValidation.controller.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { PermissionLevel, PublicationStatus } from '@graasp/sdk';
+import { PublicationStatus } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../../di/utils';
 import { db } from '../../../../../drizzle/db';
@@ -43,7 +43,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       const item = await authorizedItemService.getItemById(db, {
         accountId: member.id,
         itemId,
-        permission: PermissionLevel.Admin,
+        permission: 'admin',
       });
       return await validationService.getLastItemValidationGroupForItem(db, member, item);
     },
@@ -72,7 +72,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         .transaction(async (tx) => {
           // get item and check permission
           // only folder items are allowed as root for validation
-          const item = await folderItemService.getFolder(tx, member, itemId, PermissionLevel.Admin);
+          const item = await folderItemService.getFolder(tx, member, itemId, 'admin');
 
           const notifyOnValidationChanges = () => {
             websockets.publish(

--- a/src/services/item/plugins/publication/validation/itemValidation.service.ts
+++ b/src/services/item/plugins/publication/validation/itemValidation.service.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from 'fs';
 import path from 'path';
 import { singleton } from 'tsyringe';
 
-import { ItemValidationStatus, PermissionLevel, type UUID } from '@graasp/sdk';
+import { ItemValidationStatus, type UUID } from '@graasp/sdk';
 
 import type { DBConnection } from '../../../../../drizzle/db';
 import { type ItemRaw } from '../../../../../drizzle/types';
@@ -60,7 +60,7 @@ export class ItemValidationService {
 
     // check permissions
     await this.authorizedItemService.assertAccess(dbConnection, {
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
       accountId: member.id,
       item,
     });

--- a/src/services/item/plugins/publication/validation/test/ws.test.ts
+++ b/src/services/item/plugins/publication/validation/test/ws.test.ts
@@ -3,11 +3,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import {
-  HttpMethod,
-  type ItemOpFeedbackEvent as ItemOpFeedbackEventType,
-  PermissionLevel,
-} from '@graasp/sdk';
+import { HttpMethod, type ItemOpFeedbackEvent as ItemOpFeedbackEventType } from '@graasp/sdk';
 
 import { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../../../../../test/app';
 import { seedFromJson } from '../../../../../../../test/mocks/seed';
@@ -50,7 +46,7 @@ describe('asynchronous feedback', () => {
       items: [item],
       actor,
     } = await seedFromJson({
-      items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+      items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
     });
     assertIsDefined(actor);
     mockAuthenticate(actor);
@@ -82,7 +78,7 @@ describe('asynchronous feedback', () => {
       items: [item],
       actor,
     } = await seedFromJson({
-      items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+      items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
     });
     assertIsDefined(actor);
     mockAuthenticate(actor);

--- a/src/services/item/plugins/recycled/recycled.controller.test.ts
+++ b/src/services/item/plugins/recycled/recycled.controller.test.ts
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, MAX_TARGETS_FOR_MODIFY_REQUEST, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, MAX_TARGETS_FOR_MODIFY_REQUEST } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -60,12 +60,12 @@ describe('Recycle Bin Tests', () => {
               {
                 isDeleted: true,
                 creator: 'actor',
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
                 creator: 'actor',
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               // noise
               { isDeleted: true },
@@ -101,27 +101,27 @@ describe('Recycle Bin Tests', () => {
             items: [
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               // noise
               { isDeleted: true },
@@ -154,10 +154,10 @@ describe('Recycle Bin Tests', () => {
             items: [
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
                 children: [
                   {
                     isDeleted: true,
@@ -194,10 +194,10 @@ describe('Recycle Bin Tests', () => {
             items: [
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+                memberships: [{ account: 'actor', permission: 'read' }],
                 children: [
                   {
-                    memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                    memberships: [{ account: 'actor', permission: 'admin' }],
                   },
                 ],
               },
@@ -251,13 +251,13 @@ describe('Recycle Bin Tests', () => {
           const { actor, items } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -299,10 +299,10 @@ describe('Recycle Bin Tests', () => {
             items: [
               {},
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -343,7 +343,7 @@ describe('Recycle Bin Tests', () => {
         it('Bad request if recycle more than maxItemsInRequest items', async () => {
           const { actor, items } = await seedFromJson({
             items: Array.from({ length: MAX_TARGETS_FOR_MODIFY_REQUEST + 1 }, () => ({
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             })),
           });
           assertIsDefined(actor);
@@ -389,11 +389,11 @@ describe('Recycle Bin Tests', () => {
             items: [
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -465,11 +465,11 @@ describe('Recycle Bin Tests', () => {
             items: [
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -502,7 +502,7 @@ describe('Recycle Bin Tests', () => {
               },
               {
                 isDeleted: true,
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -541,7 +541,7 @@ describe('Recycle Bin Tests', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             children: [{}],
           },
         ],

--- a/src/services/item/plugins/recycled/recycled.repository.spec.ts
+++ b/src/services/item/plugins/recycled/recycled.repository.spec.ts
@@ -2,8 +2,6 @@ import { subMonths } from 'date-fns';
 import { eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { seedFromJson } from '../../../../../test/mocks/seed';
 import { db } from '../../../../drizzle/db';
 import { recycledItemDatasTable } from '../../../../drizzle/schema';
@@ -18,7 +16,7 @@ describe('RecycledItemDataRepository', () => {
   describe('assertAdminAccessForItemIds', () => {
     it('resolve for item with admin permission', async () => {
       const { items, actor } = await seedFromJson({
-        items: [{ memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }] }],
+        items: [{ memberships: [{ permission: 'admin', account: 'actor' }] }],
       });
       assertIsDefined(actor);
 
@@ -39,7 +37,7 @@ describe('RecycledItemDataRepository', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+            memberships: [{ permission: 'admin', account: 'actor' }],
             children: [{}],
           },
         ],
@@ -53,7 +51,7 @@ describe('RecycledItemDataRepository', () => {
 
     it('reject for item with write permission', async () => {
       const { items, actor } = await seedFromJson({
-        items: [{ memberships: [{ permission: PermissionLevel.Write, account: 'actor' }] }],
+        items: [{ memberships: [{ permission: 'write', account: 'actor' }] }],
       });
       assertIsDefined(actor);
 
@@ -70,8 +68,8 @@ describe('RecycledItemDataRepository', () => {
     it('reject for one item with write permission', async () => {
       const { items, actor } = await seedFromJson({
         items: [
-          { memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }] },
-          { memberships: [{ permission: PermissionLevel.Write, account: 'actor' }] },
+          { memberships: [{ permission: 'admin', account: 'actor' }] },
+          { memberships: [{ permission: 'write', account: 'actor' }] },
         ],
       });
       assertIsDefined(actor);
@@ -95,7 +93,7 @@ describe('RecycledItemDataRepository', () => {
         items: [
           // should return top parent, but not the child
           {
-            memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+            memberships: [{ permission: 'admin', account: 'actor' }],
             children: [{}],
             isDeleted: true,
           },
@@ -119,7 +117,7 @@ describe('RecycledItemDataRepository', () => {
           {
             children: [
               {
-                memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+                memberships: [{ permission: 'admin', account: 'actor' }],
               },
             ],
             isDeleted: true,
@@ -143,7 +141,7 @@ describe('RecycledItemDataRepository', () => {
         items: [
           // should return the deleted child, permission on the parent
           {
-            memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+            memberships: [{ permission: 'admin', account: 'actor' }],
             children: [
               {
                 isDeleted: true,
@@ -169,7 +167,7 @@ describe('RecycledItemDataRepository', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ permission: PermissionLevel.Read, account: 'actor' }],
+            memberships: [{ permission: 'read', account: 'actor' }],
             isDeleted: true,
           },
         ],
@@ -189,7 +187,7 @@ describe('RecycledItemDataRepository', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+            memberships: [{ permission: 'admin', account: 'actor' }],
           },
         ],
       });
@@ -209,11 +207,11 @@ describe('RecycledItemDataRepository', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+            memberships: [{ permission: 'admin', account: 'actor' }],
             isDeleted: true,
           },
           {
-            memberships: [{ permission: PermissionLevel.Admin, account: 'actor' }],
+            memberships: [{ permission: 'admin', account: 'actor' }],
             isDeleted: true,
           },
         ],

--- a/src/services/item/plugins/recycled/recycled.repository.ts
+++ b/src/services/item/plugins/recycled/recycled.repository.ts
@@ -3,7 +3,7 @@ import { eq, getTableColumns, inArray } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { and, asc, desc, gte, isNotNull, ne } from 'drizzle-orm/sql';
 
-import { type Paginated, type Pagination, PermissionLevel } from '@graasp/sdk';
+import { type Paginated, type Pagination } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import { isAncestorOrSelf, isDescendantOrSelf } from '../../../../drizzle/operations';
@@ -61,7 +61,7 @@ export class RecycledItemDataRepository {
       .where(
         and(
           eq(itemMembershipsTable.accountId, account.id),
-          eq(itemMembershipsTable.permission, PermissionLevel.Admin),
+          eq(itemMembershipsTable.permission, 'admin'),
         ),
       )
       .as('ownMemberships');
@@ -177,7 +177,7 @@ export class RecycledItemDataRepository {
         itemMembershipsTable,
         and(
           eq(itemMembershipsTable.accountId, memberId),
-          eq(itemMembershipsTable.permission, PermissionLevel.Admin),
+          eq(itemMembershipsTable.permission, 'admin'),
           inArray(itemsRawTable.id, ids),
           isAncestorOrSelf(itemMembershipsTable.itemPath, itemsRawTable.path),
         ),

--- a/src/services/item/plugins/recycled/recycled.service.ts
+++ b/src/services/item/plugins/recycled/recycled.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { ItemType, type Paginated, type Pagination, PermissionLevel } from '@graasp/sdk';
+import { ItemType, type Paginated, type Pagination } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import { type ItemRaw } from '../../../../drizzle/types';
@@ -66,7 +66,7 @@ export class RecycledBinService {
     // if item is already deleted, it will throw not found here
     for (const item of items) {
       await this.authorizedItemService.assertAccess(dbConnection, {
-        permission: PermissionLevel.Admin,
+        permission: 'admin',
         accountId: member.id,
         item,
       });
@@ -117,7 +117,7 @@ export class RecycledBinService {
 
     for (const item of items) {
       await this.authorizedItemService.assertAccess(dbConnection, {
-        permission: PermissionLevel.Admin,
+        permission: 'admin',
 
         accountId: member.id,
         item,

--- a/src/services/item/plugins/recycled/recycled.ws.test.ts
+++ b/src/services/item/plugins/recycled/recycled.ws.test.ts
@@ -4,7 +4,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../../../test/app';
 import { seedFromJson } from '../../../../../test/mocks/seed';
@@ -47,7 +47,7 @@ describe('Recycle websocket hooks', () => {
         items: [item],
         actor,
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -87,7 +87,7 @@ describe('Recycle websocket hooks', () => {
         items: [item],
         actor,
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -124,7 +124,7 @@ describe('Recycle websocket hooks', () => {
         items: [
           {
             isDeleted: true,
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });

--- a/src/services/item/plugins/shortLink/shortlink.controller.test.ts
+++ b/src/services/item/plugins/shortLink/shortlink.controller.test.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { Context, PermissionLevel, ShortLinkPlatform } from '@graasp/sdk';
+import { Context, ShortLinkPlatform } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -142,7 +142,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 creator: { name: 'bob' },
-                memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+                memberships: [{ account: 'actor', permission: 'write' }],
               },
             ],
           });
@@ -246,7 +246,7 @@ describe('Short links routes tests', () => {
           } = await seedFromJson({
             items: [
               { shortLinks: [{}] },
-              { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+              { memberships: [{ account: 'actor', permission: 'admin' }] },
             ],
           });
           assertIsDefined(actor);
@@ -269,7 +269,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -292,7 +292,7 @@ describe('Short links routes tests', () => {
             items: [item],
             actor,
           } = await seedFromJson({
-            items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+            items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
           });
           assertIsDefined(actor);
           mockAuthenticate(actor);
@@ -312,7 +312,7 @@ describe('Short links routes tests', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
                 isPublic: true,
                 isPublished: true,
               },
@@ -357,7 +357,7 @@ describe('Short links routes tests', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -410,7 +410,7 @@ describe('Short links routes tests', () => {
           items: [
             {
               shortLinks: [{}],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -442,7 +442,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+                memberships: [{ account: 'actor', permission: 'write' }],
               },
             ],
           });
@@ -462,7 +462,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -485,7 +485,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
               {
                 shortLinks: [{}],
@@ -508,7 +508,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -526,7 +526,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -544,7 +544,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -564,7 +564,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -582,7 +582,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -602,7 +602,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -622,7 +622,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -656,7 +656,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+                memberships: [{ account: 'actor', permission: 'read' }],
               },
             ],
           });
@@ -676,7 +676,7 @@ describe('Short links routes tests', () => {
             items: [
               {
                 shortLinks: [{}],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });
@@ -707,7 +707,7 @@ describe('Short links routes tests', () => {
           items: [
             {
               shortLinks: [{}],
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -756,7 +756,7 @@ describe('Short links routes tests', () => {
           } = await seedFromJson({
             items: [
               {
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
                 shortLinks: [{}],
               },
             ],
@@ -785,7 +785,7 @@ describe('Short links routes tests', () => {
                   { platform: ShortLinkPlatform.Builder },
                   { platform: ShortLinkPlatform.Player },
                 ],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+                memberships: [{ account: 'actor', permission: 'read' }],
               },
             ],
           });
@@ -808,7 +808,7 @@ describe('Short links routes tests', () => {
                   { platform: ShortLinkPlatform.Builder },
                   { platform: ShortLinkPlatform.Player },
                 ],
-                memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+                memberships: [{ account: 'actor', permission: 'admin' }],
               },
             ],
           });

--- a/src/services/item/plugins/shortLink/shortlink.service.ts
+++ b/src/services/item/plugins/shortLink/shortlink.service.ts
@@ -3,7 +3,6 @@ import { singleton } from 'tsyringe';
 import {
   ClientManager,
   Context,
-  PermissionLevel,
   type ShortLink,
   ShortLinkPlatform,
   type ShortLinksOfItem,
@@ -75,7 +74,7 @@ export class ShortLinkService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId: shortLink.itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
     const createdShortLink = await this.shortLinkRepository.addOne(dbConnection, shortLink);
 
@@ -93,7 +92,7 @@ export class ShortLinkService {
     await this.authorizedItemService.getItemById(dbConnection, {
       accountId: account.id,
       itemId,
-      permission: PermissionLevel.Read,
+      permission: 'read',
     });
 
     const res = await this.shortLinkRepository.getByItem(dbConnection, itemId);
@@ -130,7 +129,7 @@ export class ShortLinkService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId: shortLink.item.id,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     await this.shortLinkRepository.deleteOne(dbConnection, alias);
@@ -152,7 +151,7 @@ export class ShortLinkService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId: shortLink.item.id,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     const res = await this.shortLinkRepository.updateOne(dbConnection, alias, updatedShortLink);

--- a/src/services/item/plugins/shortcut/shortcut.controller.test.ts
+++ b/src/services/item/plugins/shortcut/shortcut.controller.test.ts
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, ItemType, PermissionLevel, ShortcutItemFactory } from '@graasp/sdk';
+import { HttpMethod, ItemType, ShortcutItemFactory } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -103,7 +103,7 @@ describe('Shortcut routes tests', () => {
         const membership = await db.query.itemMembershipsTable.findFirst({
           where: eq(itemMembershipsTable.itemPath, newItem.path),
         });
-        expect(membership?.permission).toEqual(PermissionLevel.Admin);
+        expect(membership?.permission).toEqual('admin');
       });
 
       it('Create without name', async () => {
@@ -331,7 +331,7 @@ describe('Shortcut routes tests', () => {
                 [ItemType.SHORTCUT]: { target: v4() },
               },
               settings: { isCollapsible: false },
-              memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+              memberships: [{ account: 'actor', permission: 'read' }],
             },
           ],
         });

--- a/src/services/item/plugins/tag/itemTag.controller.test.ts
+++ b/src/services/item/plugins/tag/itemTag.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel, TagCategory } from '@graasp/sdk';
+import { HttpMethod, TagCategory } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -314,7 +314,7 @@ describe('Item Tag Endpoints', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               tags: [{ name: faker.word.sample(), category: TagCategory.Discipline }],
             },
           ],

--- a/src/services/item/plugins/tag/itemTag.service.ts
+++ b/src/services/item/plugins/tag/itemTag.service.ts
@@ -1,6 +1,6 @@
 import { singleton } from 'tsyringe';
 
-import { PermissionLevel, type TagCategoryType, type UUID } from '@graasp/sdk';
+import { type TagCategoryType, type UUID } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import type { AuthenticatedUser, MaybeUser } from '../../../../types';
@@ -42,7 +42,7 @@ export class ItemTagService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: authenticatedUser.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     // create tag if does not exist
@@ -78,7 +78,7 @@ export class ItemTagService {
     const item = await this.authorizedItemService.getItemById(dbConnection, {
       accountId: authenticatedUser.id,
       itemId,
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
     });
 
     // update index if item is published

--- a/src/services/item/plugins/thumbnail/itemThumbnail.service.ts
+++ b/src/services/item/plugins/thumbnail/itemThumbnail.service.ts
@@ -3,7 +3,7 @@ import { fromPath as convertPDFtoImageFromPath } from 'pdf2pic';
 import { Readable } from 'stream';
 import { delay, inject, injectable } from 'tsyringe';
 
-import { MimeTypes, PermissionLevel, ThumbnailSize } from '@graasp/sdk';
+import { MimeTypes, ThumbnailSize } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import { type ItemRaw } from '../../../../drizzle/types';
@@ -40,7 +40,7 @@ export class ItemThumbnailService {
 
   async upload(dbConnection: DBConnection, member: MinimalMember, itemId: string, file: Readable) {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
-      permission: PermissionLevel.Write,
+      permission: 'write',
       accountId: member.id,
       itemId,
     });
@@ -162,7 +162,7 @@ export class ItemThumbnailService {
     await this.authorizedItemService.assertAccessForItemId(dbConnection, {
       accountId: member.id,
       itemId,
-      permission: PermissionLevel.Write,
+      permission: 'write',
     });
     await Promise.all(
       Object.values(ThumbnailSize).map(async (size) => {

--- a/src/services/item/types.ts
+++ b/src/services/item/types.ts
@@ -1,6 +1,7 @@
-import { ItemType, type PermissionLevelOptions, type UnionOfConst } from '@graasp/sdk';
+import { ItemType, type UnionOfConst } from '@graasp/sdk';
 
 import type { MinimalAccount } from '../../drizzle/types';
+import { PermissionLevel } from '../../types';
 
 export enum SortBy {
   ItemType = 'item.type',
@@ -33,7 +34,7 @@ export type ItemSearchParams = {
   keywords?: string[];
   sortBy?: SortBy;
   ordering?: Ordering;
-  permissions?: PermissionLevelOptions[];
+  permissions?: PermissionLevel[];
   types?: UnionOfConst<typeof ItemType>[];
 };
 

--- a/src/services/item/ws/ws.test.ts
+++ b/src/services/item/ws/ws.test.ts
@@ -4,11 +4,7 @@ import waitForExpect from 'wait-for-expect';
 
 import { type FastifyInstance } from 'fastify';
 
-import {
-  HttpMethod,
-  type ItemOpFeedbackEvent as ItemOpFeedbackEventType,
-  PermissionLevel,
-} from '@graasp/sdk';
+import { HttpMethod, type ItemOpFeedbackEvent as ItemOpFeedbackEventType } from '@graasp/sdk';
 
 import { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../../test/app';
 import { seedFromJson } from '../../../../test/mocks/seed';
@@ -52,7 +48,7 @@ describe('Item websocket hooks', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -89,7 +85,7 @@ describe('Item websocket hooks', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -125,8 +121,8 @@ describe('Item websocket hooks', () => {
         items: [newParent, item],
       } = await seedFromJson({
         items: [
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
         ],
       });
       assertIsDefined(actor);
@@ -166,8 +162,8 @@ describe('Item websocket hooks', () => {
         items: [newParent, item],
       } = await seedFromJson({
         items: [
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
         ],
       });
       assertIsDefined(actor);
@@ -205,8 +201,8 @@ describe('Item websocket hooks', () => {
         items: [newParent, item],
       } = await seedFromJson({
         items: [
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
         ],
       });
       assertIsDefined(actor);
@@ -244,8 +240,8 @@ describe('Item websocket hooks', () => {
         items: [newParent, item],
       } = await seedFromJson({
         items: [
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
-          { memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
+          { memberships: [{ account: 'actor', permission: 'admin' }] },
         ],
       });
       assertIsDefined(actor);

--- a/src/services/itemLogin/itemLogin.controller.test.ts
+++ b/src/services/itemLogin/itemLogin.controller.test.ts
@@ -4,12 +4,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyInstance } from 'fastify';
 
-import {
-  HttpMethod,
-  ItemLoginSchemaStatus,
-  ItemLoginSchemaType,
-  PermissionLevel,
-} from '@graasp/sdk';
+import { HttpMethod, ItemLoginSchemaStatus, ItemLoginSchemaType } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
 import { seedFromJson } from '../../../test/mocks/seed';
@@ -132,7 +127,7 @@ describe('Item Login Tests', () => {
           {
             isHidden: true,
             itemLoginSchema: {},
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
         ],
       });
@@ -157,7 +152,7 @@ describe('Item Login Tests', () => {
           {
             isHidden: true,
             itemLoginSchema: {},
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
       });
@@ -227,7 +222,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {},
             },
           ],
@@ -257,7 +252,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: { status: ItemLoginSchemaStatus.Freeze },
             },
           ],
@@ -286,7 +281,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: { status: ItemLoginSchemaStatus.Disabled },
             },
           ],
@@ -316,7 +311,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {},
               children: [{}],
             },
@@ -346,7 +341,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
             },
           ],
         });
@@ -369,7 +364,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               itemLoginSchema: {},
               children: [{}],
             },
@@ -570,7 +565,7 @@ describe('Item Login Tests', () => {
               items: [
                 {
                   itemLoginSchema: {},
-                  memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+                  memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
                 },
               ],
             });
@@ -799,7 +794,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {
                 type: ItemLoginSchemaType.UsernameAndPassword,
               },
@@ -831,7 +826,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {
                 type: ItemLoginSchemaType.UsernameAndPassword,
                 status: ItemLoginSchemaStatus.Freeze,
@@ -864,7 +859,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {
                 type: ItemLoginSchemaType.UsernameAndPassword,
                 status: ItemLoginSchemaStatus.Disabled,
@@ -898,7 +893,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {
                 status: ItemLoginSchemaStatus.Active,
                 type: ItemLoginSchemaType.Username,
@@ -932,7 +927,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {
                 type: ItemLoginSchemaType.Username,
                 status: ItemLoginSchemaStatus.Active,
@@ -968,7 +963,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               itemLoginSchema: {},
             },
           ],
@@ -993,7 +988,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: {},
               children: [{}],
             },
@@ -1062,7 +1057,7 @@ describe('Item Login Tests', () => {
         actor: null,
         items: [
           {
-            memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+            memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             itemLoginSchema: {},
           },
         ],
@@ -1086,7 +1081,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+              memberships: [{ account: 'actor', permission: 'admin' }],
               itemLoginSchema: { guests: [{}] },
             },
           ],
@@ -1118,7 +1113,7 @@ describe('Item Login Tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+              memberships: [{ account: 'actor', permission: 'write' }],
               itemLoginSchema: { guests: [{}] },
             },
           ],

--- a/src/services/itemLogin/itemLogin.controller.ts
+++ b/src/services/itemLogin/itemLogin.controller.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { ItemLoginSchemaStatus, PermissionLevel } from '@graasp/sdk';
+import { ItemLoginSchemaStatus } from '@graasp/sdk';
 
 import { resolveDependency } from '../../di/utils';
 import { db } from '../../drizzle/db';
@@ -71,7 +71,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       const item = await authorizedItemService.getItemById(db, {
         accountId: user?.account?.id,
         itemId,
-        permission: PermissionLevel.Admin,
+        permission: 'admin',
       });
       const itemLoginSchema = await itemLoginService.getByItemPath(db, item.path);
       if (!itemLoginSchema) {
@@ -119,7 +119,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         const item = await authorizedItemService.getItemById(tx, {
           accountId: member.id,
           itemId,
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
         });
 
         await itemLoginService.updateOrCreate(tx, item.path, type, status);
@@ -143,7 +143,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         await authorizedItemService.getItemById(tx, {
           accountId: member.id,
           itemId,
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
         });
         try {
           await itemLoginService.delete(tx, itemId);

--- a/src/services/itemLogin/itemLogin.service.ts
+++ b/src/services/itemLogin/itemLogin.service.ts
@@ -3,7 +3,6 @@ import { singleton } from 'tsyringe';
 import {
   ItemLoginSchemaStatus,
   ItemVisibilityType,
-  PermissionLevel,
   PermissionLevelCompare,
   type UUID,
 } from '@graasp/sdk';
@@ -166,7 +165,7 @@ export class ItemLoginService {
         itemPath: itemLoginSchema.item.path,
         accountId: guestAccount.id,
         creatorId: guestAccount.id,
-        permission: PermissionLevel.Read,
+        permission: 'read',
       });
     }
 
@@ -223,7 +222,7 @@ export class ItemLoginService {
         actor?.id,
         itemPath,
       );
-      if (!membership || PermissionLevelCompare.lt(membership.permission, PermissionLevel.Write)) {
+      if (!membership || PermissionLevelCompare.lt(membership.permission, 'write')) {
         return false;
       }
     }

--- a/src/services/itemMembership/membership.controller.test.ts
+++ b/src/services/itemMembership/membership.controller.test.ts
@@ -5,7 +5,7 @@ import { v4 } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod } from '@graasp/sdk';
 
 import build, { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../test/app';
 import { seedFromJson } from '../../../test/mocks/seed';
@@ -175,7 +175,7 @@ describe('Membership routes tests', () => {
       const payload = {
         accountId: member.id,
         itemId: item.id,
-        permission: PermissionLevel.Write,
+        permission: 'write',
       };
       const response = await app.inject({
         method: HttpMethod.Post,
@@ -198,7 +198,7 @@ describe('Membership routes tests', () => {
         mockAuthenticate(actor);
         const payload = {
           accountId: member.id,
-          permission: PermissionLevel.Write,
+          permission: 'write',
         };
         const response = await app.inject({
           method: HttpMethod.Post,
@@ -224,13 +224,13 @@ describe('Membership routes tests', () => {
               memberships: [{ account: 'actor' }],
               children: [
                 {
-                  memberships: [{ permission: PermissionLevel.Write, account: { name: 'bob' } }],
+                  memberships: [{ permission: 'write', account: { name: 'bob' } }],
                 },
               ],
             },
             // noise
             {
-              memberships: [{ permission: PermissionLevel.Write, account: { name: 'bob' } }],
+              memberships: [{ permission: 'write', account: { name: 'bob' } }],
               children: [{}],
             },
           ],
@@ -240,7 +240,7 @@ describe('Membership routes tests', () => {
         mockAuthenticate(actor);
 
         const newMembership = {
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
           accountId: member.id,
         };
         const [_actorMembership, membership, anotherMembership] = itemMemberships;
@@ -286,7 +286,7 @@ describe('Membership routes tests', () => {
 
         const payload = {
           accountId: member.id,
-          permission: PermissionLevel.Write,
+          permission: 'write',
         };
         const response = await app.inject({
           method: HttpMethod.Post,
@@ -330,7 +330,7 @@ describe('Membership routes tests', () => {
             {
               memberships: [
                 { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Write },
+                { account: { name: 'bob' }, permission: 'write' },
               ],
             },
           ],
@@ -343,7 +343,7 @@ describe('Membership routes tests', () => {
           method: HttpMethod.Post,
           url: `/api/items/${item.id}/memberships`,
           payload: {
-            permission: PermissionLevel.Read,
+            permission: 'read',
             itemId: item.id,
             accountId: member.id,
           },
@@ -364,7 +364,7 @@ describe('Membership routes tests', () => {
             {
               memberships: [
                 { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Write },
+                { account: { name: 'bob' }, permission: 'write' },
               ],
               children: [{}],
             },
@@ -375,7 +375,7 @@ describe('Membership routes tests', () => {
         expect(await getMembershipsByItemPath(parent.path)).toHaveLength(2);
 
         const newMembership = {
-          permission: PermissionLevel.Read,
+          permission: 'read',
           accountId: member.id,
           itemId: item.id,
         };
@@ -407,7 +407,7 @@ describe('Membership routes tests', () => {
           method: HttpMethod.Post,
           url: `/api/items/${id}/memberships`,
           payload: {
-            permission: PermissionLevel.Read,
+            permission: 'read',
             itemId: item.id,
             accountId: member.id,
           },
@@ -450,7 +450,7 @@ describe('Membership routes tests', () => {
         items: [item],
       } = await seedFromJson({ items: [{ memberships: [{ account: 'actor' }] }] });
       const payload = {
-        permission: PermissionLevel.Write,
+        permission: 'write',
       };
       const response = await app.inject({
         method: HttpMethod.Patch,
@@ -469,13 +469,8 @@ describe('Membership routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [
-                { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Read },
-              ],
-              children: [
-                { memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Write }] },
-              ],
+              memberships: [{ account: 'actor' }, { account: { name: 'bob' }, permission: 'read' }],
+              children: [{ memberships: [{ account: { name: 'bob' }, permission: 'write' }] }],
             },
           ],
         });
@@ -485,7 +480,7 @@ describe('Membership routes tests', () => {
         expect(await getMembershipsByItemPath(child.path)).toHaveLength(1);
 
         const newMembership = {
-          permission: PermissionLevel.Read,
+          permission: 'read',
           accountId: member.id,
         };
         const response = await app.inject({
@@ -508,7 +503,7 @@ describe('Membership routes tests', () => {
             {
               memberships: [
                 { account: 'actor' },
-                { permission: PermissionLevel.Write, account: { name: 'bob' } },
+                { permission: 'write', account: { name: 'bob' } },
               ],
             },
           ],
@@ -519,7 +514,7 @@ describe('Membership routes tests', () => {
         expect(await getMembershipsByItemPath(item.path)).toHaveLength(2);
 
         const newMembership = {
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
         };
         const response = await app.inject({
           method: HttpMethod.Patch,
@@ -543,13 +538,10 @@ describe('Membership routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [
-                { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Read },
-              ],
+              memberships: [{ account: 'actor' }, { account: { name: 'bob' }, permission: 'read' }],
               children: [
                 {
-                  memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Write }],
+                  memberships: [{ account: { name: 'bob' }, permission: 'write' }],
                 },
               ],
             },
@@ -560,7 +552,7 @@ describe('Membership routes tests', () => {
         mockAuthenticate(actor);
         expect(await getMembershipsByItemPath(parent.path)).toHaveLength(2);
 
-        const newMembership = { permission: PermissionLevel.Write };
+        const newMembership = { permission: 'write' };
         const response = await app.inject({
           method: HttpMethod.Patch,
           url: `/api/items/${parent.id}/memberships/${readMembership.id}`,
@@ -593,7 +585,7 @@ describe('Membership routes tests', () => {
         const response = await app.inject({
           method: HttpMethod.Patch,
           url: `/api/items/${id}/memberships/${id}`,
-          payload: { permission: PermissionLevel.Write },
+          payload: { permission: 'write' },
         });
         expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
         expect(response.statusMessage).toEqual(ReasonPhrases.BAD_REQUEST);
@@ -609,11 +601,11 @@ describe('Membership routes tests', () => {
             {
               memberships: [
                 { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Write },
+                { account: { name: 'bob' }, permission: 'write' },
               ],
               children: [
                 {
-                  memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+                  memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
                 },
               ],
             },
@@ -626,7 +618,7 @@ describe('Membership routes tests', () => {
           method: HttpMethod.Patch,
           url: `/api/items/${child.id}/memberships/${adminMembership.id}`,
           payload: {
-            permission: PermissionLevel.Read,
+            permission: 'read',
             accountId: member.id,
           },
         });
@@ -653,7 +645,7 @@ describe('Membership routes tests', () => {
         mockAuthenticate(actor);
 
         const newMembership = {
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
           accountId: guest.id,
         };
         const response = await app.inject({
@@ -691,11 +683,9 @@ describe('Membership routes tests', () => {
             {
               memberships: [
                 { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Admin },
+                { account: { name: 'bob' }, permission: 'admin' },
               ],
-              children: [
-                { memberships: [{ permission: PermissionLevel.Admin, account: { name: 'bob' } }] },
-              ],
+              children: [{ memberships: [{ permission: 'admin', account: { name: 'bob' } }] }],
             },
           ],
         });
@@ -723,11 +713,9 @@ describe('Membership routes tests', () => {
             {
               memberships: [
                 { account: 'actor' },
-                { account: { name: 'bob' }, permission: PermissionLevel.Admin },
+                { account: { name: 'bob' }, permission: 'admin' },
               ],
-              children: [
-                { memberships: [{ permission: PermissionLevel.Admin, account: { name: 'bob' } }] },
-              ],
+              children: [{ memberships: [{ permission: 'admin', account: { name: 'bob' } }] }],
             },
           ],
         });
@@ -781,10 +769,7 @@ describe('Membership routes tests', () => {
         } = await seedFromJson({
           items: [
             {
-              memberships: [
-                { account: 'actor', permission: PermissionLevel.Read },
-                { account: { name: 'bob' } },
-              ],
+              memberships: [{ account: 'actor', permission: 'read' }, { account: { name: 'bob' } }],
             },
           ],
         });
@@ -808,7 +793,7 @@ describe('Membership routes tests', () => {
           items: [
             {
               memberships: [
-                { account: 'actor', permission: PermissionLevel.Write },
+                { account: 'actor', permission: 'write' },
                 { account: { name: 'bob' } },
               ],
             },

--- a/src/services/itemMembership/membership.repository.spec.ts
+++ b/src/services/itemMembership/membership.repository.spec.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { seedFromJson } from '../../../test/mocks/seed';
 import { db } from '../../drizzle/db';
 import { assertIsDefined } from '../../utils/assertions';
@@ -27,10 +25,10 @@ describe('ItemMembership Repository', () => {
         items: [
           {
             memberships: [
-              { account: { name: 'bob' }, permission: PermissionLevel.Admin },
-              { account: { name: 'cedric' }, permission: PermissionLevel.Admin },
-              { account: { name: 'anna' }, permission: PermissionLevel.Write },
-              { account: { name: 'david' }, permission: PermissionLevel.Read },
+              { account: { name: 'bob' }, permission: 'admin' },
+              { account: { name: 'cedric' }, permission: 'admin' },
+              { account: { name: 'anna' }, permission: 'write' },
+              { account: { name: 'david' }, permission: 'read' },
             ],
           },
         ],
@@ -50,18 +48,18 @@ describe('ItemMembership Repository', () => {
         items: [
           {
             memberships: [
-              { account: { name: 'bob' }, permission: PermissionLevel.Admin },
-              { account: { name: 'cedric' }, permission: PermissionLevel.Admin },
-              { account: { name: 'anna' }, permission: PermissionLevel.Write },
-              { account: { name: 'david' }, permission: PermissionLevel.Read },
+              { account: { name: 'bob' }, permission: 'admin' },
+              { account: { name: 'cedric' }, permission: 'admin' },
+              { account: { name: 'anna' }, permission: 'write' },
+              { account: { name: 'david' }, permission: 'read' },
             ],
             children: [
               {
                 memberships: [
-                  { account: { name: 'evian' }, permission: PermissionLevel.Admin },
-                  { account: { name: 'fabrice' }, permission: PermissionLevel.Admin },
-                  { account: { name: 'george' }, permission: PermissionLevel.Write },
-                  { account: { name: 'helene' }, permission: PermissionLevel.Read },
+                  { account: { name: 'evian' }, permission: 'admin' },
+                  { account: { name: 'fabrice' }, permission: 'admin' },
+                  { account: { name: 'george' }, permission: 'write' },
+                  { account: { name: 'helene' }, permission: 'read' },
                 ],
               },
             ],
@@ -89,20 +87,20 @@ describe('ItemMembership Repository', () => {
         items: [
           {
             name: 'commonStart 1',
-            memberships: [{ account: 'actor', permission: PermissionLevel.Read }],
+            memberships: [{ account: 'actor', permission: 'read' }],
           },
           {
             name: 'commonStart 2',
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
           {
             name: 'commonStart 3',
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
           // noise
           {
             name: 'commonStart 4',
-            memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+            memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
           },
         ],
       });
@@ -129,12 +127,12 @@ describe('ItemMembership Repository', () => {
             children: [
               {
                 name: 'commonStart 2',
-                memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+                memberships: [{ account: 'actor', permission: 'write' }],
               },
               // noise
               {
                 name: 'commonStart 4',
-                memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+                memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
               },
             ],
           },
@@ -159,24 +157,24 @@ describe('ItemMembership Repository', () => {
         items: [
           {
             name: 'commonStart 1',
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
             children: [
               // noise
               {
                 name: 'commonStart 2',
-                memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+                memberships: [{ account: 'actor', permission: 'write' }],
               },
               // noise
               {
                 name: 'commonStart 3',
-                memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+                memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
               },
             ],
           },
           // noise
           {
             name: 'commonStart 4',
-            memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+            memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
           },
         ],
       });
@@ -200,13 +198,13 @@ describe('ItemMembership Repository', () => {
         items: [
           {
             memberships: [
-              { account: 'actor', permission: PermissionLevel.Admin },
-              { account: { name: 'bob' }, permission: PermissionLevel.Read },
+              { account: 'actor', permission: 'admin' },
+              { account: { name: 'bob' }, permission: 'read' },
             ],
           },
           // noise
           {
-            memberships: [{ account: { name: 'cedric' }, permission: PermissionLevel.Admin }],
+            memberships: [{ account: { name: 'cedric' }, permission: 'admin' }],
           },
         ],
       });
@@ -217,12 +215,12 @@ describe('ItemMembership Repository', () => {
       const adminM = result.find((m) => m.id === adminMembership.id);
       assertIsDefined(adminM);
       expect(adminM.item.path).toEqual(item.path);
-      expect(adminM.permission).toEqual(PermissionLevel.Admin);
+      expect(adminM.permission).toEqual('admin');
 
       const readM = result.find((m) => m.id === readMembership.id);
       assertIsDefined(readM);
       expect(readM.item.path).toEqual(item.path);
-      expect(readM.permission).toEqual(PermissionLevel.Read);
+      expect(readM.permission).toEqual('read');
     });
     it('return inherited memberships', async () => {
       const {
@@ -232,21 +230,21 @@ describe('ItemMembership Repository', () => {
         items: [
           {
             memberships: [
-              { account: 'actor', permission: PermissionLevel.Admin },
-              { account: { name: 'bob' }, permission: PermissionLevel.Read },
+              { account: 'actor', permission: 'admin' },
+              { account: { name: 'bob' }, permission: 'read' },
             ],
             children: [
               {
                 memberships: [
-                  { account: { name: 'bob' }, permission: PermissionLevel.Admin },
-                  { account: { name: 'alice' }, permission: PermissionLevel.Write },
+                  { account: { name: 'bob' }, permission: 'admin' },
+                  { account: { name: 'alice' }, permission: 'write' },
                 ],
               },
             ],
           },
           // noise
           {
-            memberships: [{ account: { name: 'cedric' }, permission: PermissionLevel.Admin }],
+            memberships: [{ account: { name: 'cedric' }, permission: 'admin' }],
           },
         ],
       });
@@ -260,7 +258,7 @@ describe('ItemMembership Repository', () => {
       );
       assertIsDefined(adminM);
       expect(adminM.item.path).toEqual(item.path);
-      expect(adminM.permission).toEqual(PermissionLevel.Admin);
+      expect(adminM.permission).toEqual('admin');
 
       // bob admin membership on item
       const readM = result.find(
@@ -268,7 +266,7 @@ describe('ItemMembership Repository', () => {
       );
       assertIsDefined(readM);
       expect(readM.item.path).toEqual(child.path);
-      expect(readM.permission).toEqual(PermissionLevel.Admin);
+      expect(readM.permission).toEqual('admin');
 
       // alice write membership on item
       const writeM = result.find(
@@ -276,7 +274,7 @@ describe('ItemMembership Repository', () => {
       );
       assertIsDefined(writeM);
       expect(writeM.item.path).toEqual(child.path);
-      expect(writeM.permission).toEqual(PermissionLevel.Write);
+      expect(writeM.permission).toEqual('write');
     });
   });
 });

--- a/src/services/itemMembership/membership.schemas.ts
+++ b/src/services/itemMembership/membership.schemas.ts
@@ -3,10 +3,9 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifySchema } from 'fastify';
 
-import { PermissionLevel } from '@graasp/sdk';
-
 import { customType, registerSchemaAsRef } from '../../plugins/typebox';
 import { errorSchemaRef } from '../../schemas/global';
+import { permissionLevelSchemaRef } from '../../types';
 import {
   augmentedAccountSchemaRef,
   nullableAugmentedAccountSchemaRef,
@@ -21,7 +20,7 @@ export const itemMembershipSchemaRef = registerSchemaAsRef(
       id: customType.UUID(),
       account: augmentedAccountSchemaRef,
       item: itemSchemaRef,
-      permission: customType.EnumString(Object.values(PermissionLevel)),
+      permission: permissionLevelSchemaRef,
       creator: Type.Optional(nullableAugmentedAccountSchemaRef),
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
@@ -40,7 +39,7 @@ export const itemMembershipWithoutRelationsSchemaRef = registerSchemaAsRef(
       id: customType.UUID(),
       accountId: customType.UUID(),
       itemPath: Type.String(),
-      permission: customType.EnumString(Object.values(PermissionLevel)),
+      permission: permissionLevelSchemaRef,
       creator: Type.Optional(customType.UUID()),
       createdAt: customType.DateTime(),
       updatedAt: customType.DateTime(),
@@ -53,7 +52,7 @@ export const itemMembershipWithoutRelationsSchemaRef = registerSchemaAsRef(
 
 export const createItemMembershipSchema = customType.StrictObject({
   accountId: customType.UUID(),
-  permission: customType.EnumString(Object.values(PermissionLevel)),
+  permission: permissionLevelSchemaRef,
 });
 
 // schema for creating an item membership
@@ -100,7 +99,7 @@ export const updateOne = {
     itemId: customType.UUID(),
   }),
   body: customType.StrictObject({
-    permission: customType.EnumString(Object.values(PermissionLevel)),
+    permission: permissionLevelSchemaRef,
   }),
   response: {
     [StatusCodes.NO_CONTENT]: Type.Null({ description: 'Successful Response' }),

--- a/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.test.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.test.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, MembershipRequestStatus, PermissionLevel } from '@graasp/sdk';
+import { HttpMethod, MembershipRequestStatus } from '@graasp/sdk';
 
 import build, {
   clearDatabase,
@@ -65,7 +65,7 @@ describe('MembershipRequest', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -87,7 +87,7 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             membershipRequests: [{ member: { name: 'bob' } }],
           },
         ],
@@ -113,7 +113,7 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             membershipRequests: [
               { member: { name: 'bob' } },
               { member: { name: 'alice' } },
@@ -122,7 +122,7 @@ describe('MembershipRequest', () => {
           },
           // noise
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             membershipRequests: [{ member: { name: 'bob' } }],
           },
         ],
@@ -176,7 +176,7 @@ describe('MembershipRequest', () => {
         actor,
         items: [item],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Write }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'write' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -228,7 +228,7 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             children: [{}],
           },
         ],
@@ -275,7 +275,7 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
           },
         ],
       });
@@ -300,7 +300,7 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Admin }],
+            memberships: [{ account: 'actor', permission: 'admin' }],
             membershipRequests: [{ member: 'actor' }],
           },
         ],
@@ -352,7 +352,7 @@ describe('MembershipRequest', () => {
         items: [item],
         members: [admin],
       } = await seedFromJson({
-        items: [{ memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: { name: 'bob' }, permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -385,16 +385,16 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: { name: 'bob' }, permission: PermissionLevel.Admin }],
+            memberships: [{ account: { name: 'bob' }, permission: 'admin' }],
             children: [
               {
-                memberships: [{ account: { name: 'alice' }, permission: PermissionLevel.Admin }],
+                memberships: [{ account: { name: 'alice' }, permission: 'admin' }],
                 children: [
                   {
                     memberships: [
-                      { account: { name: 'cedric' }, permission: PermissionLevel.Admin },
+                      { account: { name: 'cedric' }, permission: 'admin' },
                       // noise
-                      { account: { name: 'noise' }, permission: PermissionLevel.Read },
+                      { account: { name: 'noise' }, permission: 'read' },
                     ],
                   },
                 ],
@@ -670,7 +670,7 @@ describe('MembershipRequest', () => {
       } = await seedFromJson({
         items: [
           {
-            memberships: [{ account: 'actor', permission: PermissionLevel.Write }],
+            memberships: [{ account: 'actor', permission: 'write' }],
           },
         ],
         members: [{}],

--- a/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
+++ b/src/services/itemMembership/plugins/MembershipRequest/membershipRequest.controller.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import type { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox';
 
-import { MembershipRequestStatus, PermissionLevel } from '@graasp/sdk';
+import { MembershipRequestStatus } from '@graasp/sdk';
 
 import { resolveDependency } from '../../../../di/utils';
 import { db } from '../../../../drizzle/db';
@@ -46,7 +46,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         await authorizedItemService.assertAccessForItemId(tx, {
           accountId: member.id,
           itemId,
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
         });
 
         const requests = await membershipRequestService.getAllByItem(tx, itemId);
@@ -118,7 +118,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         // Check if the member already has an access to the item (from membership), if so, throw an error
         if (
           await authorizedItemService.hasPermission(tx, {
-            permission: PermissionLevel.Read,
+            permission: 'read',
             accountId: member.id,
             item,
           })
@@ -148,7 +148,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         await authorizedItemService.assertAccessForItemId(tx, {
           accountId: member.id,
           itemId,
-          permission: PermissionLevel.Admin,
+          permission: 'admin',
         });
 
         const result = await membershipRequestService.deleteOne(tx, memberId, itemId);

--- a/src/services/itemMembership/ws/ws.test.ts
+++ b/src/services/itemMembership/ws/ws.test.ts
@@ -3,7 +3,7 @@ import waitForExpect from 'wait-for-expect';
 
 import type { FastifyInstance } from 'fastify';
 
-import { HttpMethod, PermissionLevel, Websocket } from '@graasp/sdk';
+import { HttpMethod, Websocket } from '@graasp/sdk';
 
 import { clearDatabase, mockAuthenticate, unmockAuthenticate } from '../../../../test/app';
 import { seedFromJson } from '../../../../test/mocks/seed';
@@ -96,7 +96,7 @@ describe('Item websocket hooks', () => {
         members: [bob],
       } = await seedFromJson({
         members: [{ name: 'bob' }],
-        items: [{ memberships: [{ account: 'actor', permission: PermissionLevel.Admin }] }],
+        items: [{ memberships: [{ account: 'actor', permission: 'admin' }] }],
       });
       assertIsDefined(actor);
       mockAuthenticate(actor);
@@ -107,7 +107,7 @@ describe('Item websocket hooks', () => {
         channel: item.id,
       });
 
-      const payload = { accountId: bob.id, permission: PermissionLevel.Read };
+      const payload = { accountId: bob.id, permission: 'read' };
       const response = await app.inject({
         method: HttpMethod.Post,
         url: `/api/items/${item.id}/memberships`,
@@ -134,8 +134,8 @@ describe('Item websocket hooks', () => {
         items: [
           {
             memberships: [
-              { account: { name: 'bob' }, permission: PermissionLevel.Read },
-              { account: 'actor', permission: PermissionLevel.Admin },
+              { account: { name: 'bob' }, permission: 'read' },
+              { account: 'actor', permission: 'admin' },
             ],
           },
         ],
@@ -152,7 +152,7 @@ describe('Item websocket hooks', () => {
       const response = await app.inject({
         method: HttpMethod.Patch,
         url: `/api/items/${item.id}/memberships/${membership.id}`,
-        payload: { permission: PermissionLevel.Admin },
+        payload: { permission: 'admin' },
       });
       expect(response.statusCode).toBe(StatusCodes.NO_CONTENT);
 
@@ -162,7 +162,7 @@ describe('Item websocket hooks', () => {
         expect(membershipUpdate).toMatchObject(
           ItemMembershipEvent(
             'update',
-            expect.objectContaining({ id: membership.id, permission: PermissionLevel.Admin }),
+            expect.objectContaining({ id: membership.id, permission: 'admin' }),
           ),
         );
       });
@@ -179,8 +179,8 @@ describe('Item websocket hooks', () => {
         items: [
           {
             memberships: [
-              { account: { name: 'bob' }, permission: PermissionLevel.Read },
-              { account: 'actor', permission: PermissionLevel.Admin },
+              { account: { name: 'bob' }, permission: 'read' },
+              { account: 'actor', permission: 'admin' },
             ],
           },
         ],

--- a/src/services/member/plugins/action/memberAction.service.ts
+++ b/src/services/member/plugins/action/memberAction.service.ts
@@ -1,7 +1,7 @@
 import partition from 'lodash.partition';
 import { singleton } from 'tsyringe';
 
-import { ActionTriggers, PermissionLevel } from '@graasp/sdk';
+import { ActionTriggers } from '@graasp/sdk';
 
 import { type DBConnection } from '../../../../drizzle/db';
 import type { ItemRaw } from '../../../../drizzle/types';
@@ -74,7 +74,7 @@ export class ActionMemberService {
     const { itemMemberships } = await this.authorizedItemService.getPropertiesForItems(
       dbConnection,
       {
-        permission: PermissionLevel.Read,
+        permission: 'read',
         accountId: authenticatedUser.id,
         items: setOfItemsToCheckPermission as ItemRaw[],
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,8 @@
+import { Static, Type } from '@sinclair/typebox';
+
 import type { UnionOfConst } from '@graasp/sdk';
+
+import { registerSchemaAsRef } from './plugins/typebox';
 
 export const AccountType = {
   Individual: 'individual',
@@ -75,3 +79,16 @@ export type KeysWithValsOfType<T, V> = keyof {
   [P in keyof T as T[P] extends V ? P : never]: P;
 };
 export type KeysOfString<T> = KeysWithValsOfType<T, string>;
+
+const permissionLevelSchema = Type.Union([
+  Type.Literal('read'),
+  Type.Literal('write'),
+  Type.Literal('admin'),
+]);
+export type PermissionLevel = Static<typeof permissionLevelSchema>;
+
+export const permissionLevelSchemaRef = registerSchemaAsRef(
+  'permissionLevel',
+  'PermissionLevel',
+  permissionLevelSchema,
+);

--- a/test/mocks/seed.ts
+++ b/test/mocks/seed.ts
@@ -12,8 +12,6 @@ import {
   ItemValidationStatus,
   type ItemVisibilityOptionsType,
   ItemVisibilityType,
-  PermissionLevel,
-  type PermissionLevelOptions,
   ShortLinkPlatform,
   buildPathFromIds,
   getIdsFromPath,
@@ -82,6 +80,7 @@ import type {
   TagRaw,
 } from '../../src/drizzle/types';
 import { encryptPassword } from '../../src/services/auth/plugins/password/utils';
+import { PermissionLevel } from '../../src/types';
 import { APPS_PUBLISHER_ID } from '../../src/utils/config';
 import { ActionFactory } from '../factories/action.factory';
 import { ItemFactory } from '../factories/item.factory';
@@ -98,7 +97,7 @@ type SeedMember = Partial<MemberRaw> & { profile?: Partial<MemberProfileRaw> };
 type SeedMembership<M = SeedMember> = Partial<Omit<ItemMembershipRaw, 'creator' | 'account'>> & {
   account: M;
   creator?: M | null;
-  permission?: PermissionLevelOptions;
+  permission?: PermissionLevel;
 };
 type SeedItem<M = SeedMember> = (Partial<Omit<ItemRaw, 'creator'>> & { creator?: M | null }) & {
   children?: SeedItem<M>[];
@@ -403,7 +402,7 @@ const processItemMemberships = (items: DataType['items'] = []) => {
   return items
     ?.flatMap((i) => i.memberships?.map((im) => ({ ...im, itemPath: i.path })) ?? [])
     ?.map((im) => ({
-      permission: PermissionLevel.Admin,
+      permission: 'admin',
       accountId: (im.account as any).id,
       creatorId: im.creator ? (im.creator as any).id : null,
       ...im,
@@ -763,14 +762,14 @@ async function createItemLoginSchemasAndGuests(items: (SeedItem & { path: string
     const guestMemberships = guestsData.reduce<
       {
         accountId: string;
-        permission: PermissionLevelOptions;
+        permission: PermissionLevel;
         itemPath: string;
       }[]
     >((acc, { id, itemPath: path }) => {
       return acc.concat([
         {
           accountId: id,
-          permission: PermissionLevel.Read,
+          permission: 'read',
           itemPath: path,
         },
       ]);
@@ -1063,7 +1062,7 @@ export async function seedFromJson(data: DataType = {}) {
       return acc.concat(
         i.invitations.map(() => ({
           itemPath: i.path,
-          permission: PermissionLevel.Read,
+          permission: 'read',
           email: faker.internet.email().toLowerCase(),
         })),
       );


### PR DESCRIPTION
- Replace `PermissionLevel` (enum) with constant strings.
- Replace `PermissionLevelOptions` (type) with `PermissionLevel` from typebox's schema.