### PR TITLE
fix: add thumbnail URL access to bookmarks

### DIFF
--- a/src/services/item/plugins/itemBookmark/itemBookmark.service.spec.ts
+++ b/src/services/item/plugins/itemBookmark/itemBookmark.service.spec.ts
@@ -97,7 +97,7 @@ describe('BookmarkService', () => {
           id: itemWithoutThumbnail.id,
         },
       });
-      expect(result[1].item).not.toHaveProperty('thumbnails');
+      expect(result[1].item.thumbnails).toBeUndefined();
     });
   });
 });

--- a/src/services/item/plugins/itemBookmark/itemBookmark.service.spec.ts
+++ b/src/services/item/plugins/itemBookmark/itemBookmark.service.spec.ts
@@ -1,0 +1,103 @@
+import { v4 } from 'uuid';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ItemFactory } from '../../../../../test/factories/item.factory';
+import { MemberFactory } from '../../../../../test/factories/member.factory';
+import type { DBConnection } from '../../../../drizzle/db';
+import { AuthorizedItemService } from '../../../authorizedItem.service';
+import { ItemMembershipRepository } from '../../../itemMembership/membership.repository';
+import { ItemVisibilityRepository } from '../itemVisibility/itemVisibility.repository';
+import { ItemThumbnailService } from '../thumbnail/itemThumbnail.service';
+import { ItemBookmarkRepository } from './itemBookmark.repository';
+import { BookmarkService } from './itemBookmark.service';
+
+const dbConnection = {} as DBConnection;
+
+describe('BookmarkService', () => {
+  describe('getOwn', () => {
+    it('returns packed bookmarked items with thumbnail URLs', async () => {
+      const member = MemberFactory();
+      const itemWithThumbnail = ItemFactory({ settings: { hasThumbnail: true } });
+      const itemWithoutThumbnail = ItemFactory({ settings: { hasThumbnail: false } });
+      const thumbnailUrls = {
+        [itemWithThumbnail.id]: {
+          small: 'https://example.com/small-thumbnail',
+          medium: 'https://example.com/medium-thumbnail',
+        },
+      };
+      const bookmarks = [
+        {
+          id: v4(),
+          itemId: itemWithThumbnail.id,
+          memberId: member.id,
+          createdAt: new Date().toISOString(),
+          item: itemWithThumbnail,
+        },
+        {
+          id: v4(),
+          itemId: itemWithoutThumbnail.id,
+          memberId: member.id,
+          createdAt: new Date().toISOString(),
+          item: itemWithoutThumbnail,
+        },
+      ];
+
+      const itemBookmarkRepository = {
+        getBookmarksForMember: vi.fn().mockResolvedValue(bookmarks),
+      } as unknown as ItemBookmarkRepository;
+      const itemMembershipRepository = {
+        getForManyItems: vi.fn().mockResolvedValue({
+          data: {
+            [itemWithThumbnail.id]: [{ permission: 'read' }],
+            [itemWithoutThumbnail.id]: [{ permission: 'read' }],
+          },
+          errors: [],
+        }),
+      } as unknown as ItemMembershipRepository;
+      const itemVisibilityRepository = {
+        getManyForMany: vi.fn().mockResolvedValue({
+          data: {
+            [itemWithThumbnail.id]: [],
+            [itemWithoutThumbnail.id]: [],
+          },
+          errors: [],
+        }),
+      } as unknown as ItemVisibilityRepository;
+      const itemThumbnailService = {
+        getUrlsByItems: vi.fn().mockResolvedValue(thumbnailUrls),
+      } as unknown as ItemThumbnailService;
+
+      const service = new BookmarkService(
+        {} as AuthorizedItemService,
+        itemBookmarkRepository,
+        itemMembershipRepository,
+        itemVisibilityRepository,
+        itemThumbnailService,
+      );
+
+      const result = await service.getOwn(dbConnection, member);
+
+      expect(itemThumbnailService.getUrlsByItems).toHaveBeenCalledWith([
+        itemWithThumbnail,
+        itemWithoutThumbnail,
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: bookmarks[0].id,
+        createdAt: bookmarks[0].createdAt,
+        item: {
+          id: itemWithThumbnail.id,
+          thumbnails: thumbnailUrls[itemWithThumbnail.id],
+        },
+      });
+      expect(result[1]).toMatchObject({
+        id: bookmarks[1].id,
+        createdAt: bookmarks[1].createdAt,
+        item: {
+          id: itemWithoutThumbnail.id,
+        },
+      });
+      expect(result[1].item).not.toHaveProperty('thumbnails');
+    });
+  });
+});

--- a/src/services/item/plugins/itemBookmark/itemBookmark.service.ts
+++ b/src/services/item/plugins/itemBookmark/itemBookmark.service.ts
@@ -8,6 +8,7 @@ import { AuthorizedItemService } from '../../../authorizedItem.service';
 import { ItemMembershipRepository } from '../../../itemMembership/membership.repository';
 import type { PackedItem } from '../../packedItem.dto';
 import { ItemVisibilityRepository } from '../itemVisibility/itemVisibility.repository';
+import { ItemThumbnailService } from '../thumbnail/itemThumbnail.service';
 import { ItemBookmarkRepository } from './itemBookmark.repository';
 
 type PackedBookmarkedItem = ItemBookmarkRaw & { item: PackedItem };
@@ -18,17 +19,20 @@ export class BookmarkService {
   private readonly itemBookmarkRepository: ItemBookmarkRepository;
   private readonly itemMembershipRepository: ItemMembershipRepository;
   private readonly itemVisibilityRepository: ItemVisibilityRepository;
+  private readonly itemThumbnailService: ItemThumbnailService;
 
   constructor(
     authorizedItemService: AuthorizedItemService,
     itemBookmarkRepository: ItemBookmarkRepository,
     itemMembershipRepository: ItemMembershipRepository,
     itemVisibilityRepository: ItemVisibilityRepository,
+    itemThumbnailService: ItemThumbnailService,
   ) {
     this.authorizedItemService = authorizedItemService;
     this.itemBookmarkRepository = itemBookmarkRepository;
     this.itemMembershipRepository = itemMembershipRepository;
     this.itemVisibilityRepository = itemVisibilityRepository;
+    this.itemThumbnailService = itemThumbnailService;
   }
 
   async getOwn(dbConnection: DBConnection, member: MinimalMember): Promise<PackedBookmarkedItem[]> {
@@ -36,6 +40,8 @@ export class BookmarkService {
       dbConnection,
       member.id,
     );
+    const bookmarkedItems = bookmarks.map(({ item }) => item);
+    const thumbnails = await this.itemThumbnailService.getUrlsByItems(bookmarkedItems);
 
     // filter out items user might not have access to
     // and packed item
@@ -46,7 +52,8 @@ export class BookmarkService {
         itemMembershipRepository: this.itemMembershipRepository,
         itemVisibilityRepository: this.itemVisibilityRepository,
       },
-      bookmarks.map(({ item }) => item),
+      bookmarkedItems,
+      thumbnails,
     );
 
     // insert back packed item inside bookmark entities

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -71,11 +71,15 @@ export const CORS_ORIGIN_REGEX = process.env.CORS_ORIGIN_REGEX;
 export const PUBLIC_URL = new URL(process.env.PUBLIC_URL || HOST);
 export const LIBRARY_HOST = process.env.LIBRARY_CLIENT_HOST || HOST;
 
+<<<<<<< HEAD
 export const ALLOWED_ORIGINS = [
   new URL(PUBLIC_URL).origin,
   new URL(HOST).origin,
   new URL(LIBRARY_HOST).origin,
 ];
+=======
+export const ALLOWED_ORIGINS = [new URL(PUBLIC_URL).origin, new URL(LIBRARY_HOST).origin];
+>>>>>>> 8036ca63 (Add thumbnail URL support in BookmarkService and tests)
 
 // Add the hosts of the different clients
 ClientManager.getInstance().setHost(HOST).addHost(Context.Library, LIBRARY_HOST);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -71,15 +71,11 @@ export const CORS_ORIGIN_REGEX = process.env.CORS_ORIGIN_REGEX;
 export const PUBLIC_URL = new URL(process.env.PUBLIC_URL || HOST);
 export const LIBRARY_HOST = process.env.LIBRARY_CLIENT_HOST || HOST;
 
-<<<<<<< HEAD
 export const ALLOWED_ORIGINS = [
   new URL(PUBLIC_URL).origin,
   new URL(HOST).origin,
   new URL(LIBRARY_HOST).origin,
 ];
-=======
-export const ALLOWED_ORIGINS = [new URL(PUBLIC_URL).origin, new URL(LIBRARY_HOST).origin];
->>>>>>> 8036ca63 (Add thumbnail URL support in BookmarkService and tests)
 
 // Add the hosts of the different clients
 ClientManager.getInstance().setHost(HOST).addHost(Context.Library, LIBRARY_HOST);


### PR DESCRIPTION
Adds thumbnail URLs to bookmarked items returned by the bookmarks endpoint.
- Inject `ItemThumbnailService` into `ItemBookmarkService`.
- Pass thumbnail URLs into 'filterOutPackedItems' for 'ItemBookmarkSchemas' to have access to it.

Adds test file for thumbnail functionality
- Creates a mock bookmark repository to verify item.thumbnail exists on bookmarks with appropiate features.
