### PR TITLE
chore: make small fixes to improve experience

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     hostname: db
     image: postgres:16.11-alpine
     restart: on-failure
+    shm_size: 1g
     ports:
       - 5432:5432
     volumes:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ H5P_CONTENT_REGION=garage
 H5P_CONTENT_BUCKET=h5p-items
 H5P_CONTENT_ACCESS_KEY_ID=<your bucket key>
 H5P_CONTENT_SECRET_ACCESS_KEY_ID=<your bucket secret>
+H5P_PATH_PREFIX=h5p-content/
 
 
 ### External services configuration


### PR DESCRIPTION
In this PR I:
- add `shm_size` parameter on the `db` image to increase the shared_memory partition size of the linux container, see [the reference in the docker compose reference](https://docs.docker.com/reference/compose-file/build/#shm_size)
- add missing env var in readme to remove installation error for newcomers
