### PR TITLE
fix: update workers image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:24.12-bookworm AS base
+
 RUN apt-get update  \
-    && apt-get -y --no-install-recommends install  \
-        sudo curl git ca-certificates build-essential dumb-init \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get -y --no-install-recommends install  \
+  sudo curl git ca-certificates build-essential dumb-init \
+  && rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"

--- a/docker/workers.Dockerfile
+++ b/docker/workers.Dockerfile
@@ -1,36 +1,30 @@
 FROM node:24.12-bookworm AS base
 
+RUN apt-get update  \
+  && apt-get -y --no-install-recommends install  \
+  sudo curl git ca-certificates build-essential dumb-init \
+  && rm -rf /var/lib/apt/lists/*
 
-# -------------------------------------------------------
-# get the init system
-FROM base AS tools
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 
-# update packages and install the minimal init system "dumb-init"
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
-
+# Install mise
+RUN curl https://mise.run | sh
 
 # -------------------------------------------------------
 FROM base AS build
 
 WORKDIR /app
-COPY package.json yarn.lock .yarnrc.yml ./
-# We need a specific command because we need to copy the folder with it, not just the content.
-COPY .yarn/releases ./.yarn/releases/
-RUN yarn set version berry && yarn install --immutable
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml mise.toml ./
+
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN mise trust && mise install && corepack enable && pnpm install --frozen-lockfile
 
 ENV NODE_ENV=production
 COPY . .
-RUN yarn build-ts
+RUN pnpm build-ts
 
-# -------------------------------------------------------
-FROM base AS deps
-
-WORKDIR /app
-COPY package.json yarn.lock .yarnrc.yml ./
-# We need a specific command because we need to copy the folder with it, not just the content.
-COPY .yarn/releases ./.yarn/releases/
-RUN yarn set version berry && yarn workspaces focus --all --production
-
+RUN pnpm install --prod --frozen-lockfile
 
 # -------------------------------------------------------
 # Final step that will run the application
@@ -49,10 +43,10 @@ ENV NODE_ENV=production
 WORKDIR /app
 
 # Copy the installed dumb-init system from build image
-COPY --from=tools /usr/bin/dumb-init /usr/bin/dumb-init
+COPY --from=base /usr/bin/dumb-init /usr/bin/dumb-init
 
 # Copy the dependencies and compiled server code
-COPY --chown=node:node --from=deps ./app/node_modules ./node_modules
+COPY --chown=node:node --from=build ./app/node_modules ./node_modules
 COPY --chown=node:node --from=build ./app/dist ./dist
 
 # Set user to be non-root node


### PR DESCRIPTION
In this PR I update the docker image for the workers.

In doing this I noticed that the core image and the workers image are the same, they just do not run the same command at the end. 
We could override the command for the workers in the task definition in AWS and save ourself one image.