### PR TITLE
fix: allow ordered list attributes

### DIFF
--- a/src/services/item/plugins/document/document.service.ts
+++ b/src/services/item/plugins/document/document.service.ts
@@ -66,7 +66,11 @@ export class DocumentItemService extends ItemService {
     itemExtra?: DocumentItemExtraProperties,
   ): DocumentItemExtraProperties {
     return {
-      content: sanitize(content ?? itemExtra?.content ?? ''),
+      content: sanitize(content ?? itemExtra?.content ?? '', {
+        allowedAttributes: {
+          li: ['data-list'],
+        },
+      }),
       isRaw: isRaw ?? itemExtra?.isRaw,
       flavor: flavor ?? itemExtra?.flavor,
     };


### PR DESCRIPTION
In this PR I allow the ordered list attributes that quill sets on the list items so that they can be rendered in the interface.