### PR TITLE
fix: take into account previousItemId parameter to get correct ordering when creating folder with thumbnail

### DIFF
--- a/src/services/item/item.controller.ts
+++ b/src/services/item/item.controller.ts
@@ -90,7 +90,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       async (request) => {
         const {
           user,
-          query: { parentId },
+          query: { parentId, previousItemId },
         } = request;
         const member = asDefined(user?.account);
         assertIsMember(member);
@@ -109,6 +109,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
             parentId,
             geolocation,
             thumbnail,
+            previousItemId,
           });
           await itemActionService.postPostAction(tsx, request, item);
           return item;

--- a/src/services/item/item.controller.update.test.ts
+++ b/src/services/item/item.controller.update.test.ts
@@ -730,6 +730,116 @@ describe('Item routes tests', () => {
       expect(response.statusCode).toBe(StatusCodes.OK);
       expect(uploadDoneMock).toHaveBeenCalled();
     });
+
+    it('Post item with thumbnail inside parent', async () => {
+      const {
+        actor,
+        items: [parent],
+      } = await seedFromJson({
+        items: [{ name: 'parent', memberships: [{ account: 'actor', permission: 'admin' }] }],
+      });
+      assertIsDefined(actor);
+      assertIsMemberForTest(actor);
+      mockAuthenticate(actor);
+      const imageStream = fs.createReadStream(path.resolve(__dirname, './test/fixtures/image.png'));
+      const itemName = 'Test Item';
+      const payload = new FormData();
+      payload.append('name', itemName);
+      payload.append('type', 'folder');
+      payload.append('description', '');
+      payload.append('file', imageStream);
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: `/api/items/with-thumbnail`,
+        query: {
+          parentId: parent.id,
+        },
+        payload,
+        headers: payload.getHeaders(),
+      });
+
+      const newItem = response.json();
+      expectItem(
+        newItem,
+        FolderItemFactory({
+          parentItem: parent,
+          name: itemName,
+          type: 'folder',
+          description: '',
+          settings: { hasThumbnail: true },
+          lang: parent.lang,
+        }),
+        actor,
+      );
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expect(uploadDoneMock).toHaveBeenCalled();
+    });
+
+    it('Post item with thumbnail inside parent after first item', async () => {
+      const {
+        actor,
+        items: [parent, firstChild],
+      } = await seedFromJson({
+        items: [
+          {
+            name: 'parent',
+            type: 'folder',
+            memberships: [{ account: 'actor', permission: 'admin' }],
+            children: [
+              {
+                name: 'first',
+                // we need to specify the order as it is not set automatically, without this it returns a wrong ordering
+                order: 20,
+              },
+            ],
+          },
+        ],
+      });
+      assertIsDefined(actor);
+      assertIsMemberForTest(actor);
+      mockAuthenticate(actor);
+      const imageStream = fs.createReadStream(path.resolve(__dirname, './test/fixtures/image.png'));
+      const itemName = 'Test Item';
+      const payload = new FormData();
+      payload.append('name', itemName);
+      payload.append('type', 'folder');
+      payload.append('description', '');
+      payload.append('file', imageStream);
+      const response = await app.inject({
+        method: HttpMethod.Post,
+        url: `/api/items/with-thumbnail`,
+        query: {
+          parentId: parent.id,
+          previousItemId: firstChild.id,
+        },
+        payload,
+        headers: payload.getHeaders(),
+      });
+
+      const newItem = response.json();
+      expectItem(
+        newItem,
+        FolderItemFactory({
+          parentItem: parent,
+          name: itemName,
+          type: 'folder',
+          description: '',
+          settings: { hasThumbnail: true },
+          lang: parent.lang,
+        }),
+        actor,
+      );
+      expect(response.statusCode).toBe(StatusCodes.OK);
+      expect(uploadDoneMock).toHaveBeenCalled();
+
+      // check the children order is correct: first should be first and the new item should be second
+      const childrenResp = await app.inject({
+        method: HttpMethod.Get,
+        url: `/api/items/${parent.id}/children`,
+      });
+      const children = await childrenResp.json();
+      expectItem(newItem, children.at(1));
+    });
   });
 
   describe('PATCH /api/items/:id', () => {

--- a/src/services/item/item.schemas.create.ts
+++ b/src/services/item/item.schemas.create.ts
@@ -161,6 +161,8 @@ export const createWithThumbnail = {
   summary: 'Create an item with a thumbnail',
   description: 'Create an item with a thumbnail. The data is sent using a form-data.',
 
-  querystring: Type.Partial(customType.StrictObject({ parentId: customType.UUID() })),
+  querystring: Type.Partial(
+    customType.StrictObject({ parentId: customType.UUID(), previousItemId: customType.UUID() }),
+  ),
   response: { [StatusCodes.OK]: genericItemSchemaRef, '4xx': errorSchemaRef },
 } as const satisfies FastifySchema;


### PR DESCRIPTION
In this PR I fix a small bug affecting the creation of folders with a thumbnail.

### Current behaviour

When creating a folder with a thumbnail it always appears as the first element in the parent.

### Expected behaviour

When creating a folder with a thumbnail inside a parent that already has some content it should be placed as the last element (this is the behaviour when creating a folder without a thumbnail).

### Reason for the bug

The endpoint that receives the request to create a folder with a thumbnail ignored the `previousItemId` query param that tells where to put the new item. So it was put at the top.

### Additional mitigation

I added test cases that ensure that a folder created with a thumbnail either alone or after an existing item get the correct order.